### PR TITLE
Feat/mining v0 perforator

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -194,6 +194,21 @@ debug_console={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
 ]
 }
+toggle_tool={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+aim={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+perforate={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/scenes/normal_player/crosshair_manager.gd
+++ b/scenes/normal_player/crosshair_manager.gd
@@ -1,8 +1,8 @@
 class_name CrosshairManager extends Control
 #
-# Reusable manager for on-demand aim crosshairs (overlays shown depending on the
-# context: aiming, weapon, tool...), IN ADDITION to the permanent small dot
-# (which stays handled separately in player_ui).
+# Reusable manager that owns ALL crosshair drawing: a permanent base reticle
+# (the small dot, drawn at all times via base_style) PLUS on-demand overlays shown
+# depending on the context (aiming, weapon, tool...) via set_style(), drawn on top.
 #
 # Usage:
 #   var cm := CrosshairManager.new()
@@ -16,10 +16,13 @@ class_name CrosshairManager extends Control
 
 var _styles: Dictionary = {}   # name:String -> Callable(canvas: CanvasItem)
 var _current: String = ""
+## Always-drawn base reticle, rendered under the current overlay ("" = none).
+var base_style: String = "dot"
 
 func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	# built-in styles
+	register("dot", _draw_dot)
 	register("aim", _draw_aim_star)
 
 ## Register (or replace) a crosshair style.
@@ -38,10 +41,17 @@ func clear() -> void:
 	set_style("")
 
 func _draw() -> void:
+	# Always-on base reticle first, then the contextual overlay on top.
+	if base_style != "" and _styles.has(base_style):
+		_styles[base_style].call(self)
 	if _current != "" and _styles.has(_current):
 		_styles[_current].call(self)
 
 # ── Built-in styles ─────────────────────────────────────────────────────────
+
+## Permanent small dot reticle (always visible), centered on screen.
+func _draw_dot(canvas: CanvasItem) -> void:
+	canvas.draw_circle(Vector2.ZERO, 1.0, Color.WHITE)
 
 ## "Star/sun" crosshair: center dot + rays + 4 cardinal lines.
 func _draw_aim_star(canvas: CanvasItem) -> void:

--- a/scenes/normal_player/crosshair_manager.gd
+++ b/scenes/normal_player/crosshair_manager.gd
@@ -14,10 +14,10 @@ class_name CrosshairManager extends Control
 # A "style" is a Callable that receives the CanvasItem to draw on, centered on
 # Vector2.ZERO (= screen center if the manager is inside a CenterContainer).
 
-var _styles: Dictionary = {}   # name:String -> Callable(canvas: CanvasItem)
-var _current: String = ""
 ## Always-drawn base reticle, rendered under the current overlay ("" = none).
 var base_style: String = "dot"
+var _styles: Dictionary = {}   # name:String -> Callable(canvas: CanvasItem)
+var _current: String = ""
 
 func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE

--- a/scenes/normal_player/crosshair_manager.gd
+++ b/scenes/normal_player/crosshair_manager.gd
@@ -1,0 +1,59 @@
+class_name CrosshairManager extends Control
+#
+# Reusable manager for on-demand aim crosshairs (overlays shown depending on the
+# context: aiming, weapon, tool...), IN ADDITION to the permanent small dot
+# (which stays handled separately in player_ui).
+#
+# Usage:
+#   var cm := CrosshairManager.new()
+#   parent.add_child(cm)              # ideally inside a CenterContainer (screen-centered)
+#   cm.register("aim", _my_function)  # add a custom style (optional)
+#   cm.set_style("aim")               # show a style
+#   cm.clear()                        # show nothing
+#
+# A "style" is a Callable that receives the CanvasItem to draw on, centered on
+# Vector2.ZERO (= screen center if the manager is inside a CenterContainer).
+
+var _styles: Dictionary = {}   # name:String -> Callable(canvas: CanvasItem)
+var _current: String = ""
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# built-in styles
+	register("aim", _draw_aim_star)
+
+## Register (or replace) a crosshair style.
+func register(style_name: String, draw_fn: Callable) -> void:
+	_styles[style_name] = draw_fn
+
+## Show the given style ("" = none).
+func set_style(style_name: String) -> void:
+	if style_name == _current:
+		return
+	_current = style_name
+	queue_redraw()
+
+## Show no overlay crosshair.
+func clear() -> void:
+	set_style("")
+
+func _draw() -> void:
+	if _current != "" and _styles.has(_current):
+		_styles[_current].call(self)
+
+# ── Built-in styles ─────────────────────────────────────────────────────────
+
+## "Star/sun" crosshair: center dot + rays + 4 cardinal lines.
+func _draw_aim_star(canvas: CanvasItem) -> void:
+	var col := Color(1, 1, 1, 0.9)
+	var center := Vector2.ZERO
+	canvas.draw_circle(center, 3.0, col)
+	var rays := 28
+	var inner := 9.0
+	var outer := 20.0
+	for i in rays:
+		var a := TAU * float(i) / float(rays)
+		var dir := Vector2(cos(a), sin(a))
+		canvas.draw_line(dir * inner, dir * outer, col, 1.5)
+	for d in [Vector2.RIGHT, Vector2.LEFT, Vector2.UP, Vector2.DOWN]:
+		canvas.draw_line(d * (outer + 3.0), d * (outer + 16.0), col, 2.0)

--- a/scenes/normal_player/crosshair_manager.gd.uid
+++ b/scenes/normal_player/crosshair_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://b1nut32iu2in5

--- a/scenes/normal_player/equipment_mount.gd
+++ b/scenes/normal_player/equipment_mount.gd
@@ -1,0 +1,44 @@
+class_name EquipmentMount
+extends Node3D
+
+## Generic hand mount for the player's currently held equipment (tool, weapon,
+## carried hand object...). Attach one to the player body at the hand offset;
+## any item parented under it inherits the body yaw (it is a child of the body)
+## and gets the camera pitch applied here. Centralizing the aiming in one place
+## means every present and future piece of equipment is oriented the same way,
+## for the local player and -- once the camera pitch is replicated -- for remote
+## players too, without touching the items themselves (open/closed principle).
+
+## Node whose local X rotation (pitch) the held item must follow, typically the
+## player's CameraPivot. Injected so the mount stays decoupled from the player.
+@export var pitch_source: Node3D
+
+var _rest_basis: Basis = Basis.IDENTITY
+var _item: Node3D = null
+
+func _ready() -> void:
+	# Rest orientation captured once; the camera pitch is applied on top of it.
+	_rest_basis = transform.basis
+
+## Attach (and own) an item under the mount, replacing any previous one.
+func hold(item: Node3D) -> void:
+	clear()
+	_item = item
+	add_child(item)
+
+## The item currently held, or null.
+func held_item() -> Node3D:
+	return _item
+
+## Remove and free the held item, if any.
+func clear() -> void:
+	if _item != null and is_instance_valid(_item):
+		_item.queue_free()
+	_item = null
+
+func _process(_delta: float) -> void:
+	if pitch_source == null:
+		return
+	# Pitch the whole mount around the body's right axis so the held item aims
+	# where the camera looks; yaw comes for free from the body (our parent).
+	basis = Basis(Vector3(1, 0, 0), pitch_source.rotation.x) * _rest_basis

--- a/scenes/normal_player/equipment_mount.gd
+++ b/scenes/normal_player/equipment_mount.gd
@@ -13,6 +13,20 @@ extends Node3D
 ## player's CameraPivot. Injected so the mount stays decoupled from the player.
 @export var pitch_source: Node3D
 
+## When set (a global Vector3 point), the mount aims the held item's forward at
+## it (look_at) instead of pitching by pitch_source. Used to make a tool/weapon
+## point EXACTLY where the player targets, so its action acts at that point.
+var aim_target = null   # Variant: Vector3 or null
+var aim_up: Vector3 = Vector3.UP
+## Roll correction (deg) around the aim axis, to keep the held item upright in
+## aim mode (compensates for the model's native orientation).
+var aim_roll_deg: float = 0.0
+## Aim-point smoothing speed (higher = snappier; smooths the depth jump when the
+## crosshair moves from empty space to a near surface).
+var aim_smooth: float = 18.0
+var _smoothed_aim: Vector3 = Vector3.ZERO
+var _aim_init: bool = false
+
 var _rest_basis: Basis = Basis.IDENTITY
 var _item: Node3D = null
 
@@ -36,7 +50,23 @@ func clear() -> void:
 		_item.queue_free()
 	_item = null
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
+	# Aim mode: point the held item's forward (its base rotation aligns its tip
+	# with our -Z) at a world target, e.g. the point under the crosshair.
+	if aim_target != null:
+		# Smooth the aim point to avoid a snap when the target depth changes
+		# (empty space -> near surface).
+		if _aim_init:
+			_smoothed_aim = _smoothed_aim.lerp(aim_target, clampf(aim_smooth * delta, 0.0, 1.0))
+		else:
+			_smoothed_aim = aim_target
+			_aim_init = true
+		if not global_position.is_equal_approx(_smoothed_aim):
+			look_at(_smoothed_aim, aim_up)
+			if aim_roll_deg != 0.0:
+				rotate_object_local(Vector3(0, 0, 1), deg_to_rad(aim_roll_deg))
+		return
+	_aim_init = false
 	if pitch_source == null:
 		return
 	# Pitch the whole mount around the body's right axis so the held item aims

--- a/scenes/normal_player/equipment_mount.gd.uid
+++ b/scenes/normal_player/equipment_mount.gd.uid
@@ -1,0 +1,1 @@
+uid://snr2ea4134fn

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -1,0 +1,183 @@
+class_name MiningTool extends Node3D
+
+# Mining gameplay encapsulated as a player component: it holds the perforator on
+# a generic EquipmentMount, detects nearby/aimed mining rocks, runs the aim mode
+# and the perforation animation. Networking stays in the player (which owns the
+# connection): this node emits `sync_requested` when the local owner changes a
+# replicated state, and the player calls `apply_remote()` / `server_set_tool()`.
+#
+# Setup: add this as a child node of the player in the scene (so its @export
+# values show in the inspector), then call setup(camera_pivot, camera) from the
+# player's _ready.
+
+## Owner-only: a replicated state changed; the player relays it to the server.
+signal sync_requested(data: Dictionary)
+## The aim crosshair should be shown/hidden (the player forwards it to the UI).
+signal aiming_changed(aiming: bool)
+
+const PERFORATOR_SCENE := preload("res://assets/models/equipments/tools/mining/hammerdrill.glb")
+const PERFORATION_DURATION := 5.0
+
+@export_group("Aim")
+## Mouse-sensitivity factor while aiming (1.0 = normal).
+@export_range(0.1, 1.0) var aim_sensitivity_factor: float = 0.4
+## Move-speed factor while aiming (1.0 = normal).
+@export_range(0.1, 1.0) var aim_speed_factor: float = 0.4
+## Max distance (m) to a mining rock to be allowed to enter aim mode.
+@export var aim_rock_distance: float = 2.0
+
+@export_group("Perforation")
+@export var perforation_hammer_freq: float = 10.0       # back-and-forth jabs per second
+@export var perforation_hammer_amplitude: float = 0.18  # depth of one jab (m)
+@export var perforation_shake_amplitude: float = 0.025  # tremble (m)
+
+@export_group("Equipment placement")
+## Mount position on the body. This is the PIVOT the held item rotates around when aiming.
+@export var equipment_hand_offset: Vector3 = Vector3(0.4, 1.0, -0.4)
+## Held item offset inside the mount. Shift it so the item's grip sits on the pivot above.
+@export var equipment_item_offset: Vector3 = Vector3.ZERO
+## Held item base rotation, to make the model point forward (-Z).
+@export var equipment_item_rotation_deg: Vector3 = Vector3(0, -90, 0)
+## Held item uniform scale.
+@export var equipment_item_scale: float = 2.0
+
+## True while aiming (read by the player to slow the mouse/movement).
+var is_aiming: bool = false
+## True during perforation (read by the player to freeze the mouse/movement).
+var is_perforating: bool = false
+
+var _camera: Camera3D = null
+var _camera_pivot: Node3D = null
+var _equipment_mount: EquipmentMount = null
+var _perforator: Node3D = null
+var _perforation_t: float = 0.0
+var _perforator_rest_pos: Vector3 = Vector3.ZERO
+var _rock_ray: RayCast3D = null
+var _crosshair_shown: bool = false
+var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" sync)
+
+## Inject the player's camera rig and build the equipment mount + perforator.
+func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
+	_camera_pivot = camera_pivot
+	_camera = camera
+	_equipment_mount = EquipmentMount.new()
+	_equipment_mount.name = "EquipmentMount"
+	add_child(_equipment_mount)
+	_equipment_mount.position = equipment_hand_offset  # the pivot the held item rotates around
+	_equipment_mount.pitch_source = camera_pivot       # aim follows the camera pitch
+	# First item: the mining perforator (hidden until equipped with 1/&).
+	_perforator = PERFORATOR_SCENE.instantiate()
+	_perforator.position = equipment_item_offset       # shift the model so its grip sits on the pivot
+	_perforator.rotation_degrees = equipment_item_rotation_deg
+	_perforator.scale = Vector3.ONE * equipment_item_scale
+	_perforator.visible = false
+	_equipment_mount.hold(_perforator)
+	_perforator_rest_pos = _perforator.position
+
+func _process(delta: float) -> void:
+	# Perforation visual runs on EVERY instance (remote players too), driven by
+	# is_perforating (set by input locally, or by the replicated "perforating").
+	_update_perforation_visual(delta)
+
+## Owner only (called by the player's _process): aim mode, perforation control,
+## camera-pitch ("head") replication.
+func update_local(_delta: float) -> void:
+	# Aim mode: only if the tool is equipped AND near a rock.
+	var can_aim := _perforator != null and _perforator.visible and _is_near_mining_rock()
+	is_aiming = Input.is_action_pressed("aim") and can_aim
+	# The aim crosshair shows only while aiming AND looking at the rock.
+	var looking := is_aiming and _is_looking_at_rock()
+	if looking != _crosshair_shown:
+		_crosshair_shown = looking
+		aiming_changed.emit(looking)
+
+	# Perforation control: start on left-click while aiming, stop on release or
+	# after PERFORATION_DURATION. The visual is handled by _update_perforation_visual.
+	if is_perforating:
+		if not is_aiming or not Input.is_action_pressed("perforate"):
+			_set_perforating(false)  # released -> cancelled, no effect
+		elif _perforation_t >= PERFORATION_DURATION:
+			# animation end -> the fracture would trigger HERE (server-side, TODO)
+			_set_perforating(false)
+	elif looking and Input.is_action_just_pressed("perforate"):
+		_set_perforating(true)
+
+	# Replicate the camera pitch ("head") while a tool is equipped, so other
+	# players see where we aim. Throttled to meaningful changes.
+	if _perforator and _perforator.visible:
+		var head_q: float = snappedf(_camera_pivot.rotation.x, 0.02)
+		if head_q != _last_head_sent:
+			_last_head_sent = head_q
+			sync_requested.emit({"action": "set_head", "head": head_q})
+
+## Owner only: toggle the equipped tool and replicate the state.
+func toggle_equip() -> void:
+	if _perforator == null:
+		return
+	var equipped := not _perforator.visible
+	_perforator.visible = equipped  # immediate local toggle (first-person view)
+	# Send the equipped tool as a STATE (not a one-shot event) so other clients
+	# always converge to the right state via the replicated "tools" property.
+	sync_requested.emit({"action": "equip_tool", "tools": ("perforator" if equipped else "")})
+
+## Server (authoritative): apply the equipped-tool state. The player rebroadcasts it.
+func server_set_tool(tool_id: String) -> void:
+	if _perforator:
+		_perforator.visible = tool_id != ""
+
+## Apply replicated state on remote players (tool visibility, camera aim, perforation).
+func apply_remote(data: Dictionary) -> void:
+	if data.has("tools") and _perforator:
+		_perforator.visible = str(data["tools"]) != ""
+	if data.has("head") and _camera_pivot:
+		_camera_pivot.rotation.x = float(data["head"])
+	if data.has("perforating"):
+		_apply_perforating(bool(data["perforating"]))
+
+# ── Internals ────────────────────────────────────────────────────────────────
+
+## True if a mining rock (group "miningrock") is within aim range.
+func _is_near_mining_rock() -> bool:
+	for r in get_tree().get_nodes_in_group("miningrock"):
+		if r is Node3D and global_position.distance_to((r as Node3D).global_position) <= aim_rock_distance:
+			return true
+	return false
+
+## True if the camera is currently looking at a mining rock (camera raycast).
+func _is_looking_at_rock() -> bool:
+	if _camera == null:
+		return false
+	if _rock_ray == null:
+		_rock_ray = RayCast3D.new()
+		_rock_ray.target_position = Vector3(0.0, 0.0, -(aim_rock_distance + 2.0))
+		_rock_ray.collision_mask = 0xFFFFFFFF
+		_camera.add_child(_rock_ray)
+	_rock_ray.force_raycast_update()
+	var c = _rock_ray.get_collider()
+	return c != null and c.is_in_group("miningrock")
+
+## Apply the perforating state locally (owner from input, remote from "perforating").
+func _apply_perforating(active: bool) -> void:
+	if active == is_perforating:
+		return
+	is_perforating = active
+	_perforation_t = 0.0
+	if not active and _perforator:
+		_perforator.position = _perforator_rest_pos
+
+## Owner: set the perforating state AND replicate it so others see the animation.
+func _set_perforating(active: bool) -> void:
+	if active == is_perforating:
+		return
+	_apply_perforating(active)
+	sync_requested.emit({"action": "set_perforating", "perforating": active})
+
+## Advance and apply the jackhammer visual (runs on every instance while perforating).
+func _update_perforation_visual(delta: float) -> void:
+	if not is_perforating or _perforator == null:
+		return
+	_perforation_t += delta
+	# fast back-and-forth jabs along the aim (-Z) + random tremble
+	var hammer: float = absf(sin(_perforation_t * perforation_hammer_freq * TAU)) * perforation_hammer_amplitude
+	var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
+	_perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, hammer) + shake

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -25,10 +25,18 @@ const PERFORATION_DURATION := 5.0
 @export_range(0.1, 1.0) var aim_speed_factor: float = 0.4
 ## Max distance (m) to a mining rock to be allowed to enter aim mode.
 @export var aim_rock_distance: float = 2.0
+## Roll correction (deg) to keep the tool upright while aiming (model-dependent).
+@export var aim_roll_deg: float = 0.0
 
 @export_group("Perforation")
 @export var perforation_hammer_freq: float = 10.0       # back-and-forth jabs per second
-@export var perforation_hammer_amplitude: float = 0.18  # depth of one jab (m)
+## Animate only the chisel/bit node (reciprocating) instead of the whole tool.
+@export var animate_bit_only: bool = true
+@export var bit_node_name: String = "hammerdrill_chiselflat"
+## Local axis the bit slides along.
+@export var bit_axis: Vector3 = Vector3(0, 0, 1)
+@export var bit_amplitude: float = 0.06
+@export var perforation_hammer_amplitude: float = 0.18  # whole-tool jab depth (m)
 @export var perforation_shake_amplitude: float = 0.025  # tremble (m)
 
 @export_group("Equipment placement")
@@ -50,8 +58,10 @@ var _camera: Camera3D = null
 var _camera_pivot: Node3D = null
 var _equipment_mount: EquipmentMount = null
 var _perforator: Node3D = null
+var _bit: Node3D = null
 var _perforation_t: float = 0.0
 var _perforator_rest_pos: Vector3 = Vector3.ZERO
+var _bit_rest: Vector3 = Vector3.ZERO
 var _rock_ray: RayCast3D = null
 var _crosshair_shown: bool = false
 var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" sync)
@@ -60,6 +70,12 @@ var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" syn
 func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
 	_camera_pivot = camera_pivot
 	_camera = camera
+	# Aim raycast from the camera center (the crosshair direction). Created here so
+	# it exists on EVERY instance (remote players reconstruct the aim too).
+	_rock_ray = RayCast3D.new()
+	_rock_ray.target_position = Vector3(0.0, 0.0, -(aim_rock_distance + 2.0))
+	_rock_ray.collision_mask = 0xFFFFFFFF
+	_camera.add_child(_rock_ray)
 	_equipment_mount = EquipmentMount.new()
 	_equipment_mount.name = "EquipmentMount"
 	add_child(_equipment_mount)
@@ -73,10 +89,23 @@ func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
 	_perforator.visible = false
 	_equipment_mount.hold(_perforator)
 	_perforator_rest_pos = _perforator.position
+	_bit = _perforator.get_node_or_null(bit_node_name)
+	if _bit:
+		_bit_rest = _bit.position
 
 func _process(delta: float) -> void:
-	# Perforation visual runs on EVERY instance (remote players too), driven by
-	# is_perforating (set by input locally, or by the replicated "perforating").
+	# Aim the held tool at the point under the crosshair on EVERY instance: the
+	# owner uses its real camera; remote players use the camera driven by the
+	# synced body rotation + "head" pitch -> the tool points where they aim, with
+	# no extra networking.
+	if _equipment_mount != null:
+		if _perforator != null and _perforator.visible and _camera != null:
+			_equipment_mount.aim_target = _aim_point()
+			_equipment_mount.aim_up = global_transform.basis.y
+			_equipment_mount.aim_roll_deg = aim_roll_deg
+		else:
+			_equipment_mount.aim_target = null
+	# Perforation visual runs on EVERY instance, driven by is_perforating.
 	_update_perforation_visual(delta)
 
 ## Owner only (called by the player's _process): aim mode, perforation control,
@@ -148,13 +177,22 @@ func _is_looking_at_rock() -> bool:
 	if _camera == null:
 		return false
 	if _rock_ray == null:
-		_rock_ray = RayCast3D.new()
-		_rock_ray.target_position = Vector3(0.0, 0.0, -(aim_rock_distance + 2.0))
-		_rock_ray.collision_mask = 0xFFFFFFFF
-		_camera.add_child(_rock_ray)
+		return false
 	_rock_ray.force_raycast_update()
 	var c = _rock_ray.get_collider()
 	return c != null and c.is_in_group("miningrock")
+
+## World point under the crosshair: camera-center raycast hit, else far forward.
+func _aim_point() -> Vector3:
+	if _camera == null:
+		return global_position
+	var origin: Vector3 = _camera.global_position
+	var fwd: Vector3 = -_camera.global_transform.basis.z
+	if _rock_ray != null:
+		_rock_ray.force_raycast_update()
+		if _rock_ray.is_colliding():
+			return _rock_ray.get_collision_point()
+	return origin + fwd * (aim_rock_distance + 2.0)
 
 ## Apply the perforating state locally (owner from input, remote from "perforating").
 func _apply_perforating(active: bool) -> void:
@@ -164,6 +202,8 @@ func _apply_perforating(active: bool) -> void:
 	_perforation_t = 0.0
 	if not active and _perforator:
 		_perforator.position = _perforator_rest_pos
+		if _bit:
+			_bit.position = _bit_rest
 
 ## Owner: set the perforating state AND replicate it so others see the animation.
 func _set_perforating(active: bool) -> void:
@@ -177,7 +217,12 @@ func _update_perforation_visual(delta: float) -> void:
 	if not is_perforating or _perforator == null:
 		return
 	_perforation_t += delta
-	# fast back-and-forth jabs along the aim (-Z) + random tremble
-	var hammer: float = absf(sin(_perforation_t * perforation_hammer_freq * TAU)) * perforation_hammer_amplitude
-	var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
-	_perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, hammer) + shake
+	var phase: float = absf(sin(_perforation_t * perforation_hammer_freq * TAU))
+	if animate_bit_only and _bit:
+		# The chisel/bit reciprocates along its local axis; the body only trembles.
+		_bit.position = _bit_rest + bit_axis * (phase * bit_amplitude)
+		_perforator.position = _perforator_rest_pos + Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
+	else:
+		# Whole-tool jab along the aim (-Z) + tremble.
+		var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
+		_perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, phase * perforation_hammer_amplitude) + shake

