### PR TITLE
Mining V0: multiplayer perforator and rock fracture

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -144,11 +144,6 @@ toggle_chat={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194343,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
-ext_cam={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194335,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-]
-}
 interact={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -65,6 +65,8 @@ var _bit_rest: Vector3 = Vector3.ZERO
 var _rock_ray: RayCast3D = null
 var _crosshair_shown: bool = false
 var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" sync)
+var _target_rock_uuid: String = ""     # rock aimed when the perforation started
+var _target_hit_local: Vector3 = Vector3.ZERO  # aim point, in that rock's local space
 
 ## Inject the player's camera rig and build the equipment mount + perforator.
 func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
@@ -126,9 +128,10 @@ func update_local(_delta: float) -> void:
 		if not is_aiming or not Input.is_action_pressed("perforate"):
 			_set_perforating(false)  # released -> cancelled, no effect
 		elif _perforation_t >= PERFORATION_DURATION:
-			# animation end -> the fracture would trigger HERE (server-side, TODO)
+			_emit_perforate()  # animation complete -> fracture the targeted rock
 			_set_perforating(false)
 	elif looking and Input.is_action_just_pressed("perforate"):
+		_capture_target()
 		_set_perforating(true)
 
 	# Replicate the camera pitch ("head") while a tool is equipped, so other
@@ -193,6 +196,27 @@ func _aim_point() -> Vector3:
 		if _rock_ray.is_colliding():
 			return _rock_ray.get_collision_point()
 	return origin + fwd * (aim_rock_distance + 2.0)
+
+## Capture the rock under the crosshair + the aim point (in the rock's local space)
+## when a perforation starts, so we can fracture exactly there at the end.
+func _capture_target() -> void:
+	_target_rock_uuid = ""
+	if _rock_ray == null or not _rock_ray.is_colliding():
+		return
+	var rock = _rock_ray.get_collider()
+	if rock != null and rock.is_in_group("miningrock") and "uuid" in rock:
+		_target_rock_uuid = str(rock.uuid)
+		_target_hit_local = (rock as Node3D).to_local(_rock_ray.get_collision_point())
+
+## Owner: ask the server to fracture the targeted rock at the captured point.
+func _emit_perforate() -> void:
+	if _target_rock_uuid == "":
+		return
+	sync_requested.emit({
+		"action": "perforate_rock",
+		"uuid": _target_rock_uuid,
+		"hit": {"x": _target_hit_local.x, "y": _target_hit_local.y, "z": _target_hit_local.z},
+	})
 
 ## Apply the perforating state locally (owner from input, remote from "perforating").
 func _apply_perforating(active: bool) -> void:

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -17,6 +17,8 @@ signal aiming_changed(aiming: bool)
 
 const PERFORATOR_SCENE := preload("res://assets/models/equipments/tools/mining/hammerdrill.glb")
 const PERFORATION_DURATION := 5.0
+## Brief "rejected" jab when perforating off a fault: the bit lunges and snaps back.
+const REJECT_DURATION := 0.3
 
 @export_group("Aim")
 ## Mouse-sensitivity factor while aiming (1.0 = normal).
@@ -27,6 +29,9 @@ const PERFORATION_DURATION := 5.0
 @export var aim_rock_distance: float = 2.0
 ## Roll correction (deg) to keep the tool upright while aiming (model-dependent).
 @export var aim_roll_deg: float = 0.0
+## Orient the tool toward the aimed rock (look_at). Uncheck to keep it on the camera
+## pitch only (no pointing at the rock).
+@export var orient_tool_at_rock: bool = true
 
 @export_group("Perforation")
 @export var perforation_hammer_freq: float = 10.0       # back-and-forth jabs per second
@@ -49,6 +54,19 @@ const PERFORATION_DURATION := 5.0
 ## Held item uniform scale.
 @export var equipment_item_scale: float = 2.0
 
+@export_group("Bit tip & reach")
+## Chisel tip position in the PERFORATOR's local space. Calibrate it with the gizmo
+## below: enable show_tip_gizmo, run, and adjust until the sphere sits on the tip.
+@export var bit_tip_offset: Vector3 = Vector3.ZERO
+## Show a small sphere at bit_tip_offset to calibrate it.
+@export var show_tip_gizmo: bool = false
+## Slide the perforator so the bit tip touches the rock at the aim point.
+@export var reach_enabled: bool = true
+## How fast the reach follows (higher = snappier).
+@export var reach_smooth: float = 12.0
+## Max forward extension (m), so the tool never flies off the hand.
+@export var reach_max: float = 1.2
+
 ## True while aiming (read by the player to slow the mouse/movement).
 var is_aiming: bool = false
 ## True during perforation (read by the player to freeze the mouse/movement).
@@ -67,6 +85,11 @@ var _crosshair_shown: bool = false
 var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" sync)
 var _target_rock_uuid: String = ""     # rock aimed when the perforation started
 var _target_hit_local: Vector3 = Vector3.ZERO  # aim point, in that rock's local space
+var _target_aim_dir: Vector3 = Vector3.ZERO    # perforation direction, in that rock's local space
+var _target_on_fault: bool = false     # whether that aim point is on a fault (cuttable)
+var _reject_t: float = -1.0            # >=0 while playing the off-fault "rejected" jab
+var _perforator_base: Vector3 = Vector3.ZERO  # rest pos or reach target (the animation jabs on top of this)
+var _tip_gizmo: MeshInstance3D = null  # debug sphere on the bit tip (calibration)
 
 ## Inject the player's camera rig and build the equipment mount + perforator.
 func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
@@ -91,9 +114,24 @@ func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
 	_perforator.visible = false
 	_equipment_mount.hold(_perforator)
 	_perforator_rest_pos = _perforator.position
+	_perforator_base = _perforator_rest_pos
 	_bit = _perforator.get_node_or_null(bit_node_name)
 	if _bit:
 		_bit_rest = _bit.position
+	# Calibration gizmo: a small sphere at the bit tip, child of the perforator so it
+	# follows the model. Move bit_tip_offset until it sits exactly on the chisel point.
+	if show_tip_gizmo:
+		_tip_gizmo = MeshInstance3D.new()
+		var sphere := SphereMesh.new()
+		sphere.radius = 0.03
+		sphere.height = 0.06
+		var mat := StandardMaterial3D.new()
+		mat.albedo_color = Color(0.2, 1.0, 0.3)
+		mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+		sphere.material = mat
+		_tip_gizmo.mesh = sphere
+		_tip_gizmo.position = bit_tip_offset
+		_perforator.add_child(_tip_gizmo)
 
 func _process(delta: float) -> void:
 	# Aim the held tool at the point under the crosshair on EVERY instance: the
@@ -101,14 +139,44 @@ func _process(delta: float) -> void:
 	# synced body rotation + "head" pitch -> the tool points where they aim, with
 	# no extra networking.
 	if _equipment_mount != null:
-		if _perforator != null and _perforator.visible and _camera != null:
+		# Orient the tool toward the rock while perforating (both clicks) OR during the
+		# off-fault "rejected" jab, so the failed attempt looks the same (orient + plunge
+		# + snap back). During plain aiming it stays on the camera pitch.
+		if orient_tool_at_rock and (is_perforating or _reject_t >= 0.0) and _perforator != null and _perforator.visible and _camera != null:
 			_equipment_mount.aim_target = _aim_point()
 			_equipment_mount.aim_up = global_transform.basis.y
 			_equipment_mount.aim_roll_deg = aim_roll_deg
 		else:
-			_equipment_mount.aim_target = null
+			_equipment_mount.aim_target = null   # no look_at -> follow the camera pitch only
+	# Calibration: keep the gizmo on bit_tip_offset (tunable live via the remote inspector).
+	if _tip_gizmo != null:
+		_tip_gizmo.position = bit_tip_offset
+	# Place the perforator so the bit tip touches the rock at the aim point (full 3D).
+	_update_reach(delta)
+	if _perforator != null:
+		_perforator.position = _perforator_base   # default; the visuals jab on top of it
 	# Perforation visual runs on EVERY instance, driven by is_perforating.
 	_update_perforation_visual(delta)
+	# Off-fault "rejected" jab (owner-local feedback): the bit lunges out then snaps back.
+	_update_reject_visual(delta)
+
+## Lerp the perforator so the bit TIP lands exactly on the rock at the aim point — full
+## 3D (including the tip's lateral offset, not just depth). Only while actively aiming
+## (right-click) or perforating; otherwise it returns to its rest position.
+func _update_reach(delta: float) -> void:
+	var target := _perforator_rest_pos
+	# Reach ONLY while perforating (left-click), not during mere aiming — otherwise the
+	# tip slides on the surface as the crosshair moves. The player is frozen while
+	# perforating, so the tip stays put once engaged.
+	if reach_enabled and _equipment_mount != null and _perforator != null and _perforator.visible \
+			and (is_perforating or _reject_t >= 0.0):
+		var hit: Vector3 = _aim_point()
+		# Solve the perforator position so the tip (basis * bit_tip_offset) == hit.
+		target = _equipment_mount.to_local(hit) - (_perforator.basis * bit_tip_offset)
+		var off: Vector3 = target - _perforator_rest_pos
+		if off.length() > reach_max:
+			target = _perforator_rest_pos + off.normalized() * reach_max   # don't fly off the hand
+	_perforator_base = _perforator_base.lerp(target, clampf(reach_smooth * delta, 0.0, 1.0))
 
 ## Owner only (called by the player's _process): aim mode, perforation control,
 ## camera-pitch ("head") replication.
@@ -132,7 +200,10 @@ func update_local(_delta: float) -> void:
 			_set_perforating(false)
 	elif looking and Input.is_action_just_pressed("perforate"):
 		_capture_target()
-		_set_perforating(true)
+		if _target_rock_uuid != "" and _target_on_fault:
+			_set_perforating(true)            # on a fault -> real perforation
+		else:
+			_reject_t = 0.0                   # off a fault -> brief rejected jab, no cut
 
 	# Replicate the camera pitch ("head") while a tool is equipped, so other
 	# players see where we aim. Throttled to meaningful changes.
@@ -201,6 +272,7 @@ func _aim_point() -> Vector3:
 ## when a perforation starts, so we can fracture exactly there at the end.
 func _capture_target() -> void:
 	_target_rock_uuid = ""
+	_target_on_fault = false
 	if _rock_ray != null:
 		_rock_ray.force_raycast_update()   # fresh hit before capturing the target
 	if _rock_ray == null or not _rock_ray.is_colliding():
@@ -208,7 +280,15 @@ func _capture_target() -> void:
 	var rock = _rock_ray.get_collider()
 	if rock != null and rock.is_in_group("miningrock") and "uuid" in rock:
 		_target_rock_uuid = str(rock.uuid)
-		_target_hit_local = (rock as Node3D).to_local(_rock_ray.get_collision_point())
+		var hit_world: Vector3 = _rock_ray.get_collision_point()
+		_target_hit_local = (rock as Node3D).to_local(hit_world)
+		# Perforation direction (camera forward) in the rock's local space, so the server
+		# can recoil the pieces away from the bit.
+		var dir_world: Vector3 = -_camera.global_transform.basis.z if _camera != null else Vector3.FORWARD
+		_target_aim_dir = ((rock as Node3D).to_local(hit_world + dir_world) - _target_hit_local).normalized()
+		# Only a hit on a fault is cuttable; elsewhere the perforation just bounces off.
+		if rock.has_method("is_on_fault"):
+			_target_on_fault = rock.is_on_fault(_target_hit_local)
 
 ## Owner: ask the server to fracture the targeted rock at the captured point.
 func _emit_perforate() -> void:
@@ -218,6 +298,7 @@ func _emit_perforate() -> void:
 		"action": "perforate_rock",
 		"uuid": _target_rock_uuid,
 		"hit": {"x": _target_hit_local.x, "y": _target_hit_local.y, "z": _target_hit_local.z},
+		"dir": {"x": _target_aim_dir.x, "y": _target_aim_dir.y, "z": _target_aim_dir.z},
 	})
 
 ## Apply the perforating state locally (owner from input, remote from "perforating").
