### PR TITLE
Various spawn fixes

### DIFF
--- a/assets/models/spawn_kiosk/spawn_kiosk.gd
+++ b/assets/models/spawn_kiosk/spawn_kiosk.gd
@@ -1,37 +1,27 @@
 extends StaticBody3D
 
 @onready var kiosk_interaction_area: Area3D = $KioskInteractionArea
+@onready var spawn_area: Area3D = $SpawnArea
+@onready var spawn_response_label: Label3D = $SpawnResponseLabel
+@onready var spawn_response_timer: Timer = $SpawnResponseLabel/Timer
 
 func _ready() -> void:
 	kiosk_interaction_area.connect("interacted", _on_interaction_requested)
-	pass
-	#kiosk_interaction_area.connect("body_entered", on_player_entered)
-	#kiosk_interaction_area.connect("body_exited", on_player_exited)
-#
-#func on_player_entered(player: Node3D) -> void:
-	#if player is Player and not multiplayer.is_server():
-		#Globals.print_rich_distinguished("[color=green]COUCOU, JE VEUX UN SHIP %s[/color]", [player.name])
-		#player.interact_label.text = "[F] Request your ship"
-		#player.interact_label.show()
-		#var spawn_position: Vector3 = global_position + Vector3(0.0,10.0,0.0)
-		#player.emit_signal("client_action_requested", {"action": "spawn", "entity": "ship"})
-		##OnlineOrchestrator.spawn_ship.rpc_id(1, player_scene_path, spawn_position, spawn_up, peer_id)
-#
-#func on_player_exited(player: Node3D) -> void:
-	#if player is Player and not multiplayer.is_server():
-		#Globals.print_rich_distinguished("[color=green]AU REVOIR %s[/color]", [player.name])
-		#player.interact_label.hide()
+	spawn_response_timer.connect("timeout", _on_timer_timeout)
 
 func _on_interaction_requested(interactor: Node) -> void:
 	if interactor is Player and not multiplayer.is_server():
-		var spawn_position: Vector3 = interactor.global_position - interactor.global_basis.z * 5.0 + interactor.global_basis.y * 5.0
 		
-		var player_up = interactor.global_transform.basis.y.normalized()
-		var to_player = (interactor.global_transform.origin - spawn_position)
-		to_player -= to_player.dot(player_up) * player_up
-		to_player = to_player.normalized()
-		var ship_basis: Basis = Basis.looking_at(to_player, player_up)
-		ship_basis = ship_basis.rotated(Vector3.UP, deg_to_rad(-90))
-		var spawn_rotation = ship_basis.get_euler()
+		if spawn_area.has_overlapping_bodies():
+			spawn_response_timer.stop()
+			spawn_response_label.text = "Clear the pad first"
+			spawn_response_timer.start()
+			return
+		
+		var spawn_position: Vector3 = spawn_area.global_position
+		var spawn_rotation: Vector3 = spawn_area.global_rotation
 		
 		interactor.emit_signal("client_action_requested", {"action": "spawn", "entity": "ship", "spawn_position": spawn_position, "spawn_rotation": spawn_rotation})
+
+func _on_timer_timeout() -> void:
+	spawn_response_label.text = ""

--- a/assets/models/spawn_kiosk/spawn_kiosk.tscn
+++ b/assets/models/spawn_kiosk/spawn_kiosk.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://dtcsox8hfg83s"]
+[gd_scene load_steps=12 format=3 uid="uid://dtcsox8hfg83s"]
 
 [ext_resource type="Script" uid="uid://s8pbsagvb7ix" path="res://assets/models/spawn_kiosk/spawn_kiosk.gd" id="1_1t3ni"]
 [ext_resource type="ArrayMesh" uid="uid://2udj7wjyt5fu" path="res://assets/models/spawn_kiosk/kiosk_body.mesh" id="1_hh7gi"]