--- a/scenes/normal_player/mining_tool.gd.uid
+++ b/scenes/normal_player/mining_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://d2lihgny3jxwd

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -35,6 +35,74 @@ const PAUSE: String = "pause"
 @export var fast_climb_speed: float = 8.0
 @export_range(0.0, 1.0) var view_bobbing_amount: float = 1.0
 @export_range(1.0, 10.0) var camera_sensitivity: float = 2.0
+
+# Aim mode (right-click): slow-down factors (1.0 = normal)
+@export_range(0.1, 1.0) var aim_sensitivity_factor: float = 0.4
+@export_range(0.1, 1.0) var aim_speed_factor: float = 0.4
+# Max distance (m) to a mining rock to be allowed to enter aim mode
+@export var aim_rock_distance: float = 2.0
+var is_aiming: bool = false
+
+# Perforation (left-click while aiming): jackhammer-style hammering ~5 s
+const PERFORATION_DURATION := 5.0
+@export var perforation_hammer_freq: float = 10.0       # back-and-forth jabs per second
+@export var perforation_hammer_amplitude: float = 0.18  # depth of one jab (m)
+@export var perforation_shake_amplitude: float = 0.025  # tremble (m)
+var is_perforating: bool = false
+var _perforation_t: float = 0.0
+var _perforator_rest_pos: Vector3 = Vector3.ZERO
+var _rock_ray: RayCast3D = null   # camera raycast to detect "looking at a rock"
+var _crosshair_shown: bool = false
+var _last_head_sent: float = INF   # last camera pitch sent to the server (throttle "head" sync)
+
+## True if a mining rock (group "miningrock") is within aim range.
+func _is_near_mining_rock() -> bool:
+	for r in get_tree().get_nodes_in_group("miningrock"):
+		if r is Node3D and global_position.distance_to((r as Node3D).global_position) <= aim_rock_distance:
+			return true
+	return false
+
+## True if the camera is currently looking at a mining rock (camera raycast).
+func _is_looking_at_rock() -> bool:
+	if camera == null:
+		return false
+	if _rock_ray == null:
+		_rock_ray = RayCast3D.new()
+		_rock_ray.target_position = Vector3(0.0, 0.0, -(aim_rock_distance + 2.0))
+		_rock_ray.collision_mask = 0xFFFFFFFF
+		camera.add_child(_rock_ray)
+	_rock_ray.force_raycast_update()
+	var c = _rock_ray.get_collider()
+	return c != null and c.is_in_group("miningrock")
+
+## Apply the perforating state locally (owner from input, remote from the
+## replicated "perforating" property). Resets the timer, and returns the tool to
+## its rest position when stopping.
+func _apply_perforating(active: bool) -> void:
+	if active == is_perforating:
+		return
+	is_perforating = active
+	_perforation_t = 0.0
+	if not active and perforator:
+		perforator.position = _perforator_rest_pos
+
+## Owner: set the perforating state AND replicate it so other players see the animation.
+func _set_perforating(active: bool) -> void:
+	if active == is_perforating:
+		return
+	_apply_perforating(active)
+	client_send_action_to_server({"action": "set_perforating", "perforating": active})
+
+## Advance and apply the jackhammer visual. Runs on EVERY instance while
+## perforating (remote players too), so the animation is seen by everyone.
+func _update_perforation_visual(delta: float) -> void:
+	if not is_perforating or perforator == null:
+		return
+	_perforation_t += delta
+	# fast back-and-forth jabs along the aim (-Z) + random tremble
+	var hammer: float = absf(sin(_perforation_t * perforation_hammer_freq * TAU)) * perforation_hammer_amplitude
+	var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
+	perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, hammer) + shake
 @export_range(0.0, 0.5) var camera_start_deadzone: float = .2
 @export_range(0.0, 0.5) var camera_end_deadzone: float = .1
 