@@ -247,8 +328,27 @@ func _update_perforation_visual(delta: float) -> void:
 	if animate_bit_only and _bit:
 		# The chisel/bit reciprocates along its local axis; the body only trembles.
 		_bit.position = _bit_rest + bit_axis * (phase * bit_amplitude)
-		_perforator.position = _perforator_rest_pos + Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
+		_perforator.position = _perforator_base + Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
 	else:
 		# Whole-tool jab along the aim (-Z) + tremble.
 		var shake := Vector3(randf_range(-1.0, 1.0), randf_range(-1.0, 1.0), 0.0) * perforation_shake_amplitude
-		_perforator.position = _perforator_rest_pos - Vector3(0.0, 0.0, phase * perforation_hammer_amplitude) + shake
+		_perforator.position = _perforator_base - Vector3(0.0, 0.0, phase * perforation_hammer_amplitude) + shake
+
+## Owner-local feedback when perforating off a fault: one quick out-and-back jab, then
+## the tool snaps back to rest. Nothing is sent to the server (no cut).
+func _update_reject_visual(delta: float) -> void:
+	if _reject_t < 0.0 or _perforator == null or is_perforating:
+		return
+	_reject_t += delta
+	if _reject_t >= REJECT_DURATION:
+		_reject_t = -1.0
+		_perforator_base = _perforator_rest_pos   # abrupt snap back to rest (no slow lerp)
+		_perforator.position = _perforator_rest_pos
+		if _bit:
+			_bit.position = _bit_rest
+		return
+	var jab: float = sin((_reject_t / REJECT_DURATION) * PI)   # 0 -> 1 -> 0
+	if _bit:
+		_bit.position = _bit_rest + bit_axis * (jab * bit_amplitude)
+	else:
+		_perforator.position = _perforator_base - Vector3(0.0, 0.0, jab * perforation_hammer_amplitude)

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -201,6 +201,8 @@ func _aim_point() -> Vector3:
 ## when a perforation starts, so we can fracture exactly there at the end.
 func _capture_target() -> void:
 	_target_rock_uuid = ""
+	if _rock_ray != null:
+		_rock_ray.force_raycast_update()   # fresh hit before capturing the target
 	if _rock_ray == null or not _rock_ray.is_colliding():
 		return
 	var rock = _rock_ray.get_collider()

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -679,6 +679,15 @@ func client_channel_data_update(data: Dictionary) -> void:
 	if remote_player:
 		mining_tool.apply_remote(data)
 
+## Find a spawned mining rock by its uuid (server-side).
+func _find_mining_rock(rock_uuid: String) -> Node:
+	if rock_uuid == "":
+		return null
+	for r in get_tree().get_nodes_in_group("miningrock"):
+		if "uuid" in r and str(r.uuid) == rock_uuid:
+			return r
+	return null
+
 # receive properties from the client, often the actions
 func server_action_received(data: Dictionary) -> void:
 	match data["action"]:
@@ -697,6 +706,12 @@ func server_action_received(data: Dictionary) -> void:
 		"set_perforating":
 			# Replicate the perforation state so others see the jackhammer animation.
 			server_send_properties_to_client({"perforating": data.get("perforating", false)})
+		"perforate_rock":
+			# Authoritative fracture: cut the targeted rock along the aimed fault.
+			var rock := _find_mining_rock(str(data.get("uuid", "")))
+			if rock and rock.has_method("server_perforate"):
+				var h: Dictionary = data.get("hit", {})
+				rock.server_perforate(Vector3(h.get("x", 0.0), h.get("y", 0.0), h.get("z", 0.0)))
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -132,7 +132,6 @@ func _ready() -> void:
 
 	if remote_player:
 		camera.current = false
-		$ExtCamera3D.current = false
 		set_player_name(name)
 		return
 
@@ -150,7 +149,6 @@ func _ready() -> void:
 
 		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 		camera.current = true
-		$ExtCamera3D.current = true
 
 		camera.make_current()
 		# hide player name label for me only
@@ -251,14 +249,6 @@ func _unhandled_input(event: InputEvent) -> void:
 		else:
 			display_debug.emit(true)
 			_display_debug = true