@@ -14,6 +14,9 @@ size = Vector3(1.5, 1.75, 0.6)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_1t3ni"]
 size = Vector3(1, 1.75, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_bompr"]
+size = Vector3(4, 4, 9)
 
 [node name="SpawnKiosk" type="StaticBody3D"]
 script = ExtResource("1_1t3ni")
@@ -42,3 +45,17 @@ label = "[F] Request your ship"
 [node name="CollisionShape3D" type="CollisionShape3D" parent="KioskInteractionArea"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.875, 0)
 shape = SubResource("BoxShape3D_1t3ni")
+
+[node name="SpawnArea" type="Area3D" parent="."]
+transform = Transform3D(6.12323e-17, 0, 1, 0, 1, 0, -1, 0, 6.12323e-17, 0, 2, -5)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="SpawnArea"]
+shape = SubResource("BoxShape3D_bompr")
+
+[node name="SpawnResponseLabel" type="Label3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.1, 0)
+billboard = 2
+
+[node name="Timer" type="Timer" parent="SpawnResponseLabel"]
+wait_time = 2.0
+one_shot = true

--- a/scenes/globals/network_orchestrator.gd
+++ b/scenes/globals/network_orchestrator.gd
@@ -508,19 +508,21 @@ func _create_local_player_not_exists_in_universe(uuid, playerName, spawn_point, 
 				spawn_up = (spawn_position - universe_scene.get_node("PlanetA").global_position).normalized()
 			elif spawn_point_node_path.contains("PlanetB"):
 				spawn_up = (spawn_position - universe_scene.get_node("PlanetB").global_position).normalized()
-			elif spawn_point_node_path.contains("StationA"):
+			elif spawn_point_node_path.contains("StationA") or spawn_point_node_path.contains("StationB"):
 				spawn_up = universe_scene.get_node(spawn_point_node_path).transform.basis.y.normalized()
 		else:
 			var parent_entity_spawn_position: Vector3 = universe_scene.get_node(spawn_point_node_path).global_position
 			spawn_position = random_spawn_on_planet(parent_entity_spawn_position, 2000.0)
 			spawn_up = (spawn_position - parent_entity_spawn_position).normalized()
-
+	
+	spawn_position = _apply_small_variation(spawn_position, spawn_up)
+	
 	small_props_spawner_node.spawn({
 		"entity": "player",
 		"player_scene_path": player_scene_path,
 		"player_name": playerName,
 		"player_spawn_position": spawn_position,
-		"player_spawn_up": Vector3.UP,
+		"player_spawn_up": spawn_up,
 		"authority_peer_id": id,
 		"uuid": uuid
 	})
@@ -585,6 +587,18 @@ func _create_local_player_not_exists_in_universe(uuid, playerName, spawn_point, 
 	# 	"y": 0.0000329,
 	# 	"z": 2154.9038085938
 	# }
+
+func _apply_small_variation(original_spawn_position: Vector3, spawn_up: Vector3) -> Vector3:
+	const variation: float = 3.0
+	var new_spawn_position: Vector3 = original_spawn_position
+	
+	var random_vector = Vector3(randf() * 2.0 - 1.0, randf() * 2.0 - 1.0, randf() * 2.0 - 1.0)
+	var tangent = (random_vector - spawn_up * random_vector.dot(spawn_up)).normalized()
+	var distance = variation * randf()
+	
+	new_spawn_position += tangent * distance
+	
+	return new_spawn_position
 
 func _create_local_player_come_from_another_server(uuid, playerName, id):
 	network_agent.PlayersListCurrentlyInTransfert[uuid] = true
@@ -717,6 +731,7 @@ func spawn_prop(proptype,data: Dictionary ) -> void: #spawn_position: Vector3 = 
 	var spawn_position = Vector3(data["x"],data["y"],data["z"])
 	var spawn_rotation = Vector3(data["rx"],data["ry"],data["rz"])
 	prop_instance.spawn_position = spawn_position
+	prop_instance.spawn_rotation = spawn_rotation
 	if data.has("uid"):
 		if prop_instance.has_node("DataEntity"):
 			prop_instance.get_node("DataEntity").load_obj(data)
@@ -829,6 +844,8 @@ func notify_client_connected():
 
 @rpc("any_peer", "call_local", "unreliable")
 func set_player_uuid(uuid, playerName, spawn_point: int = 0, id = null):
+	if not multiplayer.is_server():
+		return
 	if Globals.isGUTRunning == false:
 		id = universe_scene.multiplayer.get_remote_sender_id()
 	network_agent.PlayersListCurrentlyInTransfert[uuid] = id

--- a/scenes/normal_player/label_server_zone.gd
+++ b/scenes/normal_player/label_server_zone.gd
@@ -11,15 +11,15 @@ func _set_gameserver_serverzone(serverzone):
 	var z_start = "∞"
 	var z_end = "∞"
 	if serverzone.x_start != -10000000.0 and serverzone.x_start != 10000000.0:
-		x_start = str(serverzone.x_start)
+		x_start = String.num(serverzone.x_start, 2)
 	if serverzone.x_end != -10000000.0 and serverzone.x_end != 10000000.0:
-		x_end = str(serverzone.x_end)
+		x_end = String.num(serverzone.x_end, 2)
 	if serverzone.y_start != -10000000.0 and serverzone.y_start != 10000000.0:
-		y_start = str(serverzone.y_start)
+		y_start = String.num(serverzone.y_start, 2)
 	if serverzone.y_end != -10000000.0 and serverzone.y_end != 10000000.0:
-		y_end = str(serverzone.y_end)
+		y_end = String.num(serverzone.y_end, 2)
 	if serverzone.z_start != -10000000.0 and serverzone.z_start != 10000000.0:
-		z_start = str(serverzone.z_start)
+		z_start = String.num(serverzone.z_start, 2)
 	if serverzone.z_end != -10000000.0 and serverzone.z_end != 10000000.0:
-		z_end = str(serverzone.z_end)
+		z_end = String.num(serverzone.z_end, 2)
 	text = "Server zone | x " + x_start + " -> " + x_end + " | y " + y_start + " -> " + y_end + " | z " + z_start + " -> " + z_end + " |"

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -72,17 +72,26 @@ var gravity_parents: Array[Area3D]
 var active = true
 
 func _enter_tree() -> void:
+	
 	if name.begins_with("remoteplayer"):
 		set_multiplayer_authority(1)
 		global_position = spawn_position
 	else:
+		if not is_multiplayer_authority():
+			return
 		NetworkOrchestrator.set_player_global_position.connect(_set_player_global_position)
+		global_position = spawn_position
+		global_transform.basis.y = spawn_up
+		var forward = -global_transform.basis.z.normalized()
+		var right = forward.cross(spawn_up).normalized()
+		forward = spawn_up.cross(right).normalized()
+		global_transform.basis = Basis(right, spawn_up, -forward)
+		up_direction = spawn_up
 
 func _ready() -> void:
 	if not is_multiplayer_authority():
 		return
 	
-	global_position = spawn_position
 	look_at(global_transform.origin + Vector3.FORWARD, spawn_up)
 	
 	NetworkOrchestrator.set_gameserver_name.connect(_set_gameserver_name)
@@ -203,7 +212,8 @@ func _physics_process(delta: float) -> void:
 	var move_direction = (global_transform.basis * Vector3(input_direction.x, 0, input_direction.y)).normalized()
 	
 	if gravity > 0:
-		orient_player()
+		pass
+		#orient_player()
 	
 	var speed = sprint_speed if sprint else walk_speed
 	
@@ -267,5 +277,6 @@ func _set_gameserver_name(server_name: String):
 	labelServerName.text = "(" + server_name + ")"
 
 func _set_player_global_position(pos, rot):
+	Globals.print_rich_distinguished("Dans _set_player_global_position", [])
 	global_position = pos
 	global_rotation =rot

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -63,6 +63,7 @@ far = 40000.0
 
 [node name="InteractRay" type="RayCast3D" parent="CameraPivot/Camera3D"]
 target_position = Vector3(0, 0, -3)
+collision_mask = 3
 collide_with_areas = true
 collide_with_bodies = false
 
@@ -118,7 +119,7 @@ mouse_filter = 2
 
 [node name="ColorRect" type="ColorRect" parent="UserInterface/Debug"]
 layout_mode = 0
-offset_right = 561.0
+offset_right = 700.0
 offset_bottom = 104.0
 color = Color(0, 0, 0, 0.690196)
 

--- a/scenes/props/testbox/box_4m.gd
+++ b/scenes/props/testbox/box_4m.gd
@@ -8,12 +8,13 @@ var type_name = "box4m"
 var spawn_position: Vector3 = Vector3.ZERO
 var spawn_rotation: Vector3 = Vector3.UP
 
+func _enter_tree() -> void:
+	global_position = spawn_position
+	global_rotation = spawn_rotation
+
 func _ready() -> void:
 	$Area3D.body_entered.connect(_on_box_entered)
 	$Area3D.body_exited.connect(_on_box_exited)
-
-	global_position = spawn_position
-	global_rotation = spawn_rotation
 
 func _on_box_entered(body: Node3D):
 	if body.is_in_group("containable"):

--- a/scenes/props/testbox/box_50_cm.gd
+++ b/scenes/props/testbox/box_50_cm.gd
@@ -8,5 +8,9 @@ var type_name = "box50cm"
 var spawn_position: Vector3 = Vector3.ZERO
 var spawn_rotation: Vector3 = Vector3.UP
 
-func _ready() -> void:
+func _enter_tree() -> void:
 	global_position = spawn_position
+	global_rotation = spawn_rotation
+
+func _ready() -> void:
+	pass

--- a/scenes/spaceship/test_spaceship/test_spaceship.tscn
+++ b/scenes/spaceship/test_spaceship/test_spaceship.tscn
@@ -47,6 +47,7 @@ shape = SubResource("BoxShape3D_hn282")
 
 [node name="ShipConsole" type="Area3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.921729, -3.45297)
+collision_layer = 2
 script = ExtResource("2_xjcjc")
 label = "Pilot ship [F]"
 

--- a/ui/direct_chat/direct_chat.gd
+++ b/ui/direct_chat/direct_chat.gd
@@ -36,9 +36,13 @@ var forced_colors := {
 }
 
 func _enter_tree() -> void:
+	if not is_multiplayer_authority(): return
+	
 	connect("visibility_changed", _on_visibility_changed)
 
 func _ready():
+	if not is_multiplayer_authority(): return
+	
 	visible = false
 	is_shown = visible
 


### PR DESCRIPTION
Les joueurs, vaisseaux et caisses ont maintenant leurs position et rotation de spawn appliqués une fois dans l'arbre et non plus lorsqu'il sont prêts.
Les vaisseaux ne peuvent plus spawn tant que le "pad" n'est pas dégagé.
Ajout d'une légère variation des positions de spawn des joueurs pour tenter d'éviter qu'ils se rentrent dedans.
Le Vecteur UP du joueur est maintenant correctement calculé.
Suppression d'un appel à la fonction 'orient_player' dans 'normal_player.gd', elle se trouvait appelée plusieurs fois dans la même frame rendant le résultat incertain. A priori ça n'a rien cassé.