@@ -103,6 +171,24 @@ var _display_debug:bool = false
 
 @onready var flashlight: SpotLight3D = $CameraPivot/Camera3D/Torch
 
+# Perforator V0 mining tool — equipped/unequipped with key 1/& (issue #117).
+# Instanced at runtime on every client/server instance, hidden until equipped.
+const PERFORATOR_SCENE := preload("res://assets/models/equipments/tools/mining/hammerdrill.glb")
+var perforator: Node3D = null
+## Generic hand mount that holds and aims the current equipment (see EquipmentMount).
+var equipment_mount: EquipmentMount = null
+
+## Equipment placement (tune in the inspector, applied on the next run).
+@export_group("Equipment placement")
+## Mount position on the body. This is the PIVOT the held item rotates around when aiming.
+@export var equipment_hand_offset: Vector3 = Vector3(0.4, 1.0, -0.4)
+## Held item offset inside the mount. Shift it so the item's grip sits on the pivot above.
+@export var equipment_item_offset: Vector3 = Vector3.ZERO
+## Held item base rotation, to make the model point forward (-Z).
+@export var equipment_item_rotation_deg: Vector3 = Vector3(0, -90, 0)
+## Held item uniform scale.
+@export var equipment_item_scale: float = 2.0
+
 func _enter_tree() -> void:
 	if remote_player:
 		position = spawn_position