-
-	if Input.is_action_just_pressed("ext_cam"):
-		if $ExtCamera3D.current:
-			camera.make_current()
-			astronaut.visible = false
-		else:
-			astronaut.visible = true
-			$ExtCamera3D.make_current()
 
 func server_set_input(input_dir: Vector2, newrotation: Vector3) -> void:
 	input_from_server["input_direction"] = input_dir
@@ -711,7 +701,10 @@ func server_action_received(data: Dictionary) -> void:
 			var rock := _find_mining_rock(str(data.get("uuid", "")))
 			if rock and rock.has_method("server_perforate"):
 				var h: Dictionary = data.get("hit", {})
-				rock.server_perforate(Vector3(h.get("x", 0.0), h.get("y", 0.0), h.get("z", 0.0)))
+				var dd: Dictionary = data.get("dir", {})
+				rock.server_perforate(
+					Vector3(h.get("x", 0.0), h.get("y", 0.0), h.get("z", 0.0)),
+					Vector3(dd.get("x", 0.0), dd.get("y", 0.0), dd.get("z", 0.0)))
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -500,8 +500,10 @@ visible = false
 
 [node name="MiningTool" type="Node3D" parent="." unique_id=709506111]
 script = ExtResource("33_2sxo3")
-aim_roll_deg = 0.0
-perforation_hammer_freq = 5.0
+aim_sensitivity_factor = 0.25
+aim_speed_factor = 0.25
+aim_rock_distance = 1.5
+perforation_hammer_freq = 4.0
 bit_axis = Vector3(1, 0, 0)
 perforation_hammer_amplitude = 0.01
 perforation_shake_amplitude = 0.003

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -95,9 +95,6 @@ monitorable = false
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.702767, 0.0593262)
 shape = SubResource("BoxShape3D_kcm5r")
 
-[node name="ExtCamera3D" type="Camera3D" parent="." unique_id=382186473]
-transform = Transform3D(1, 0, 0, 0, 0.793608, 0.608429, 0, -0.608429, 0.793608, 0, 1.87897, 1.33817)
-
 [node name="LabelPlayerName" type="Label3D" parent="." unique_id=957060553]
 unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2, 0)
@@ -510,6 +507,7 @@ perforation_shake_amplitude = 0.003
 equipment_hand_offset = Vector3(0.4, 1, 0.1)
 equipment_item_offset = Vector3(0, -0.15, -0.2)
 equipment_item_scale = 1.0
+bit_tip_offset = Vector3(-0.55, 0.24, 0)
 
 [connection signal="display_debug" from="." to="UserInterface/Debug" method="_on_normal_player_display_debug"]
 [connection signal="display_debug" from="." to="UserInterface/Debug/universe_servers" method="_on_normal_player_display_debug"]

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -40,6 +40,15 @@ var has_parent: bool = false
 # a non-empty parent_id that Horizon doesn't know is queued forever (never spawned).
 var created_parent_id: String = ""
 
+# Predefined faults (fixed, not random) — shown as red veins; perforating a vein
+# cuts the rock along it. keep_side = which half we keep when cut (the other half
+# becomes a new rock). number = fault priority: when the aim point is on the crossing
+# of several faults, the LOWEST number is cut.
+var blocs = [
+	{ "fractured": false, "number": 1, "position": 0.5, "rotation_y": 0.0, "rotation_z": 8.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "number": 2, "position": 0.5, "rotation_y": 0.0, "rotation_z": 82.0, "keep_side": 1, "side2_uuid": "" },
+]
+
 # Cut geometry: the mesh is rebuilt as "base mesh minus EVERY fractured fault", so a
 # rock can be cut along several faults (a half can be split again -> down to 4 pieces).
 var _base_mesh: Mesh = null
@@ -49,15 +58,6 @@ var _mesh_instance: MeshInstance3D = null
 var _mesh_center: Vector3 = Vector3.ZERO
 # Velocity to apply once when this piece spawns, to push it off the half it split from.
 var _spawn_kick: Vector3 = Vector3.ZERO
-
-# Predefined faults (fixed, not random) — shown as red veins; perforating a vein
-# cuts the rock along it. keep_side = which half we keep when cut (the other half
-# becomes a new rock). number = fault priority: when the aim point is on the crossing
-# of several faults, the LOWEST number is cut.
-var blocs = [
-	{ "fractured": false, "number": 1, "position": 0.5, "rotation_y": 0.0, "rotation_z": 8.0, "keep_side": 1, "side2_uuid": "" },
-	{ "fractured": false, "number": 2, "position": 0.5, "rotation_y": 0.0, "rotation_z": 82.0, "keep_side": 1, "side2_uuid": "" },
-]
 
 @onready var rock_shape = $CollisionShape3D
 

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -21,15 +21,13 @@ var has_parent: bool = false
 
 var bloc_yet_fractured: bool = false
 
+# Predefined faults (fixed, not random) — shown as red veins; perforating a vein
+# cuts the rock along it. keep_side = which half we keep when cut (the other half
+# becomes a new rock).
 var blocs = [
-	{
-		"fractured": false,
-		"position": randf_range(0.0, 1.0),
-		"rotation_y": randf_range(-50.0, 50.0),
-		"rotation_z": randf_range(-50.0, 50.0),
-		"keep_side": 1, # when cut a rock, we have 2 parts, we must indicate which part we keep
-		"side2_uuid": ""
-	}
+	{ "fractured": false, "position": 0.35, "rotation_y": 18.0, "rotation_z": 12.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "position": 0.55, "rotation_y": -28.0, "rotation_z": 34.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "position": 0.70, "rotation_y": 42.0, "rotation_z": -22.0, "keep_side": 1, "side2_uuid": "" },
 ]
 
 @onready var rock_shape = $CollisionShape3D
@@ -99,8 +97,8 @@ func _cut_rock(bloc: Dictionary) -> void:
 
 	var meshinstance = MeshInstance3D.new()
 	meshinstance.mesh = mesh
-	# add the material (1 = the cut part)
-	var material = load("res://scenes/props/rock/rock_material.tres")
+	# Keep the textured + veins material on the cut piece (remaining faults only).
+	var material := _make_vein_material()
 	meshinstance.set_surface_override_material(0, material)
 	meshinstance.set_surface_override_material(1, material)
 	add_child(meshinstance)
@@ -134,8 +132,12 @@ func _cut_rock(bloc: Dictionary) -> void:
 	bloc_yet_fractured = true
 	combiner.queue_free()
 
-	if int(bloc.keep_side) == 1 and OS.has_feature("dedicated_server") and create_part2_rock == true:
-		_server_create_side2_rock(bloc)
+	# V0: skip spawning the broken-off half as a networked rock — it triggers
+	# "PARENT ID NOT FOUND" on Horizon and spams the server. The rock just loses
+	# the chunk along the fault. TODO: re-enable side2 (the mined chunk = loot)
+	# once prop parenting is sorted out.
+	#if int(bloc.keep_side) == 1 and OS.has_feature("dedicated_server") and create_part2_rock == true:
+	#	_server_create_side2_rock(bloc)
 
 	meshinstance.position = -meshcenter
 	rock_shape.position = -meshcenter
@@ -149,7 +151,34 @@ func _cut_rock(bloc: Dictionary) -> void:
 ######################################################################
 
 func _client_ready() -> void:
-	pass
+	_show_faults()
+
+## Show each not-yet-fractured fault as a red vein (a thin slice through the rock)
+## at its cut plane, so faults are visible before perforating.
+func _show_faults() -> void:
+	var mesh_node = combiner.get_child(0) if combiner.get_child_count() > 0 else null
+	if mesh_node is CSGMesh3D:
+		(mesh_node as CSGMesh3D).material = _make_vein_material()
+
+## Rock material that draws red veins where the surface is near a not-yet-fractured
+## fault plane (intersection only -> crack lines, nothing sticking out).
+func _make_vein_material() -> ShaderMaterial:
+	var mat := ShaderMaterial.new()
+	mat.shader = preload("res://scenes/props/rock/rock_vein.gdshader")
+	mat.set_shader_parameter("albedo_tex", preload("res://assets/textures/grounds/rock/Rock029_2K_Color.jpg"))
+	mat.set_shader_parameter("tex_scale", 1.0)
+	var normals: Array = []
+	var offsets: Array = []
+	for bloc in blocs:
+		if bloc.get("fractured", false):
+			continue
+		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
+		normals.append(r * Vector3(1.0, 0.0, 0.0))   # fault plane normal (rock-local)
+		offsets.append(0.5 - bloc.position)           # plane offset (rock-local)
+	mat.set_shader_parameter("plane_count", normals.size())
+	mat.set_shader_parameter("plane_normals", normals)
+	mat.set_shader_parameter("plane_offsets", offsets)
+	return mat
 
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
@@ -196,6 +225,26 @@ func _server_ready() -> void:
 		has_parent
 	)
 	_calculate_blocs()
+
+## Server: perforate the fault nearest to `hit_local` (a rock-local point) and cut
+## along it. One cut per rock for V0 (the CSG combiner is freed after a cut).
+func server_perforate(hit_local: Vector3) -> void:
+	if not OS.has_feature("dedicated_server") or bloc_yet_fractured:
+		return
+	var best_i := -1
+	var best_d := INF
+	for i in blocs.size():
+		var bloc = blocs[i]
+		if bloc.get("fractured", false):
+			continue
+		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
+		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
+		var d: float = absf(n.dot(hit_local) - (0.5 - bloc.position))
+		if d < best_d:
+			best_d = d
+			best_i = i
+	if best_i >= 0:
+		_cut_rock(blocs[best_i])
 
 func _physics_process(_delta: float) -> void:
 	if GameOrchestrator.is_server():
@@ -255,15 +304,10 @@ func _server_create_side2_rock(bloc: Dictionary) -> void:
 	}
 	ServerNetwork.send_message(message, "devmodecreate_object")
 
-### When the mining tool used by the user enter in the area zone, we break the rock
-func _on_area_3d_body_entered(body: Node3D) -> void:
-	if OS.has_feature("dedicated_server"):
-		# run cut the rock only for the player character enter in area zone
-		if body is CharacterBody3D:
-			for bloc in blocs:
-				if bloc.fractured == false:
-					_cut_rock(bloc)
-					return
+### Rock no longer breaks on body contact: the fracture is triggered by the mining
+### tool (perforation along the targeted fault), handled server-side via an action.
+func _on_area_3d_body_entered(_body: Node3D) -> void:
+	pass
 
 func _exit_tree() -> void:
 	if GameOrchestrator.is_server():

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -5,6 +5,10 @@ signal hs_server_prop_delete
 
 const UUID_UTIL = preload("res://addons/uuid/uuid.gd")
 
+# Speed (m/s) the two halves get pushed apart along the fault normal when cut, so they
+# don't stay stacked (especially on a horizontal cut).
+const SEPARATION_SPEED := 1.5
+
 @export var uuid: String = ""
 
 var type_name = "miningrock"
@@ -28,14 +32,18 @@ var created_parent_id: String = ""
 # rock can be cut along several faults (a half can be split again -> down to 4 pieces).
 var _base_mesh: Mesh = null
 var _mesh_instance: MeshInstance3D = null
+# Geometric center of the base mesh (its origin is not necessarily its middle), used
+# so a fault at position 0.5 sits in the true middle along its normal.
+var _mesh_center: Vector3 = Vector3.ZERO
+# Velocity to apply once when this piece spawns, to push it off the half it split from.
+var _spawn_kick: Vector3 = Vector3.ZERO
 
 # Predefined faults (fixed, not random) — shown as red veins; perforating a vein
 # cuts the rock along it. keep_side = which half we keep when cut (the other half
 # becomes a new rock).
 var blocs = [
-	{ "fractured": false, "position": 0.35, "rotation_y": 18.0, "rotation_z": 12.0, "keep_side": 1, "side2_uuid": "" },
-	{ "fractured": false, "position": 0.55, "rotation_y": -28.0, "rotation_z": 34.0, "keep_side": 1, "side2_uuid": "" },
-	{ "fractured": false, "position": 0.70, "rotation_y": 42.0, "rotation_z": -22.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "position": 0.5, "rotation_y": 0.0, "rotation_z": 8.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "position": 0.5, "rotation_y": 0.0, "rotation_z": 82.0, "keep_side": 1, "side2_uuid": "" },
 ]
 
 @onready var rock_shape = $CollisionShape3D
@@ -44,6 +52,8 @@ func _ready() -> void:
 	add_to_group("miningrock")  # for proximity detection (aim mode)
 	var item_rock_mesh = get_child(0) as CSGMesh3D
 	_base_mesh = item_rock_mesh.mesh   # keep a ref to rebuild cuts later
+	if _base_mesh != null:
+		_mesh_center = _base_mesh.get_aabb().get_center()   # true middle of the rock
 	combiner = CSGCombiner3D.new()
 	add_child(combiner)
 
@@ -76,6 +86,10 @@ func _make_cut_box(bloc: Dictionary) -> CSGBox3D:
 	box.rotation = Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))
 	box.translate_object_local(Vector3(10.5, 0, 0))        # box on the far right of the rock
 	box.translate_object_local(Vector3(-bloc.position, 0.0, 0.0))
+	# Shift the cut plane onto the mesh center (along the fault normal) so position 0.5
+	# is the true middle even when the mesh origin is off-center.
+	var n: Vector3 = Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))) * Vector3(1.0, 0.0, 0.0)
+	box.translate_object_local(Vector3(n.dot(_mesh_center), 0.0, 0.0))
 	if int(bloc.keep_side) == 2:
 		box.translate_object_local(Vector3(-20.0, 0, 0))   # cut the other half instead
 	box.operation = CSGShape3D.OPERATION_SUBTRACTION
@@ -119,6 +133,10 @@ func _rebuild() -> void:
 	# half of the original volume (Godot derives the rigid body's center of mass from
 	# the offset shape). This keeps both halves in place instead of teleporting them.
 	sleeping = false
+	# Server only: kick this piece off the half it split from (set once on spawn).
+	if GameOrchestrator.is_server() and _spawn_kick != Vector3.ZERO:
+		linear_velocity += _spawn_kick
+		_spawn_kick = Vector3.ZERO
 
 ## Server: replicate the full fault state to Horizon & clients after a cut.
 func _replicate_blocs() -> void:
@@ -179,8 +197,9 @@ func _make_vein_material() -> ShaderMaterial:
 		if bloc.get("fractured", false):
 			continue
 		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
-		normals.append(r * Vector3(1.0, 0.0, 0.0))   # fault plane normal (rock-local)
-		offsets.append(0.5 - bloc.position)           # plane offset (rock-local)
+		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
+		normals.append(n)                                            # fault plane normal (rock-local)
+		offsets.append((0.5 - bloc.position) + n.dot(_mesh_center))  # plane offset, centered on the mesh
 	mat.set_shader_parameter("plane_count", normals.size())
 	mat.set_shader_parameter("plane_normals", normals)
 	mat.set_shader_parameter("plane_offsets", offsets)
@@ -193,6 +212,8 @@ func client_parent_change(parent: Node) -> void:
 func client_channel_data_update(data: Dictionary) -> void:
 	if data.has("parent_id"):
 		created_parent_id = str(data["parent_id"])