@@ -118,6 +204,24 @@ func _enter_tree() -> void:
 
 func _ready() -> void:
 	prints("Player", name, "spawned at", spawn_position, "on server" if GameOrchestrator.is_server() else "on client")
+
+	# Equipment mount: a generic hand mount attached to the player body (NOT the
+	# Astronaut model, which is hidden for the local first-person view) so held
+	# items show for self AND others. It aims whatever it holds where the camera
+	# looks; future tools/weapons attach here and inherit the aiming for free.
+	equipment_mount = EquipmentMount.new()
+	equipment_mount.name = "EquipmentMount"
+	add_child(equipment_mount)
+	equipment_mount.position = equipment_hand_offset  # the pivot the held item rotates around
+	equipment_mount.pitch_source = camera_pivot  # aim follows the camera pitch
+	# First item: the mining perforator (hidden until equipped with 1/&).
+	perforator = PERFORATOR_SCENE.instantiate()
+	perforator.position = equipment_item_offset  # shift the model so its grip sits on the pivot
+	perforator.rotation_degrees = equipment_item_rotation_deg  # model points forward (-Z)
+	perforator.scale = Vector3.ONE * equipment_item_scale
+	perforator.visible = false  # hidden until equipped with the 1/& key
+	equipment_mount.hold(perforator)
+	_perforator_rest_pos = perforator.position  # base for the perforation jab
 
 	if remote_player:
 		camera.current = false
@@ -220,6 +324,14 @@ func _unhandled_input(event: InputEvent) -> void:
 		client_send_action_to_server({"action": "toggle_flashlight"})
 		# flashlight.visible = not flashlight.visible
 
+	if event.is_action_pressed("toggle_tool"):
+		if perforator:
+			var equipped := not perforator.visible
+			perforator.visible = equipped  # immediate local toggle (first-person view)
+			# Send the equipped tool as a STATE (not a one-shot event) so other clients
+			# always converge to the right state via the replicated "tools" property.
+			client_send_action_to_server({"action": "equip_tool", "tools": ("perforator" if equipped else "")})
+
 	if event.is_action_pressed("spawn_50cmbox"):
 		spawn_box("testbox/box_50cm", "box", 1.5, 2.0)
 
@@ -252,12 +364,49 @@ func server_set_input(input_dir: Vector2, newrotation: Vector3) -> void:
 	new_input_from_server = true
 
 func _process(_delta: float) -> void:
+	# Perforation visual runs on every instance (remote players too), driven by
+	# is_perforating (set by input locally, or by the replicated "perforating").
+	_update_perforation_visual(_delta)
 	if remote_player: return
 	if !active:
 		interact_label.hide()
 		return
 
+	# Aim mode (right-click): slow down only if the tool is equipped AND near a rock
+	var can_aim := perforator != null and perforator.visible and _is_near_mining_rock()
+	is_aiming = Input.is_action_pressed("aim") and can_aim
+	# The aim crosshair shows only while aiming AND looking at the rock
+	var looking := is_aiming and _is_looking_at_rock()
+	if looking != _crosshair_shown:
+		_crosshair_shown = looking
+		$UserInterface.set_aiming(looking)
+	if is_aiming:
+		mouse_motion *= aim_sensitivity_factor
+
+	# Perforation control (owner): start on left-click while aiming, stop on
+	# release or after PERFORATION_DURATION. The visual is handled by
+	# _update_perforation_visual (also on remote players via "perforating").
+	if is_perforating:
+		if not is_aiming or not Input.is_action_pressed("perforate"):
+			_set_perforating(false)  # released (aim or left-click) -> cancelled, no effect
+		elif _perforation_t >= PERFORATION_DURATION:
+			# animation end -> the fracture would trigger HERE (server-side, TODO)
+			_set_perforating(false)
+	elif looking and Input.is_action_just_pressed("perforate"):
+		_set_perforating(true)
+
+	if is_perforating:
+		mouse_motion = Vector2.ZERO  # mouse frozen during perforation
+
 	_handle_camera_motion()
+
+	# Replicate the camera pitch ("head") while a tool is equipped, so other players
+	# see where we aim. Throttled to meaningful changes to limit network traffic.
+	if perforator and perforator.visible:
+		var head_q: float = snappedf(camera_pivot.rotation.x, 0.02)
+		if head_q != _last_head_sent:
+			_last_head_sent = head_q
+			client_send_action_to_server({"action": "set_head", "head": head_q})
 
 	# DEBUG 15deg-offset: measure WORLD displacement direction vs facing
 	if not OS.has_feature("dedicated_server"):
@@ -384,6 +533,10 @@ func _physics_process(delta: float) -> void:
 		var move_direction = (global_transform.basis * Vector3(input_direction.x, 0, input_direction.y)).normalized()
 
 		var speed = sprint_speed if sprint else walk_speed
+		if is_aiming:
+			speed *= aim_speed_factor  # slowed down in aim mode
+		if is_perforating:
+			speed = 0.0  # frozen during perforation
 
 		if is_on_floor():
 			if input_direction:
@@ -621,17 +774,35 @@ func _on_area_detector_area_exited(area: Area3D) -> void:
 		print("TUTU: Exited spawn area for area ", area)
 		var new_parent = area.get_parent().get_parent()
 		print("TUTU: Reparenting to ", new_parent)
-		reparent(new_parent)
-		emit_signal(
-			"hs_server_move",
-			client_uuid,
-			snapped(position, Vector3(0.001, 0.001, 0.001)),
-			snapped(global_rotation, Vector3(0.0001, 0.0001, 0.0001)),
-			new_parent.uuid,
-			is_parented
-		)
+		# Deferred reparent + move sync: reparenting during the Area3D signal
+		# callback is illegal ("busy adding/removing children"), and area_exited
+		# can fire several times -> overlapping reparents crash the node while out
+		# of tree. The move event MUST be emitted AFTER the reparent so the local
+		# position is expressed in the new parent's frame; otherwise the server
+		# places us with the old local position under the new parent uuid and
+		# teleports us.
+		call_deferred("_safe_reparent_and_sync", new_parent)
 		# if gravity_parents.has(area):
 		# 	gravity_parents.erase(area)