+	if data.has("kick"):
+		_spawn_kick = Vector3(data["kick"]["x"], data["kick"]["y"], data["kick"]["z"])
 	if data.has("position"):
 		position = Vector3(
 			data["position"]["x"],
@@ -246,16 +267,23 @@ func server_perforate(hit_local: Vector3) -> void:
 			continue   # already cut along this fault
 		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
 		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
-		var d: float = absf(n.dot(hit_local) - (0.5 - bloc.position))
+		# Distance to the fault PLANE, centered on the mesh (must match _make_cut_box /
+		# _make_vein_material, otherwise we pick the wrong fault and the cut is a no-op).
+		var d: float = absf(n.dot(hit_local) - ((0.5 - bloc.position) + n.dot(_mesh_center)))
 		if d < best_d:
 			best_d = d
 			best_i = i
 	if best_i < 0:
 		return
-	# Cut our half along the fault, then spawn the complementary half (side2).
+	# Cut our half along the fault, then spawn the complementary half (side2). Push the
+	# two apart along the fault normal so they don't stay stacked.
 	blocs[best_i].fractured = true
+	var cut: Dictionary = blocs[best_i]
+	var n_local: Vector3 = Basis.from_euler(Vector3(0.0, deg_to_rad(cut.rotation_y), deg_to_rad(cut.rotation_z))) * Vector3(1.0, 0.0, 0.0)
+	var n_world: Vector3 = (global_transform.basis * n_local).normalized()
 	await _rebuild()
-	_server_create_side2_rock(best_i)
+	linear_velocity += -n_world * SEPARATION_SPEED   # our half is the -normal side
+	_server_create_side2_rock(best_i, n_world * SEPARATION_SPEED)
 	_replicate_blocs()
 
 func _physics_process(_delta: float) -> void:
@@ -276,11 +304,13 @@ func _physics_process(_delta: float) -> void:
 			server_last_position = my_position
 			server_last_rotation = my_rotation
 
-func _server_create_side2_rock(cut_index: int) -> void:
+func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 	# Create the complementary half as its own networked rock. It inherits ALL our
 	# faults (so it shows the remaining veins and can be split again), but the fault we
 	# just cut is flipped to keep_side 2 so its box removes the other half instead.
 	var bloc2_uuid = UUID_UTIL.v4()
+	# Nudge the spawn off our half + carry a kick so it separates instead of overlapping.
+	var spawn_pos: Vector3 = position + kick.normalized() * 0.2
 	var side2_blocs := []
 	for i in blocs.size():
 		var bloc = blocs[i]
@@ -303,9 +333,9 @@ func _server_create_side2_rock(cut_index: int) -> void:
 				"type": type_name,
 				"uuid": bloc2_uuid,
 				"position": {
-					"x": position[0],
-					"y": position[1],
-					"z": position[2]
+					"x": spawn_pos.x,
+					"y": spawn_pos.y,
+					"z": spawn_pos.z
 				},
 				"rotation": {
 					"x": rotation[0],
@@ -313,6 +343,7 @@ func _server_create_side2_rock(cut_index: int) -> void:
 					"z": rotation[2]
 				},
 				"blocs": side2_blocs,
+				"kick": {"x": kick.x, "y": kick.y, "z": kick.z},
 				"scenename": "scenes/props/rock/rock_mining_01.tscn",
 				# Same parent as ourselves (a known GORC id, or "" for root): Horizon
 				# can resolve it, so the side2 is spawned instead of queued forever.

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -24,7 +24,10 @@ var has_parent: bool = false
 # a non-empty parent_id that Horizon doesn't know is queued forever (never spawned).
 var created_parent_id: String = ""
 
-var bloc_yet_fractured: bool = false
+# Cut geometry: the mesh is rebuilt as "base mesh minus EVERY fractured fault", so a
+# rock can be cut along several faults (a half can be split again -> down to 4 pieces).
+var _base_mesh: Mesh = null
+var _mesh_instance: MeshInstance3D = null
 
 # Predefined faults (fixed, not random) — shown as red veins; perforating a vein
 # cuts the rock along it. keep_side = which half we keep when cut (the other half
@@ -40,6 +43,7 @@ var blocs = [
 func _ready() -> void:
 	add_to_group("miningrock")  # for proximity detection (aim mode)
 	var item_rock_mesh = get_child(0) as CSGMesh3D
+	_base_mesh = item_rock_mesh.mesh   # keep a ref to rebuild cuts later
 	combiner = CSGCombiner3D.new()
 	add_child(combiner)
 
@@ -54,63 +58,70 @@ func _ready() -> void:
 	else:
 		_client_ready()
 
-func _calculate_blocs() -> void:
-	# create CSGbox3D
+## Rebuild the cut geometry from the current fault state (server + client). No cut
+## yet -> keep the initial full-rock combiner and just (re)show the veins.
+func _refresh_cuts() -> void:
 	for bloc in blocs:
-		# generate the CSB box for subtraction
-		bloc.instance = CSGBox3D.new()
-		# define the size
-		bloc.instance.size = Vector3(20.0, 20.0, 20.0)
-		# set the rotation, we must do before move to have the same cut on both parts of the rock
-		bloc.instance.rotation = Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))
-		# apply the first translation to have the box on the extreme right of the rock
-		bloc.instance.translate_object_local(Vector3(10.5, 0, 0))
-		# translate to the random position
-		bloc.instance.translate_object_local(Vector3(-bloc.position, 0.0, 0.0))
-		if int(bloc.keep_side) == 2:
-			# on bloc 2, we must move to the box x size to cut the another part
-			bloc.instance.translate_object_local(Vector3(-20.0, 0, 0))
-		bloc.instance.operation = CSGShape3D.OPERATION_SUBTRACTION
-		if bloc.fractured == true and bloc_yet_fractured == false:
-			_cut_rock(bloc)
+		if bloc.get("fractured", false):
+			_rebuild()
+			return
+	if not OS.has_feature("dedicated_server"):
+		_show_faults()
 
+## Build the CSG box that subtracts one fault's half from the rock (rock-local).
+func _make_cut_box(bloc: Dictionary) -> CSGBox3D:
+	var box := CSGBox3D.new()
+	box.size = Vector3(20.0, 20.0, 20.0)
+	# rotate before translating so the cut plane matches on both halves
+	box.rotation = Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))
+	box.translate_object_local(Vector3(10.5, 0, 0))        # box on the far right of the rock
+	box.translate_object_local(Vector3(-bloc.position, 0.0, 0.0))
+	if int(bloc.keep_side) == 2:
+		box.translate_object_local(Vector3(-20.0, 0, 0))   # cut the other half instead
+	box.operation = CSGShape3D.OPERATION_SUBTRACTION
+	return box
 
-# function to cut the rock
-func _cut_rock(bloc: Dictionary) -> void:
-	var create_part2_rock = false
-	if int(bloc.keep_side) == 1 and bloc.fractured == false:
-		create_part2_rock = true
-	# we set the bloc to fractured, needed for the server sync
-	bloc.fractured = true
-	# add to the combiner for the substration operation
-	combiner.add_child(bloc.instance)
-
-	await get_tree().process_frame
-	# create the mesh and collision shape
-	var meshes = combiner.get_meshes()
-	var mesh: Mesh = meshes[1]
-
-	if mesh.get_surface_count() == 0:
+## Rebuild the rock mesh = base mesh minus EVERY fractured fault. Always rebuilt from
+## scratch, so it is idempotent (replaying the same fault set changes nothing) and
+## supports several cuts on the same rock: a half can be split again -> down to 4 pieces.
+func _rebuild() -> void:
+	if _base_mesh == null:
 		return
-
-	# update center of mass
-	var arraymesh = mesh.surface_get_arrays(0)[Mesh.ARRAY_VERTEX]
-	var total = Vector3.ZERO
-	for vertice in arraymesh:
-		total += vertice
-	var meshcenter = total / arraymesh.size()
-
-	var meshinstance = MeshInstance3D.new()
-	meshinstance.mesh = mesh
-	# Keep the textured + veins material on the cut piece (remaining faults only).
-	var material := _make_vein_material()
-	meshinstance.set_surface_override_material(0, material)
-	meshinstance.set_surface_override_material(1, material)
-	add_child(meshinstance)
-
+	# Bake "base - all fractured boxes" with a throwaway combiner (kept transient so we
+	# don't leave a live CSG node around for every rock).
+	var temp := CSGCombiner3D.new()
+	add_child(temp)
+	var base := CSGMesh3D.new()
+	base.mesh = _base_mesh
+	temp.add_child(base)
+	for bloc in blocs:
+		if bloc.get("fractured", false):
+			temp.add_child(_make_cut_box(bloc))
+	await get_tree().process_frame
+	var meshes = temp.get_meshes()
+	var mesh: Mesh = meshes[1] if meshes.size() > 1 else null
+	temp.queue_free()
+	if mesh == null or mesh.get_surface_count() == 0:
+		return
+	# The first cut replaces the initial full-rock combiner with the baked mesh.
+	if combiner != null and is_instance_valid(combiner):
+		combiner.queue_free()
+		combiner = null
+	if _mesh_instance == null or not is_instance_valid(_mesh_instance):
+		_mesh_instance = MeshInstance3D.new()
+		add_child(_mesh_instance)
+	_mesh_instance.mesh = mesh
+	var material := _make_vein_material()   # remaining (un-fractured) faults stay visible
+	_mesh_instance.set_surface_override_material(0, material)
+	_mesh_instance.set_surface_override_material(1, material)
 	rock_shape.shape = mesh.create_convex_shape(true)
+	# No manual recenter: each piece keeps the rock's transform and occupies its own
+	# half of the original volume (Godot derives the rigid body's center of mass from
+	# the offset shape). This keeps both halves in place instead of teleporting them.
+	sleeping = false
 
-	# send update for Horizon & clients
+## Server: replicate the full fault state to Horizon & clients after a cut.
+func _replicate_blocs() -> void:
 	var message1 = {
 		"namespace": "props",
 		"event": "position",
@@ -119,35 +130,25 @@ func _cut_rock(bloc: Dictionary) -> void:
 			{
 				"type": "miningrock",
 				"uuid": uuid,
-				"blocs": [
-					{
-						"fractured": true,
-						"position": bloc.position,
-						"rotation_y": bloc.rotation_y,
-						"rotation_z": bloc.rotation_z,
-						"keep_side": 1,
-						"side2_uuid": ""
-					}
-				],
+				"blocs": _blocs_payload(),
 			}
 		]
 	}
 	ServerNetwork.send_message(message1, "prop_update")
 
-	bloc_yet_fractured = true
-	combiner.queue_free()
-
-	# Spawn the broken-off half as its own networked rock (side2), parented under
-	# the same GORC parent as us so Horizon can resolve it (see created_parent_id).
-	if int(bloc.keep_side) == 1 and OS.has_feature("dedicated_server") and create_part2_rock == true:
-		_server_create_side2_rock(bloc)
-
-	meshinstance.position = -meshcenter
-	rock_shape.position = -meshcenter
-	position += meshcenter
-	# disable freeze
-	sleeping = false
-	# can_sleep = false
+## Serializable copy of the faults (no CSG node refs) for network messages.
+func _blocs_payload() -> Array:
+	var out := []
+	for bloc in blocs:
+		out.append({
+			"fractured": bloc.get("fractured", false),
+			"position": bloc.position,
+			"rotation_y": bloc.rotation_y,
+			"rotation_z": bloc.rotation_z,
+			"keep_side": bloc.get("keep_side", 1),
+			"side2_uuid": bloc.get("side2_uuid", ""),
+		})
+	return out
 
 #####################################################################
 # Client part
@@ -159,6 +160,8 @@ func _client_ready() -> void:
 ## Show each not-yet-fractured fault as a red vein (a thin slice through the rock)
 ## at its cut plane, so faults are visible before perforating.
 func _show_faults() -> void:
+	if combiner == null or not is_instance_valid(combiner):
+		return   # already cut: the veins live on the rebuilt mesh instead
 	var mesh_node = combiner.get_child(0) if combiner.get_child_count() > 0 else null
 	if mesh_node is CSGMesh3D:
 		(mesh_node as CSGMesh3D).material = _make_vein_material()
@@ -204,15 +207,14 @@ func client_channel_data_update(data: Dictionary) -> void:
 		)
 	if data.has("blocs"):
 		blocs = data["blocs"]
-		# _cut_rock() needs `combiner`, which is created in _ready(). When this
-		# rock is spawned from the network, client_channel_data_update() is called
-		# *before* the node enters the tree (see server/client.gd ~l.622), so
-		# _ready() hasn't run yet and `combiner` is still null -> crash.
+		# _rebuild() needs `_base_mesh`, set in _ready(). When this rock is spawned
+		# from the network, client_channel_data_update() is called *before* the node
+		# enters the tree (see server/client.gd ~l.622), so _ready() hasn't run yet.
 		# Wait until the node is ready before processing the blocs.
 		if not is_node_ready():
 			await ready
-			await get_tree().process_frame  # let _ready() finish reparenting the mesh into combiner
-		_calculate_blocs()
+			await get_tree().process_frame  # let _ready() finish setting up the mesh
+		_refresh_cuts()
 
 #####################################################################
 # Server part
@@ -224,32 +226,37 @@ func _server_ready() -> void:
 		"hs_server_prop_update",
 		uuid,
 		{
-			"blocs": blocs,
+			"blocs": _blocs_payload(),
 		},
 		"miningrock",
 		has_parent
 	)
-	_calculate_blocs()
+	_refresh_cuts()
 
 ## Server: perforate the fault nearest to `hit_local` (a rock-local point) and cut
-## along it. One cut per rock for V0 (the CSG combiner is freed after a cut).
+## along it. The remaining faults stay cuttable, so a rock can be split several times.
 func server_perforate(hit_local: Vector3) -> void:
-	if not OS.has_feature("dedicated_server") or bloc_yet_fractured:
+	if not OS.has_feature("dedicated_server"):
 		return
 	var best_i := -1
 	var best_d := INF
 	for i in blocs.size():
 		var bloc = blocs[i]
 		if bloc.get("fractured", false):
-			continue
+			continue   # already cut along this fault
 		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
 		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
 		var d: float = absf(n.dot(hit_local) - (0.5 - bloc.position))
 		if d < best_d:
 			best_d = d
 			best_i = i
-	if best_i >= 0:
-		_cut_rock(blocs[best_i])
+	if best_i < 0:
+		return
+	# Cut our half along the fault, then spawn the complementary half (side2).
+	blocs[best_i].fractured = true
+	await _rebuild()
+	_server_create_side2_rock(best_i)
+	_replicate_blocs()
 
 func _physics_process(_delta: float) -> void:
 	if GameOrchestrator.is_server():
@@ -269,9 +276,23 @@ func _physics_process(_delta: float) -> void:
 			server_last_position = my_position
 			server_last_rotation = my_rotation
 
-func _server_create_side2_rock(bloc: Dictionary) -> void:
-	# send the new prop to Horizon because create item must not be done directly on godot server
+func _server_create_side2_rock(cut_index: int) -> void:
+	# Create the complementary half as its own networked rock. It inherits ALL our
+	# faults (so it shows the remaining veins and can be split again), but the fault we
+	# just cut is flipped to keep_side 2 so its box removes the other half instead.
 	var bloc2_uuid = UUID_UTIL.v4()
+	var side2_blocs := []
+	for i in blocs.size():
+		var bloc = blocs[i]
+		var is_cut: bool = (i == cut_index)
+		side2_blocs.append({
+			"fractured": bloc.get("fractured", false),
+			"position": bloc.position,
+			"rotation_y": bloc.rotation_y,
+			"rotation_z": bloc.rotation_z,
+			"keep_side": 2 if is_cut else bloc.get("keep_side", 1),
+			"side2_uuid": bloc2_uuid if is_cut else bloc.get("side2_uuid", ""),
+		})
 
 	var message = {
 		"namespace": "props",
@@ -291,16 +312,7 @@ func _server_create_side2_rock(bloc: Dictionary) -> void:
 					"y": rotation[1],
 					"z": rotation[2]
 				},
-				"blocs": [
-					{
-						"fractured": true,
-						"position": bloc.position,
-						"rotation_y": bloc.rotation_y,
-						"rotation_z": bloc.rotation_z,
-						"keep_side": 2,
-						"side2_uuid": bloc2_uuid
-					}
-				],
+				"blocs": side2_blocs,
 				"scenename": "scenes/props/rock/rock_mining_01.tscn",
 				# Same parent as ourselves (a known GORC id, or "" for root): Horizon
 				# can resolve it, so the side2 is spawned instead of queued forever.

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -9,6 +9,18 @@ const UUID_UTIL = preload("res://addons/uuid/uuid.gd")
 # don't stay stacked (especially on a horizontal cut).
 const SEPARATION_SPEED := 1.5
 
+# Speed (m/s) both pieces get pushed along the perforation direction (away from the bit
+# / the player), so the rock recoils where the drill hits.
+const PERFORATION_PUSH_SPEED := 2.5
+
+# How close (rock-local units) two fault distances must be to count as "the same
+# crossing": within this margin of the nearest fault, the LOWEST-numbered one is cut.
+const INTERSECTION_MARGIN := 0.06
+
+# Max distance (rock-local) from the aim point to a fault plane for the hit to count
+# as "on a fault". Aiming farther than this = not on a vein -> no cut.
+const FAULT_HIT_THRESHOLD := 0.05
+
 @export var uuid: String = ""
 
 var type_name = "miningrock"