+
+## Reparent guarded against invalid states (node/parent out of tree, already
+## parented, repeated area_exited events) to avoid a server segfault, then emit
+## the move so the server receives the position relative to the new parent.
+func _safe_reparent_and_sync(new_parent: Node) -> void:
+	if new_parent == null or not is_instance_valid(new_parent):
+		return
+	if not is_inside_tree() or not new_parent.is_inside_tree():
+		return
+	if get_parent() != new_parent:
+		reparent(new_parent)
+	emit_signal(
+		"hs_server_move",
+		client_uuid,
+		snapped(position, Vector3(0.001, 0.001, 0.001)),
+		snapped(global_rotation, Vector3(0.0001, 0.0001, 0.0001)),
+		new_parent.uuid,
+		is_parented
+	)
 
 func _set_player_global_position(pos, rot):
 	global_position = pos
@@ -705,6 +876,16 @@ func client_channel_data_update(data: Dictionary) -> void:
 				is_jumping = true
 			"toggle_flashlight":
 				flashlight.visible = not flashlight.visible
+	# Replicated equipment state: show/hide the held tool on remote players.
+	if data.has("tools") and remote_player and perforator:
+		perforator.visible = str(data["tools"]) != ""
+	# Replicated camera pitch: orient the remote player's aim (EquipmentMount reads
+	# CameraPivot.rotation.x to aim the held tool).
+	if data.has("head") and remote_player:
+		camera_pivot.rotation.x = float(data["head"])
+	# Replicated perforation state: drive the jackhammer animation on remote players.
+	if data.has("perforating") and remote_player:
+		_apply_perforating(bool(data["perforating"]))
 
 # receive properties from the client, often the actions
 func server_action_received(data: Dictionary) -> void:
@@ -713,6 +894,19 @@ func server_action_received(data: Dictionary) -> void:
 			is_jumping = true
 		"toggle_flashlight":
 			flashlight.visible = not flashlight.visible
+		"equip_tool":
+			# Authoritative tool state, then replicate it as a property ("tools") to
+			# nearby clients via the generic update path so they show/hide the tool.
+			var tool_id: String = data.get("tools", "")
+			if perforator:
+				perforator.visible = tool_id != ""
+			server_send_properties_to_client({"tools": tool_id})
+		"set_head":
+			# Replicate the camera pitch so others see where this player aims.
+			server_send_properties_to_client({"head": data.get("head", 0.0)})
+		"set_perforating":
+			# Replicate the perforation state so others see the jackhammer animation.
+			server_send_properties_to_client({"perforating": data.get("perforating", false)})
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -36,73 +36,6 @@ const PAUSE: String = "pause"
 @export_range(0.0, 1.0) var view_bobbing_amount: float = 1.0
 @export_range(1.0, 10.0) var camera_sensitivity: float = 2.0
 
-# Aim mode (right-click): slow-down factors (1.0 = normal)
-@export_range(0.1, 1.0) var aim_sensitivity_factor: float = 0.4
-@export_range(0.1, 1.0) var aim_speed_factor: float = 0.4
-# Max distance (m) to a mining rock to be allowed to enter aim mode
-@export var aim_rock_distance: float = 2.0
-var is_aiming: bool = false
-
-# Perforation (left-click while aiming): jackhammer-style hammering ~5 s
-const PERFORATION_DURATION := 5.0
-@export var perforation_hammer_freq: float = 10.0       # back-and-forth jabs per second
-@export var perforation_hammer_amplitude: float = 0.18  # depth of one jab (m)
-@export var perforation_shake_amplitude: float = 0.025  # tremble (m)
-var is_perforating: bool = false
-var _perforation_t: float = 0.0
-var _perforator_rest_pos: Vector3 = Vector3.ZERO
-var _rock_ray: RayCast3D = null   # camera raycast to detect "looking at a rock"
-var _crosshair_shown: bool = false
-var _last_head_sent: float = INF   # last camera pitch sent to the server (throttle "head" sync)
-
-## True if a mining rock (group "miningrock") is within aim range.
-func _is_near_mining_rock() -> bool:
-	for r in get_tree().get_nodes_in_group("miningrock"):
-		if r is Node3D and global_position.distance_to((r as Node3D).global_position) <= aim_rock_distance:
-			return true
-	return false
-
-## True if the camera is currently looking at a mining rock (camera raycast).
-func _is_looking_at_rock() -> bool:
-	if camera == null:
-		return false
-	if _rock_ray == null:
-		_rock_ray = RayCast3D.new()
-		_rock_ray.target_position = Vector3(0.0, 0.0, -(aim_rock_distance + 2.0))
-		_rock_ray.collision_mask = 0xFFFFFFFF
-		camera.add_child(_rock_ray)
-	_rock_ray.force_raycast_update()
-	var c = _rock_ray.get_collider()
-	return c != null and c.is_in_group("miningrock")
-
-## Apply the perforating state locally (owner from input, remote from the
-## replicated "perforating" property). Resets the timer, and returns the tool to
-## its rest position when stopping.
-func _apply_perforating(active: bool) -> void:
-	if active == is_perforating:
-		return
-	is_perforating = active
-	_perforation_t = 0.0
-	if not active and perforator:
-		perforator.position = _perforator_rest_pos
-
-## Owner: set the perforating state AND replicate it so other players see the animation.
-func _set_perforating(active: bool) -> void:
-	if active == is_perforating:
-		return
-	_apply_perforating(active)
-	client_send_action_to_server({"action": "set_perforating", "perforating": active})
-
-## Advance and apply the jackhammer visual. Runs on EVERY instance while
-## perforating (remote players too), so the animation is seen by everyone.
-func _update_perforation_visual(delta: float) -> void:
-	if not is_perforating or perforator == null:
-		return
-	_perforation_t += delta
-	# fast back-and-forth jabs along the aim (-Z) + random tremble
-	var hammer: float = absf(sin(_perforation_t * perforation_hammer_freq * TAU)) * perforation_hammer_amplitude
-	var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
-	perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, hammer) + shake
 @export_range(0.0, 0.5) var camera_start_deadzone: float = .2
 @export_range(0.0, 0.5) var camera_end_deadzone: float = .1
 
@@ -171,23 +104,9 @@ var _display_debug:bool = false
 
 @onready var flashlight: SpotLight3D = $CameraPivot/Camera3D/Torch
 
-# Perforator V0 mining tool — equipped/unequipped with key 1/& (issue #117).
-# Instanced at runtime on every client/server instance, hidden until equipped.
-const PERFORATOR_SCENE := preload("res://assets/models/equipments/tools/mining/hammerdrill.glb")
-var perforator: Node3D = null
-## Generic hand mount that holds and aims the current equipment (see EquipmentMount).
-var equipment_mount: EquipmentMount = null
-
-## Equipment placement (tune in the inspector, applied on the next run).
-@export_group("Equipment placement")
-## Mount position on the body. This is the PIVOT the held item rotates around when aiming.
-@export var equipment_hand_offset: Vector3 = Vector3(0.4, 1.0, -0.4)
-## Held item offset inside the mount. Shift it so the item's grip sits on the pivot above.
-@export var equipment_item_offset: Vector3 = Vector3.ZERO
-## Held item base rotation, to make the model point forward (-Z).
-@export var equipment_item_rotation_deg: Vector3 = Vector3(0, -90, 0)
-## Held item uniform scale.
-@export var equipment_item_scale: float = 2.0
+# Mining gameplay (perforator equip, aim, perforation) is encapsulated in the
+# MiningTool component (scene child). Networking stays here (see _ready wiring).
+@onready var mining_tool: MiningTool = $MiningTool
 
 func _enter_tree() -> void:
 	if remote_player:
@@ -205,23 +124,11 @@ func _enter_tree() -> void:
 func _ready() -> void:
 	prints("Player", name, "spawned at", spawn_position, "on server" if GameOrchestrator.is_server() else "on client")
 
-	# Equipment mount: a generic hand mount attached to the player body (NOT the
-	# Astronaut model, which is hidden for the local first-person view) so held
-	# items show for self AND others. It aims whatever it holds where the camera
-	# looks; future tools/weapons attach here and inherit the aiming for free.
-	equipment_mount = EquipmentMount.new()
-	equipment_mount.name = "EquipmentMount"
-	add_child(equipment_mount)
-	equipment_mount.position = equipment_hand_offset  # the pivot the held item rotates around
-	equipment_mount.pitch_source = camera_pivot  # aim follows the camera pitch
-	# First item: the mining perforator (hidden until equipped with 1/&).
-	perforator = PERFORATOR_SCENE.instantiate()
-	perforator.position = equipment_item_offset  # shift the model so its grip sits on the pivot
-	perforator.rotation_degrees = equipment_item_rotation_deg  # model points forward (-Z)
-	perforator.scale = Vector3.ONE * equipment_item_scale
-	perforator.visible = false  # hidden until equipped with the 1/& key
-	equipment_mount.hold(perforator)
-	_perforator_rest_pos = perforator.position  # base for the perforation jab
+	# Mining tool: build its equipment mount + perforator from our camera rig, and
+	# relay its replicated-state requests to the server + its aim signal to the UI.
+	mining_tool.setup(camera_pivot, camera)
+	mining_tool.sync_requested.connect(client_send_action_to_server)
+	mining_tool.aiming_changed.connect($UserInterface.set_aiming)
 
 	if remote_player:
 		camera.current = false
@@ -325,12 +232,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		# flashlight.visible = not flashlight.visible
 
 	if event.is_action_pressed("toggle_tool"):
-		if perforator:
-			var equipped := not perforator.visible
-			perforator.visible = equipped  # immediate local toggle (first-person view)
-			# Send the equipped tool as a STATE (not a one-shot event) so other clients
-			# always converge to the right state via the replicated "tools" property.
-			client_send_action_to_server({"action": "equip_tool", "tools": ("perforator" if equipped else "")})
+		mining_tool.toggle_equip()
 
 	if event.is_action_pressed("spawn_50cmbox"):
 		spawn_box("testbox/box_50cm", "box", 1.5, 2.0)
@@ -364,49 +266,20 @@ func server_set_input(input_dir: Vector2, newrotation: Vector3) -> void:
 	new_input_from_server = true
 
 func _process(_delta: float) -> void:
-	# Perforation visual runs on every instance (remote players too), driven by
-	# is_perforating (set by input locally, or by the replicated "perforating").
-	_update_perforation_visual(_delta)
 	if remote_player: return
 	if !active:
 		interact_label.hide()
 		return
 
-	# Aim mode (right-click): slow down only if the tool is equipped AND near a rock
-	var can_aim := perforator != null and perforator.visible and _is_near_mining_rock()
-	is_aiming = Input.is_action_pressed("aim") and can_aim
-	# The aim crosshair shows only while aiming AND looking at the rock
-	var looking := is_aiming and _is_looking_at_rock()
-	if looking != _crosshair_shown:
-		_crosshair_shown = looking
-		$UserInterface.set_aiming(looking)
-	if is_aiming:
-		mouse_motion *= aim_sensitivity_factor
-
-	# Perforation control (owner): start on left-click while aiming, stop on
-	# release or after PERFORATION_DURATION. The visual is handled by
-	# _update_perforation_visual (also on remote players via "perforating").
-	if is_perforating:
-		if not is_aiming or not Input.is_action_pressed("perforate"):
-			_set_perforating(false)  # released (aim or left-click) -> cancelled, no effect
-		elif _perforation_t >= PERFORATION_DURATION:
-			# animation end -> the fracture would trigger HERE (server-side, TODO)
-			_set_perforating(false)
-	elif looking and Input.is_action_just_pressed("perforate"):
-		_set_perforating(true)
-
-	if is_perforating:
+	# Mining (aim, perforation, head sync) runs in the MiningTool; here we just
+	# apply its effect on the local mouse look before moving the camera.
+	mining_tool.update_local(_delta)
+	if mining_tool.is_aiming:
+		mouse_motion *= mining_tool.aim_sensitivity_factor
+	if mining_tool.is_perforating:
 		mouse_motion = Vector2.ZERO  # mouse frozen during perforation
 
 	_handle_camera_motion()
-
-	# Replicate the camera pitch ("head") while a tool is equipped, so other players
-	# see where we aim. Throttled to meaningful changes to limit network traffic.
-	if perforator and perforator.visible:
-		var head_q: float = snappedf(camera_pivot.rotation.x, 0.02)
-		if head_q != _last_head_sent:
-			_last_head_sent = head_q
-			client_send_action_to_server({"action": "set_head", "head": head_q})
 
 
 	interact_label.hide()
@@ -484,9 +357,9 @@ func _physics_process(delta: float) -> void:
 		var move_direction = (global_transform.basis * Vector3(input_direction.x, 0, input_direction.y)).normalized()
 
 		var speed = sprint_speed if sprint else walk_speed
-		if is_aiming:
-			speed *= aim_speed_factor  # slowed down in aim mode
-		if is_perforating:
+		if mining_tool.is_aiming:
+			speed *= mining_tool.aim_speed_factor  # slowed down in aim mode
+		if mining_tool.is_perforating:
 			speed = 0.0  # frozen during perforation
 
 		if is_on_floor():
@@ -801,16 +674,10 @@ func client_channel_data_update(data: Dictionary) -> void:
 				is_jumping = true
 			"toggle_flashlight":
 				flashlight.visible = not flashlight.visible
-	# Replicated equipment state: show/hide the held tool on remote players.
-	if data.has("tools") and remote_player and perforator:
-		perforator.visible = str(data["tools"]) != ""
-	# Replicated camera pitch: orient the remote player's aim (EquipmentMount reads
-	# CameraPivot.rotation.x to aim the held tool).
-	if data.has("head") and remote_player:
-		camera_pivot.rotation.x = float(data["head"])
-	# Replicated perforation state: drive the jackhammer animation on remote players.
-	if data.has("perforating") and remote_player:
-		_apply_perforating(bool(data["perforating"]))
+	# Replicated mining state (tool visibility, camera aim, perforation) is applied
+	# on remote players by the MiningTool component.
+	if remote_player:
+		mining_tool.apply_remote(data)
 
 # receive properties from the client, often the actions
 func server_action_received(data: Dictionary) -> void:
@@ -820,11 +687,9 @@ func server_action_received(data: Dictionary) -> void:
 		"toggle_flashlight":
 			flashlight.visible = not flashlight.visible
 		"equip_tool":
-			# Authoritative tool state, then replicate it as a property ("tools") to
-			# nearby clients via the generic update path so they show/hide the tool.
+			# Authoritative tool state, then replicate it to nearby clients.
 			var tool_id: String = data.get("tools", "")
-			if perforator:
-				perforator.visible = tool_id != ""
+			mining_tool.server_set_tool(tool_id)
 			server_send_properties_to_client({"tools": tool_id})
 		"set_head":
 			# Replicate the camera pitch so others see where this player aims.

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -408,27 +408,6 @@ func _process(_delta: float) -> void:
 			_last_head_sent = head_q
 			client_send_action_to_server({"action": "set_head", "head": head_q})
 
-	# DEBUG 15deg-offset: measure WORLD displacement direction vs facing
-	if not OS.has_feature("dedicated_server"):
-		var _cur_world: Vector3 = global_position
-		if has_meta("_dbg_last_world"):
-			var _last: Vector3 = get_meta("_dbg_last_world")
-			var _disp: Vector3 = _cur_world - _last
-			if _disp.length() > 0.05 and input_direction.length() > 0.01:
-				var _fwd_world: Vector3 = -global_transform.basis.z
-				var _disp_dir: Vector3 = _disp.normalized()
-				# project onto horizontal plane (perpendicular to up_direction) so vertical drift doesn't dominate
-				var _up: Vector3 = up_direction.normalized() if up_direction.length() > 0.01 else Vector3.UP
-				var _fwd_h: Vector3 = (_fwd_world - _up * _fwd_world.dot(_up)).normalized()
-				var _disp_h: Vector3 = (_disp_dir - _up * _disp_dir.dot(_up)).normalized()
-				# Signed angle: positive = displacement is to the LEFT of facing (around up axis)
-				var _cross: Vector3 = _fwd_h.cross(_disp_h)
-				var _sign: float = 1.0 if _cross.dot(_up) > 0.0 else -1.0
-				var _signed_angle_deg: float = rad_to_deg(_fwd_h.angle_to(_disp_h)) * _sign
-				print("[VISUAL-MOVE] input=", input_direction, " signed_angle_disp_vs_fwd_deg=", \
-					_signed_angle_deg, " disp_len=", _disp.length(), " fwd_h=", _fwd_h, " disp_h=", _disp_h, " parent=", get_parent().name)
-		set_meta("_dbg_last_world", _cur_world)
-	# END DEBUG
 
 	interact_label.hide()
 	can_interact = false
@@ -476,34 +455,6 @@ func _physics_process(delta: float) -> void:
 		if new_input_from_server:
 			input_direction = input_from_server["input_direction"]
 			global_rotation = input_from_server["rotation"]