@@ -40,10 +52,11 @@ var _spawn_kick: Vector3 = Vector3.ZERO
 
 # Predefined faults (fixed, not random) — shown as red veins; perforating a vein
 # cuts the rock along it. keep_side = which half we keep when cut (the other half
-# becomes a new rock).
+# becomes a new rock). number = fault priority: when the aim point is on the crossing
+# of several faults, the LOWEST number is cut.
 var blocs = [
-	{ "fractured": false, "position": 0.5, "rotation_y": 0.0, "rotation_z": 8.0, "keep_side": 1, "side2_uuid": "" },
-	{ "fractured": false, "position": 0.5, "rotation_y": 0.0, "rotation_z": 82.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "number": 1, "position": 0.5, "rotation_y": 0.0, "rotation_z": 8.0, "keep_side": 1, "side2_uuid": "" },
+	{ "fractured": false, "number": 2, "position": 0.5, "rotation_y": 0.0, "rotation_z": 82.0, "keep_side": 1, "side2_uuid": "" },
 ]
 
 @onready var rock_shape = $CollisionShape3D
@@ -160,6 +173,7 @@ func _blocs_payload() -> Array:
 	for bloc in blocs:
 		out.append({
 			"fractured": bloc.get("fractured", false),
+			"number": bloc.get("number", 0),
 			"position": bloc.position,
 			"rotation_y": bloc.rotation_y,
 			"rotation_z": bloc.rotation_z,
@@ -254,11 +268,28 @@ func _server_ready() -> void:
 	)
 	_refresh_cuts()
 
+## True if a rock-local point lies on a not-yet-fractured fault (close to its plane).
+## Used by the client to decide whether perforating there should do anything.
+func is_on_fault(hit_local: Vector3) -> bool:
+	for bloc in blocs:
+		if bloc.get("fractured", false):
+			continue
+		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
+		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
+		var d: float = absf(n.dot(hit_local) - ((0.5 - bloc.position) + n.dot(_mesh_center)))
+		if d <= FAULT_HIT_THRESHOLD:
+			return true
+	return false
+
 ## Server: perforate the fault nearest to `hit_local` (a rock-local point) and cut
-## along it. The remaining faults stay cuttable, so a rock can be split several times.
-func server_perforate(hit_local: Vector3) -> void:
+## along it. `push_dir_local` = perforation direction (rock-local) used to recoil the
+## pieces away from the bit. The remaining faults stay cuttable (several cuts possible).
+func server_perforate(hit_local: Vector3, push_dir_local: Vector3 = Vector3.ZERO) -> void:
 	if not OS.has_feature("dedicated_server"):
 		return
+	# Distance from the aim point to each un-fractured fault plane (centered on the mesh,
+	# must match _make_cut_box / _make_vein_material else we'd pick the wrong fault).
+	var dists: Dictionary = {}
 	var best_i := -1
 	var best_d := INF
 	for i in blocs.size():
@@ -267,23 +298,38 @@ func server_perforate(hit_local: Vector3) -> void:
 			continue   # already cut along this fault
 		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
 		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
-		# Distance to the fault PLANE, centered on the mesh (must match _make_cut_box /
-		# _make_vein_material, otherwise we pick the wrong fault and the cut is a no-op).
 		var d: float = absf(n.dot(hit_local) - ((0.5 - bloc.position) + n.dot(_mesh_center)))
+		dists[i] = d
 		if d < best_d:
 			best_d = d
 			best_i = i
 	if best_i < 0:
 		return
+	if best_d > FAULT_HIT_THRESHOLD:
+		return   # the aim point isn't on any fault -> nothing happens
+	# Intersection priority: when the aim point sits on the crossing of several faults
+	# (their distances are nearly tied), cut the one with the LOWEST number.
+	var best_number: int = int(blocs[best_i].get("number", 9999))
+	for i in dists:
+		if dists[i] <= best_d + INTERSECTION_MARGIN:
+			var num: int = int(blocs[i].get("number", 9999))
+			if num < best_number:
+				best_number = num
+				best_i = i
 	# Cut our half along the fault, then spawn the complementary half (side2). Push the
 	# two apart along the fault normal so they don't stay stacked.
 	blocs[best_i].fractured = true
 	var cut: Dictionary = blocs[best_i]
 	var n_local: Vector3 = Basis.from_euler(Vector3(0.0, deg_to_rad(cut.rotation_y), deg_to_rad(cut.rotation_z))) * Vector3(1.0, 0.0, 0.0)
 	var n_world: Vector3 = (global_transform.basis * n_local).normalized()
+	# Recoil both pieces away from the bit (along the perforation direction).
+	var push_world: Vector3 = Vector3.ZERO
+	if push_dir_local.length() > 0.0001:
+		push_world = (global_transform.basis * push_dir_local).normalized() * PERFORATION_PUSH_SPEED
 	await _rebuild()
-	linear_velocity += -n_world * SEPARATION_SPEED   # our half is the -normal side
-	_server_create_side2_rock(best_i, n_world * SEPARATION_SPEED)
+	# Our half: pushed along the perforation dir + away from the cut plane (-normal).
+	linear_velocity += push_world - n_world * SEPARATION_SPEED
+	_server_create_side2_rock(best_i, push_world + n_world * SEPARATION_SPEED)
 	_replicate_blocs()
 
 func _physics_process(_delta: float) -> void:
@@ -317,6 +363,7 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 		var is_cut: bool = (i == cut_index)
 		side2_blocs.append({
 			"fractured": bloc.get("fractured", false),
+			"number": bloc.get("number", 0),
 			"position": bloc.position,
 			"rotation_y": bloc.rotation_y,
 			"rotation_z": bloc.rotation_z,

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -371,34 +371,30 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 			"side2_uuid": bloc2_uuid if is_cut else bloc.get("side2_uuid", ""),
 		})
 
-	var message = {
-		"namespace": "props",
-		"event": "create_object",
-		"amessagenb": 1,
-		"data": [
-			{
-				"type": type_name,
-				"uuid": bloc2_uuid,
-				"position": {
-					"x": spawn_pos.x,
-					"y": spawn_pos.y,
-					"z": spawn_pos.z
-				},
-				"rotation": {
-					"x": rotation[0],
-					"y": rotation[1],
-					"z": rotation[2]
-				},
-				"blocs": side2_blocs,
-				"kick": {"x": kick.x, "y": kick.y, "z": kick.z},
-				"scenename": "scenes/props/rock/rock_mining_01.tscn",
-				# Same parent as ourselves (a known GORC id, or "" for root): Horizon
-				# can resolve it, so the side2 is spawned instead of queued forever.
-				"parent_id": created_parent_id,
-			}
-		]
+	var data := {
+		"type": type_name,
+		"uuid": bloc2_uuid,
+		"position": {"x": spawn_pos.x, "y": spawn_pos.y, "z": spawn_pos.z},
+		"rotation": {"x": rotation[0], "y": rotation[1], "z": rotation[2]},
+		"blocs": side2_blocs,
+		"kick": {"x": kick.x, "y": kick.y, "z": kick.z},
+		"scenename": "scenes/props/rock/rock_mining_01.tscn",
+		# Same parent as ourselves (a known GORC id, or "" for root) so Horizon can
+		# resolve it instead of queuing the side2 forever.
+		"parent_id": created_parent_id,
 	}
-	ServerNetwork.send_message(message, "devmodecreate_object")
+	# 1) Register the side2 in Horizon (GORC) so the OTHER players receive it. Horizon
+	#    keeps spawn_in_gameserver=false: GORC is players-only, so it does NOT send the
+	#    object back to this game server — we create it ourselves just below.
+	ServerNetwork.send_message({
+		"namespace": "props", "event": "create_object", "amessagenb": 1, "data": [data],
+	}, "devmodecreate_object")
+	# 2) Create the side2 locally on THIS game server (Horizon won't, see above), so it
+	#    can be simulated and re-cut. Same path as a Horizon-spawned prop (instantiate +
+	#    miningrock group + props_list + hs_server_prop_update wiring).
+	NetworkOrchestrator.network_agent.create_generic_object({
+		"data": {"object_uuid": bloc2_uuid, "object_type": type_name, "object_data": data},
+	})
 
 ### Rock no longer breaks on body contact: the fracture is triggered by the mining
 ### tool (perforation along the targeted fault), handled server-side via an action.

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -19,6 +19,11 @@ var server_last_rotation = Vector3.ZERO
 
 var has_parent: bool = false
 
+# The parent we were created under (a valid GORC id, or "" for a root object).
+# Reused for the broken-off half (side2) so Horizon can resolve its parent too:
+# a non-empty parent_id that Horizon doesn't know is queued forever (never spawned).
+var created_parent_id: String = ""
+
 var bloc_yet_fractured: bool = false
 
 # Predefined faults (fixed, not random) — shown as red veins; perforating a vein
@@ -132,12 +137,10 @@ func _cut_rock(bloc: Dictionary) -> void:
 	bloc_yet_fractured = true
 	combiner.queue_free()
 
-	# V0: skip spawning the broken-off half as a networked rock — it triggers
-	# "PARENT ID NOT FOUND" on Horizon and spams the server. The rock just loses
-	# the chunk along the fault. TODO: re-enable side2 (the mined chunk = loot)
-	# once prop parenting is sorted out.
-	#if int(bloc.keep_side) == 1 and OS.has_feature("dedicated_server") and create_part2_rock == true:
-	#	_server_create_side2_rock(bloc)
+	# Spawn the broken-off half as its own networked rock (side2), parented under
+	# the same GORC parent as us so Horizon can resolve it (see created_parent_id).
+	if int(bloc.keep_side) == 1 and OS.has_feature("dedicated_server") and create_part2_rock == true:
+		_server_create_side2_rock(bloc)
 
 	meshinstance.position = -meshcenter
 	rock_shape.position = -meshcenter
@@ -185,6 +188,8 @@ func client_parent_change(parent: Node) -> void:
 	has_parent = true
 
 func client_channel_data_update(data: Dictionary) -> void:
+	if data.has("parent_id"):
+		created_parent_id = str(data["parent_id"])
 	if data.has("position"):
 		position = Vector3(
 			data["position"]["x"],
@@ -266,7 +271,6 @@ func _physics_process(_delta: float) -> void:
 
 func _server_create_side2_rock(bloc: Dictionary) -> void:
 	# send the new prop to Horizon because create item must not be done directly on godot server
-	var parent = get_parent()
 	var bloc2_uuid = UUID_UTIL.v4()
 
 	var message = {
@@ -298,7 +302,9 @@ func _server_create_side2_rock(bloc: Dictionary) -> void:
 					}
 				],
 				"scenename": "scenes/props/rock/rock_mining_01.tscn",
-				"parent_id": parent.uuid,
+				# Same parent as ourselves (a known GORC id, or "" for root): Horizon
+				# can resolve it, so the side2 is spawned instead of queued forever.
+				"parent_id": created_parent_id,
 			}
 		]
 	}