-			# DEBUG 15deg-offset: compare received rotation vs what global_rotation actually stores
-			var _recv_rot: Vector3 = input_from_server["rotation"]
-			var _stored_rot: Vector3 = global_rotation
-			var _delta: Vector3 = _stored_rot - _recv_rot
-			if _delta.length() > 0.001:
-				print("[ROT-DEBUG] recv=", _recv_rot, " stored=", _stored_rot, " delta_deg=", \
-					Vector3(rad_to_deg(_delta.x), rad_to_deg(_delta.y), rad_to_deg(_delta.z)), \
-					" parent=", get_parent().name, " is_parented=", is_parented)
-			# DEBUG: also log move_direction vs basis.z to see the angular offset
-			var _fwd_world: Vector3 = -global_transform.basis.z
-			var _move_dir: Vector3 = (global_transform.basis * Vector3(input_direction.x, 0, input_direction.y)).normalized() \
-				if input_direction.length() > 0.01 else Vector3.ZERO
-			if input_direction.length() > 0.01:
-				var _angle: float = rad_to_deg(_fwd_world.angle_to(_move_dir))
-				var _p := get_parent()
-				var _p_name: String = _p.name if _p else "<none>"
-				var _p_basis_y_deg: float = 0.0
-				var _p_fwd_world: Vector3 = Vector3.ZERO
-				var _local_pos: Vector3 = position
-				var _world_pos: Vector3 = global_position
-				if _p and _p is Node3D:
-					var _pb: Basis = (_p as Node3D).global_transform.basis
-					_p_basis_y_deg = rad_to_deg((_pb.get_euler(EULER_ORDER_YXZ)).y)
-					_p_fwd_world = -_pb.z
-				# print("[MOVE-DEBUG] input=", input_direction, " body_fwd=", _fwd_world, " move_dir=", \
-				# 	_move_dir, " angle_fwd_to_move_deg=", _angle, " parent=", _p_name, " parent_yaw_deg=", \
-				# 	_p_basis_y_deg, " parent_fwd=", _p_fwd_world, " local_pos=", _local_pos, " world_pos=", _world_pos)
-			# END DEBUG
 
 		var sprint = null
 		# print("gravity parents:", gravity_parents.size())
@@ -617,24 +568,6 @@ func _physics_process(delta: float) -> void:
 			client_last_input_direction = input_direction
 			client_last_global_rotation = short_rotation
 			emit_signal("hs_client_action_move", input_direction, short_rotation)
-			# DEBUG 15deg-offset: log what client SENDS vs current visual basis
-			var _client_fwd: Vector3 = -global_transform.basis.z
-			var _sent_basis := Basis.from_euler(short_rotation, EULER_ORDER_YXZ)
-			var _sent_fwd: Vector3 = -_sent_basis.z
-			var _angle_visual_vs_sent: float = rad_to_deg(_client_fwd.angle_to(_sent_fwd))
-			var _p := get_parent()
-			var _p_name: String = _p.name if _p else "<none>"
-			var _p_yaw_deg: float = 0.0
-			var _p_fwd_world: Vector3 = Vector3.ZERO
-			if _p and _p is Node3D:
-				var _pb: Basis = (_p as Node3D).global_transform.basis
-				_p_yaw_deg = rad_to_deg((_pb.get_euler(EULER_ORDER_YXZ)).y)
-				_p_fwd_world = -_pb.z
-			print("[CLIENT-SEND] input=", input_direction, " visual_fwd=", _client_fwd, " sent_fwd=", _sent_fwd, \
-				" angle_visual_vs_sent_deg=", _angle_visual_vs_sent, " up=", up_direction, " parent=", _p_name, \
-				" parent_yaw_deg=", _p_yaw_deg, " parent_fwd=", _p_fwd_world, " local_pos=", position, " world_pos=", \
-				global_position)
-			# END DEBUG
 		update_last_basis()
 
 		labelx.text = str("%0.2f" % global_position[0])
@@ -720,15 +653,7 @@ func _snap_to_planet_surface_if_below(area: Area3D) -> void:
 			velocity -= up_world * radial_speed
 
 func orient_player():
-	var _before_y: Vector3 = global_transform.basis.y
-	var _before_fwd: Vector3 = -global_transform.basis.z
 	global_transform = global_transform.interpolate_with(Globals.align_with_y(global_transform, up_direction), 0.3)
-	var _after_fwd: Vector3 = -global_transform.basis.z
-	var _yaw_change_deg: float = rad_to_deg(_before_fwd.angle_to(_after_fwd))
-	var _up_misalignment_deg: float = rad_to_deg(_before_y.angle_to(up_direction))
-	if _up_misalignment_deg > 0.5 or _yaw_change_deg > 0.5:
-		print("[ORIENT] up_misalignment_deg=", _up_misalignment_deg, " fwd_change_deg=", _yaw_change_deg, \
-			" up_dir=", up_direction, " before_y=", _before_y)
 
 func set_player_name(player_name):
 	label_player_name.text = str(player_name)

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -514,6 +514,5 @@ visible = false
 [connection signal="display_debug" from="." to="UserInterface/Debug/client_messages_received" method="_on_normal_player_display_debug"]
 [connection signal="display_debug" from="." to="UserInterface/Debug/client_messages_sent" method="_on_normal_player_display_debug"]
 [connection signal="area_entered" from="AreaDetector" to="." method="_on_area_detector_area_entered"]
-[connection signal="draw" from="UserInterface/HUD/CrosshairContainer/Crosshair" to="UserInterface" method="_on_crosshair_draw"]
 [connection signal="pressed" from="UserInterface/HUD/Control/AudioContainer/ButtonSpeaker" to="UserInterface" method="_on_button_speaker_pressed"]
 [connection signal="pressed" from="UserInterface/HUD/Control/AudioContainer/ButtonMicrophone" to="UserInterface" method="_on_button_microphone_pressed"]

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -32,6 +32,7 @@
 [ext_resource type="Script" uid="uid://bfpote331tkhp" path="res://scenes/normal_player/debug_server_name.gd" id="18_e837o"]
 [ext_resource type="Texture2D" uid="uid://ndwy7fky4xxu" path="res://ui/player_interface/volume-high-solid-full.svg" id="27_akued"]
 [ext_resource type="Texture2D" uid="uid://crlbs5i36jfp" path="res://ui/player_interface/microphone-solid-full.svg" id="28_2sxo3"]
+[ext_resource type="Script" uid="uid://d2lihgny3jxwd" path="res://scenes/normal_player/mining_tool.gd" id="33_2sxo3"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_2jk7f"]
 radius = 0.26542
@@ -496,6 +497,9 @@ visible = false
 [node name="hammerdrill2" parent="." unique_id=352818182 instance=ExtResource("14_fuv0x")]
 transform = Transform3D(5.406494717047727e-17, -2.8746842332822335e-17, -1, 0.4694715627858908, 0.882947592858927, 0, 0.882947592858927, -0.4694715627858908, 6.123233995736766e-17, 0.35599999999976717, 1.1830000000045402, -0.27999999999883585)
 visible = false
+
+[node name="MiningTool" type="Node3D" parent="." unique_id=709506111]
+script = ExtResource("33_2sxo3")
 
 [connection signal="display_debug" from="." to="UserInterface/Debug" method="_on_normal_player_display_debug"]
 [connection signal="display_debug" from="." to="UserInterface/Debug/universe_servers" method="_on_normal_player_display_debug"]

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -500,6 +500,14 @@ visible = false
 
 [node name="MiningTool" type="Node3D" parent="." unique_id=709506111]
 script = ExtResource("33_2sxo3")
+aim_roll_deg = 0.0
+perforation_hammer_freq = 5.0
+bit_axis = Vector3(1, 0, 0)
+perforation_hammer_amplitude = 0.01
+perforation_shake_amplitude = 0.003
+equipment_hand_offset = Vector3(0.4, 1, 0.1)
+equipment_item_offset = Vector3(0, -0.15, -0.2)
+equipment_item_scale = 1.0
 
 [connection signal="display_debug" from="." to="UserInterface/Debug" method="_on_normal_player_display_debug"]
 [connection signal="display_debug" from="." to="UserInterface/Debug/universe_servers" method="_on_normal_player_display_debug"]

--- a/scenes/normal_player/player_ui.gd
+++ b/scenes/normal_player/player_ui.gd
@@ -16,8 +16,8 @@ var bus_record_index = 0
 @onready var button_speaker = $HUD/Control/AudioContainer/ButtonSpeaker
 @onready var button_microphone = $HUD/Control/AudioContainer/ButtonMicrophone
 
-# On-demand aim crosshair manager (overlays). The permanent small dot
-# (%Crosshair) stays handled separately and is always visible.
+# Reticle manager: draws the permanent small dot (base) AND the on-demand
+# aim/overlay crosshairs. Single place responsible for all crosshair drawing.
 var crosshair_manager: CrosshairManager = null
 
 func _ready() -> void:
@@ -27,15 +27,6 @@ func _ready() -> void:
 		bus_master_index = AudioServer.get_bus_index("Master")
 		bus_record_index = AudioServer.get_bus_index("Record")
 		_setup_crosshair_manager()
-
-## Use this method if you want to draw a custom crosshair. Remove if you want to use a custom image for the crosshair
-func _draw_crosshair() -> void:
-	crosshair.draw_circle(Vector2.ZERO, 1.0, Color.WHITE)
-
-
-func _on_crosshair_draw() -> void:
-	_draw_crosshair()
-
 
 # ── Aim crosshairs: delegated to CrosshairManager (reusable helper) ──────────
 # The manager is placed in the same centered container as the small dot

--- a/scenes/normal_player/player_ui.gd
+++ b/scenes/normal_player/player_ui.gd
@@ -16,12 +16,17 @@ var bus_record_index = 0
 @onready var button_speaker = $HUD/Control/AudioContainer/ButtonSpeaker
 @onready var button_microphone = $HUD/Control/AudioContainer/ButtonMicrophone
 
+# On-demand aim crosshair manager (overlays). The permanent small dot
+# (%Crosshair) stays handled separately and is always visible.
+var crosshair_manager: CrosshairManager = null
+
 func _ready() -> void:
 	if not is_multiplayer_authority():
 		hide()
 	else:
 		bus_master_index = AudioServer.get_bus_index("Master")
 		bus_record_index = AudioServer.get_bus_index("Record")
+		_setup_crosshair_manager()
 
 ## Use this method if you want to draw a custom crosshair. Remove if you want to use a custom image for the crosshair
 func _draw_crosshair() -> void:
@@ -30,6 +35,20 @@ func _draw_crosshair() -> void:
 
 func _on_crosshair_draw() -> void:
 	_draw_crosshair()
+
+
+# ── Aim crosshairs: delegated to CrosshairManager (reusable helper) ──────────
+# The manager is placed in the same centered container as the small dot
+# (CenterContainer) so its drawings are centered on screen.
+func _setup_crosshair_manager() -> void:
+	crosshair_manager = CrosshairManager.new()
+	crosshair_manager.name = "CrosshairManager"
+	crosshair.get_parent().add_child(crosshair_manager)
+
+## Enable/disable the aim crosshair (aim mode / right-click).
+func set_aiming(aiming: bool) -> void:
+	if crosshair_manager:
+		crosshair_manager.set_style("aim" if aiming else "")
 
 
 func _on_button_speaker_pressed() -> void:

--- a/scenes/normal_player/player_ui.gd
+++ b/scenes/normal_player/player_ui.gd
@@ -12,13 +12,13 @@ var microphone_status = true
 var bus_master_index = 0
 var bus_record_index = 0
 
-@onready var crosshair: Control = %Crosshair
-@onready var button_speaker = $HUD/Control/AudioContainer/ButtonSpeaker
-@onready var button_microphone = $HUD/Control/AudioContainer/ButtonMicrophone
-
 # Reticle manager: draws the permanent small dot (base) AND the on-demand
 # aim/overlay crosshairs. Single place responsible for all crosshair drawing.
 var crosshair_manager: CrosshairManager = null
+
+@onready var crosshair: Control = %Crosshair
+@onready var button_speaker = $HUD/Control/AudioContainer/ButtonSpeaker
+@onready var button_microphone = $HUD/Control/AudioContainer/ButtonMicrophone
 
 func _ready() -> void:
 	if not is_multiplayer_authority():

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -35,6 +35,7 @@ var blocs = [
 @onready var rock_shape = $CollisionShape3D
 
 func _ready() -> void:
+	add_to_group("miningrock")  # for proximity detection (aim mode)
 	var item_rock_mesh = get_child(0) as CSGMesh3D
 	combiner = CSGCombiner3D.new()
 	add_child(combiner)

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -169,6 +169,14 @@ func client_channel_data_update(data: Dictionary) -> void:
 		)
 	if data.has("blocs"):
 		blocs = data["blocs"]
+		# _cut_rock() needs `combiner`, which is created in _ready(). When this
+		# rock is spawned from the network, client_channel_data_update() is called
+		# *before* the node enters the tree (see server/client.gd ~l.622), so
+		# _ready() hasn't run yet and `combiner` is still null -> crash.
+		# Wait until the node is ready before processing the blocs.
+		if not is_node_ready():
+			await ready
+			await get_tree().process_frame  # let _ready() finish reparenting the mesh into combiner
 		_calculate_blocs()
 
 #####################################################################

--- a/server/client.gd
+++ b/server/client.gd
@@ -574,7 +574,7 @@ func create_generic_object(event: Dictionary) -> void:
 				var parent = _search_parent_node(object_data["parent_id"])
 				if parent != null:
 					prop_instance.client_parent_change(parent)
-		print("client_channel_data_update (1) for existing object %s" % object_id)
+		#print("client_channel_data_update (1) for existing object %s" % object_id)
 		prop_instance.client_channel_data_update(object_data)
 
 	else:
@@ -590,8 +590,8 @@ func create_generic_object(event: Dictionary) -> void:
 
 			object_data = event["object_data"]
 
-			print("Object DATA")
-			print(object_data)
+			#print("Object DATA")
+			#print(object_data)
 
 			var parent = null
 			if object_data.has("parent_id"):
@@ -618,7 +618,7 @@ func create_generic_object(event: Dictionary) -> void:
 				prop_instance.freeze = true
 			prop_instance.uuid = object_id
 
-			print("client_channel_data_update (2) for existing object %s" % object_id)
+			#print("client_channel_data_update (2) for existing object %s" % object_id)
 			prop_instance.client_channel_data_update(object_data)
 
 			# client_channel_data_update must be called before parent for the position
@@ -671,7 +671,7 @@ func create_generic_object(event: Dictionary) -> void:
 						if parent != null:
 							prop_instance.client_parent_change(parent)
 
-				print("client_channel_data_update (4) for existing object %s" % object_id)
+				#print("client_channel_data_update (4) for existing object %s" % object_id)
 				prop_instance.client_channel_data_update(object_data)
 
 			# event not has scenename, so we store it for later creation
@@ -733,7 +733,7 @@ func update_generic_object(event: Dictionary) -> void:
 					if parent != null:
 						prop_instance.client_parent_change(parent)
 
-			print("client_channel_data_update (5) for existing object %s" % object_id)
+			#print("client_channel_data_update (5) for existing object %s" % object_id)
 			prop_instance.client_channel_data_update(object_data)
 		else:
 			print("Update generic object but not found: %s" % object_id)
@@ -757,7 +757,22 @@ func player_update(message: Dictionary) -> void:
 	if int(message["channel"]) == 0:
 		var uuid = message["object_id"]
 		if players_list.has(uuid):
-			if message["event_type"] == "move":
+			if message["event_type"] == "update_property":
+				# Apply replicated gameplay state (equipped tool "tools", camera "head").
+				# Position/rotation are skipped here; they come from the "move" path.
+				var player_p = players_list[uuid]
+				if is_instance_valid(player_p):
+					var d: Dictionary = message["data"]
+					var props := {}
+					if d.has("tools"):
+						props["tools"] = d["tools"]
+					if d.has("head"):
+						props["head"] = d["head"]
+					if d.has("perforating"):
+						props["perforating"] = d["perforating"]
+					if not props.is_empty():
+						player_p.client_channel_data_update(props)
+			elif message["event_type"] == "move":
 				# print("players UUIDs: %s" % players_list.keys())
 				var player = players_list[uuid]
 				if not is_instance_valid(player):


### PR DESCRIPTION
## PR 1 — `DyingStar-game/DyingStar` : `feat/mining-v0-perforator` → `develop`

**Title:** `Mining V0: perforator with multiplayer aim, animation and visibility`

**Body:**
```markdown
## What
First mining tool (perforator) as a multiplayer-visible, animated tool, plus the
supporting reticle/equipment helpers. **Requires the horizonserver PR**
"Implement generic player property replication (players/update)" — the multiplayer
parts depend on it; merge together.

## Gameplay
- Equip / unequip the perforator with key **1/&** (toggle).
- **Right-click** to aim at a nearby mining rock (≤ 2 m, group `miningrock`):
  star crosshair + slowed mouse/movement.
- **Hold left-click** to perforate: ~5 s jackhammer animation (player frozen,
  cancellable). The actual rock cut stays server-side (follow-up).
- The held tool aims at the point under the crosshair (look_at, smoothed,
  upright) and **only the drill bit reciprocates**; the aim is reconstructed on
  every client from the synced rotation + camera pitch, so others see it too.

## Multiplayer
Other players see, per player: the equipped tool (`tools`), the camera aim
(`head`) and the perforation animation (`perforating`), replicated as player
properties.

## Architecture (SOLID)
- **MiningTool** (scene component): owns equipment + aim detection + perforation;
  `@export` params in the inspector. Networking stays in the player via the
  `sync_requested` / `aiming_changed` signals and `apply_remote()` /
  `server_set_tool()` methods.
- **EquipmentMount**: generic hand mount that aims any held item toward the camera.
- **CrosshairManager**: single owner of all reticle drawing (permanent dot base
  + contextual overlays).
- **client.gd**: routes a player's replicated `update_property` to
  `client_channel_data_update`.

## Notes
- Includes the earlier fix *"Fix mining rock crash on networked fracture
  (null combiner before _ready)"*.
- The actual rock fracture (faults / cut) is a follow-up PR (WIP on a separate
  branch).
```