--- a/scenes/props/rock/rock_vein.gdshader
+++ b/scenes/props/rock/rock_vein.gdshader
@@ -1,0 +1,43 @@
+shader_type spatial;
+render_mode cull_back;
+// Rock material: local-space triplanar albedo (matches the original rock material)
+// + red veins where the SURFACE is near a predefined fault plane, so faults read
+// as crack lines ON the mesh. Each fault plane is { normal, offset } in LOCAL space:
+//   distance(fragment) = dot(normal, local_pos) - offset
+
+uniform sampler2D albedo_tex : source_color;
+uniform float tex_scale = 1.0;
+uniform vec3 vein_color : source_color = vec3(1.0, 0.15, 0.12);
+uniform float vein_width = 0.02;
+uniform int plane_count = 0;
+uniform vec3 plane_normals[8];
+uniform float plane_offsets[8];
+
+varying vec3 v_local;
+varying vec3 v_normal;
+
+void vertex() {
+	v_local = VERTEX;
+	v_normal = NORMAL;
+}
+
+void fragment() {
+	// Local-space triplanar albedo (blend the 3 axis projections by the normal).
+	vec3 bw = abs(normalize(v_normal));
+	bw /= max(bw.x + bw.y + bw.z, 0.0001);
+	vec3 p = v_local * tex_scale;
+	vec3 col = texture(albedo_tex, p.zy).rgb * bw.x
+	         + texture(albedo_tex, p.xz).rgb * bw.y
+	         + texture(albedo_tex, p.xy).rgb * bw.z;
+
+	// Red veins at the fault planes.
+	float vein = 0.0;
+	for (int i = 0; i < plane_count; i++) {
+		float d = abs(dot(plane_normals[i], v_local) - plane_offsets[i]);
+		vein = max(vein, 1.0 - smoothstep(vein_width * 0.4, vein_width, d));
+	}
+
+	ALBEDO = mix(col, vein_color, vein);
+	EMISSION = vein_color * vein * 1.5;
+	ROUGHNESS = 0.9;
+}

--- a/scenes/props/rock/rock_vein.gdshader.uid
+++ b/scenes/props/rock/rock_vein.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cg3u23hupjbcf


### PR DESCRIPTION
## Description

## PR 1 — `DyingStar-game/DyingStar` : `feat/mining-v0-multiplayer` → `develop`

**Title:** `Mining V0: multiplayer perforator and rock fracture`

**Body:**
```markdown
## What
Mining V0: equip a perforator, aim at a rock's predefined faults and drill to break it
into pieces — visible and synchronized in multiplayer. Also removes the F4 third-person
camera, which conflicts with the aim-based mining.

## Gameplay
- Equip / unequip the perforator with key **1/&**.
- **Right-click** to aim a nearby mining rock: star crosshair + slowed mouse/movement.
- Rocks show their predefined faults as **red veins** (shader: textured rock + crack
  lines where the fault planes meet the surface).
- **Hold left-click** on a vein to drill (~5 s jackhammer): the tool orients toward the
  rock and the bit tip reaches the aimed point (only while drilling). The rock is cut
  along the aimed fault; the broken-off half becomes its own rock that keeps the
  remaining faults, so it can be split again — down to 4 pieces.
- Faults are **numbered**: drilling an intersection cuts the lowest-numbered fault.
- Drilling **off** any fault does nothing (short rejected jab, no cut).
- On fracture, the pieces **recoil** along the drilling direction + split along the fault.

## Multiplayer
Other players see the equipped tool, the camera aim and the drilling animation
(replicated player properties) and the rock cuts (replicated fault state).

## Architecture (SOLID)
- **MiningTool** scene component: equipment + aim detection + drilling + tip reach, with
  `@export` params. Networking stays in the player via `sync_requested` /
  `aiming_changed` signals and `apply_remote()` / `server_set_tool()`.
- **EquipmentMount**: generic hand mount that holds/aims an item.
- **CrosshairManager**: single owner of all reticle drawing.
- **rock_mining.gd**: faults rebuilt as "base mesh minus every fractured fault"
  (idempotent, multiple cuts); the broken-off half (side2) is spawned under a parent
  Horizon can resolve.

## Notes
- Removes the F4 / `ExtCamera3D` third-person camera (and its `ext_cam` input action):
  it let the player mine in third-person, which breaks the first-person aim/reach.
- Includes the earlier fix "Fix mining rock crash on networked fracture".
```

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Mining V0: equip a perforator, aim at a rock's predefined faults and drill to break it
into pieces, visible and synchronized in multiplayer. Also removes the F4 third-person
camera, which conflicts with the aim-based mining.
See details on https://github.com/DyingStar-game/DyingStar/pull/186
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Extraction minière V0 : équipez-vous d’un perforateur, visez les failles prédéfinies d’une roche et forez pour la briser
en morceaux, visible et synchronisé en multijoueur. Supprime également la caméra à la troisième personne (F4) qui entrait en conflit avec l’extraction minière basée sur la visée.
Voir les détails sur https://github.com/DyingStar-game/DyingStar/pull/186
<!-- /CHANGELOG_FR -->



