### PR TITLE
Carry a mined ore in hands (issue #124)

### DIFF
--- a/scenes/normal_player/equipment_mount.gd
+++ b/scenes/normal_player/equipment_mount.gd
@@ -24,6 +24,9 @@ var aim_roll_deg: float = 0.0
 ## Aim-point smoothing speed (higher = snappier; smooths the depth jump when the
 ## crosshair moves from empty space to a near surface).
 var aim_smooth: float = 18.0
+## When false, the mount ignores pitch_source and keeps its rest orientation (a stowed
+## item that must NOT follow the camera). Aim mode (aim_target) still overrides this.
+var follow_pitch: bool = true
 var _smoothed_aim: Vector3 = Vector3.ZERO
 var _aim_init: bool = false
 
@@ -67,6 +70,9 @@ func _process(delta: float) -> void:
 				rotate_object_local(Vector3(0, 0, 1), deg_to_rad(aim_roll_deg))
 		return
 	_aim_init = false
+	if not follow_pitch:
+		basis = _rest_basis   # stowed: fixed orientation, no camera influence (#124)
+		return
 	if pitch_source == null:
 		return
 	# Pitch the whole mount around the body's right axis so the held item aims

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -67,6 +67,15 @@ const REJECT_DURATION := 0.3
 ## Max forward extension (m), so the tool never flies off the hand.
 @export var reach_max: float = 1.2
 
+@export_group("Stow")
+## Where the perforator slides to when stowed (player carrying an ore), relative to its
+## rest position. It stays VISIBLE there (just lowered) and lerps back on unstow.
+@export var stow_offset: Vector3 = Vector3(0.0, -0.5, 0.3)
+## How fast the perforator stows/unstows (higher = snappier).
+@export var stow_smooth: float = 10.0
+## Fixed rotation (deg) of the perforator while stowed — no camera influence (#124).
+@export var stow_rotation_deg: Vector3 = Vector3(5.0, -90.0, 95.1)
+
 ## True while aiming (read by the player to slow the mouse/movement).
 var is_aiming: bool = false
 ## True during perforation (read by the player to freeze the mouse/movement).
@@ -82,7 +91,6 @@ var _perforator_rest_pos: Vector3 = Vector3.ZERO
 var _bit_rest: Vector3 = Vector3.ZERO
 var _rock_ray: RayCast3D = null
 var _crosshair_shown: bool = false
-var _last_head_sent: float = INF   # last camera pitch sent (throttle "head" sync)
 var _target_rock_uuid: String = ""     # rock aimed when the perforation started
 var _target_hit_local: Vector3 = Vector3.ZERO  # aim point, in that rock's local space
 var _target_aim_dir: Vector3 = Vector3.ZERO    # perforation direction, in that rock's local space
@@ -90,6 +98,8 @@ var _target_on_fault: bool = false     # whether that aim point is on a fault (c
 var _reject_t: float = -1.0            # >=0 while playing the off-fault "rejected" jab
 var _perforator_base: Vector3 = Vector3.ZERO  # rest pos or reach target (the animation jabs on top of this)
 var _tip_gizmo: MeshInstance3D = null  # debug sphere on the bit tip (calibration)
+var _equipped: bool = false  # logical "tool equipped" state (visibility also depends on stow)
+var _stowed: bool = false    # true while the perforator is stowed (player carrying an ore)
 
 ## Inject the player's camera rig and build the equipment mount + perforator.
 func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
@@ -111,10 +121,10 @@ func setup(camera_pivot: Node3D, camera: Camera3D) -> void:
 	_perforator.position = equipment_item_offset       # shift the model so its grip sits on the pivot
 	_perforator.rotation_degrees = equipment_item_rotation_deg
 	_perforator.scale = Vector3.ONE * equipment_item_scale
-	_perforator.visible = false
+	_perforator.visible = true   # always visible: stowed pose by default / at spawn (#124)
 	_equipment_mount.hold(_perforator)
 	_perforator_rest_pos = _perforator.position
-	_perforator_base = _perforator_rest_pos
+	_perforator_base = _perforator_rest_pos + stow_offset   # start in the stowed pose
 	_bit = _perforator.get_node_or_null(bit_node_name)
 	if _bit:
 		_bit_rest = _bit.position
@@ -142,23 +152,47 @@ func _process(delta: float) -> void:
 		# Orient the tool toward the rock while perforating (both clicks) OR during the
 		# off-fault "rejected" jab, so the failed attempt looks the same (orient + plunge
 		# + snap back). During plain aiming it stays on the camera pitch.
-		if orient_tool_at_rock and (is_perforating or _reject_t >= 0.0) and _perforator != null and _perforator.visible and _camera != null:
+		if not _perforator_active():
+			# Stowed (carrying or not equipped): fixed lowered pose, no camera influence.
+			_equipment_mount.aim_target = null
+			_equipment_mount.follow_pitch = false
+		elif orient_tool_at_rock and (is_perforating or _reject_t >= 0.0) and _camera != null:
 			_equipment_mount.aim_target = _aim_point()
 			_equipment_mount.aim_up = global_transform.basis.y
 			_equipment_mount.aim_roll_deg = aim_roll_deg
+			_equipment_mount.follow_pitch = true
 		else:
-			_equipment_mount.aim_target = null   # no look_at -> follow the camera pitch only
+			_equipment_mount.aim_target = null   # follow the camera pitch only
+			_equipment_mount.follow_pitch = true
 	# Calibration: keep the gizmo on bit_tip_offset (tunable live via the remote inspector).
 	if _tip_gizmo != null:
 		_tip_gizmo.position = bit_tip_offset
-	# Place the perforator so the bit tip touches the rock at the aim point (full 3D).
-	_update_reach(delta)
+	# Stow/unstow + reach drive where the perforator sits and its visibility. Runs on
+	# EVERY instance, so the stow lerp is seen by all players (issue #124).
+	_update_stow_and_reach(delta)
 	if _perforator != null:
 		_perforator.position = _perforator_base   # default; the visuals jab on top of it
 	# Perforation visual runs on EVERY instance, driven by is_perforating.
 	_update_perforation_visual(delta)
 	# Off-fault "rejected" jab (owner-local feedback): the bit lunges out then snaps back.
 	_update_reject_visual(delta)
+
+## Decide the perforator's rest target: stowed pose (carrying an ore) vs reach. The tool
+## STAYS visible at the stow pose (just lowered), it is not hidden — for everyone (#124).
+func _update_stow_and_reach(delta: float) -> void:
+	var active := _perforator_active()
+	if active:
+		_update_reach(delta)
+	else:
+		# Stowed (carrying OR not equipped): lerp to a fixed lowered pose.
+		var stow_target := _perforator_rest_pos + stow_offset
+		_perforator_base = _perforator_base.lerp(stow_target, clampf(stow_smooth * delta, 0.0, 1.0))
+	if _perforator != null:
+		# Visible to OTHER players when stowed (pose at spawn), but the local owner does
+		# NOT see his own stowed perforator (first-person clutter). Always visible when out.
+		_perforator.visible = active or not _is_owner()
+		# Orientation: item base rotation when out, fixed stow rotation when stowed.
+		_perforator.rotation_degrees = equipment_item_rotation_deg if active else stow_rotation_deg
 
 ## Lerp the perforator so the bit TIP lands exactly on the rock at the aim point — full
 ## 3D (including the tip's lateral offset, not just depth). Only while actively aiming
@@ -168,7 +202,7 @@ func _update_reach(delta: float) -> void:
 	# Reach ONLY while perforating (left-click), not during mere aiming — otherwise the
 	# tip slides on the surface as the crosshair moves. The player is frozen while
 	# perforating, so the tip stays put once engaged.
-	if reach_enabled and _equipment_mount != null and _perforator != null and _perforator.visible \
+	if reach_enabled and _equipment_mount != null and _perforator_active() \
 			and (is_perforating or _reject_t >= 0.0):
 		var hit: Vector3 = _aim_point()
 		# Solve the perforator position so the tip (basis * bit_tip_offset) == hit.
@@ -182,7 +216,7 @@ func _update_reach(delta: float) -> void:
 ## camera-pitch ("head") replication.
 func update_local(_delta: float) -> void:
 	# Aim mode: only if the tool is equipped AND near a rock.
-	var can_aim := _perforator != null and _perforator.visible and _is_near_mining_rock()
+	var can_aim := _perforator_active() and _is_near_mining_rock()
 	is_aiming = Input.is_action_pressed("aim") and can_aim
 	# The aim crosshair shows only while aiming AND looking at the rock.
 	var looking := is_aiming and _is_looking_at_rock()
@@ -205,37 +239,48 @@ func update_local(_delta: float) -> void:
 		else:
 			_reject_t = 0.0                   # off a fault -> brief rejected jab, no cut
 
-	# Replicate the camera pitch ("head") while a tool is equipped, so other
-	# players see where we aim. Throttled to meaningful changes.
-	if _perforator and _perforator.visible:
-		var head_q: float = snappedf(_camera_pivot.rotation.x, 0.02)
-		if head_q != _last_head_sent:
-			_last_head_sent = head_q
-			sync_requested.emit({"action": "set_head", "head": head_q})
+	# Camera pitch ("head") is now a generic player property sent by NormalPlayer
+	# (tech-debt A), not here — MiningTool only consumes it via apply_remote().
 
 ## Owner only: toggle the equipped tool and replicate the state.
 func toggle_equip() -> void:
 	if _perforator == null:
 		return
-	var equipped := not _perforator.visible
-	_perforator.visible = equipped  # immediate local toggle (first-person view)
+	_equipped = not _equipped  # visibility is derived in _process (also depends on stow)
 	# Send the equipped tool as a STATE (not a one-shot event) so other clients
 	# always converge to the right state via the replicated "tools" property.
-	sync_requested.emit({"action": "equip_tool", "tools": ("perforator" if equipped else "")})
+	sync_requested.emit({"action": "update_property", "tools": ("perforator" if _equipped else "")})
 
 ## Server (authoritative): apply the equipped-tool state. The player rebroadcasts it.
 func server_set_tool(tool_id: String) -> void:
-	if _perforator:
-		_perforator.visible = tool_id != ""
+	_equipped = tool_id != ""  # visibility is derived in _process (server doesn't render)
 
 ## Apply replicated state on remote players (tool visibility, camera aim, perforation).
 func apply_remote(data: Dictionary) -> void:
-	if data.has("tools") and _perforator:
-		_perforator.visible = str(data["tools"]) != ""
+	if data.has("tools"):
+		_equipped = str(data["tools"]) != ""
 	if data.has("head") and _camera_pivot:
 		_camera_pivot.rotation.x = float(data["head"])
 	if data.has("perforating"):
 		_apply_perforating(bool(data["perforating"]))
+	if data.has("carrying"):
+		set_stowed(bool(data["carrying"]))
+
+## Stow/unstow the perforator (player carrying an ore). The visual lerp runs in _process
+## on every instance, so it is visible to all players. Owner predicts it on the carry key;
+## remotes get it via the replicated "carrying" player property.
+func set_stowed(value: bool) -> void:
+	_stowed = value
+
+## The perforator can aim / reach only when equipped and not stowed.
+func _perforator_active() -> bool:
+	return _perforator != null and _equipped and not _stowed
+
+## True if this tool belongs to the LOCAL player (not a replicated remote player). Used
+## so the owner doesn't see his own stowed perforator while others still do.
+func _is_owner() -> bool:
+	var p = get_parent()
+	return not (p != null and "remote_player" in p and p.remote_player)
 
 # ── Internals ────────────────────────────────────────────────────────────────
 
@@ -317,7 +362,7 @@ func _set_perforating(active: bool) -> void:
 	if active == is_perforating:
 		return
 	_apply_perforating(active)
-	sync_requested.emit({"action": "set_perforating", "perforating": active})
+	sync_requested.emit({"action": "update_property", "perforating": active})
 
 ## Advance and apply the jackhammer visual (runs on every instance while perforating).
 func _update_perforation_visual(delta: float) -> void:

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -28,6 +28,11 @@ const PAUSE: String = "pause"
 @export var player_thruster_force = 10
 @export var sprint_speed: float = 5.0
 @export var crouch_speed: float = 1.5
+# Movement speed multiplier while carrying an ore (issue #124): slower with hands full.
+@export var carry_speed_factor: float = 0.5
+## Where a carried item floats, relative to the player body (issue #124): head height, a
+## bit below the eye line and ahead. Body-relative (yaw only, no camera pitch).
+@export var carry_offset: Vector3 = Vector3(0.0, -0.2, -1.2)
 @export var jump_height: float = 1.0
 @export var acceleration: float = 10.0
 @export var arm_length: float = 0.5
@@ -82,6 +87,12 @@ var active = false
 var hands_item: Node3D = null
 
 var _display_debug:bool = false
+
+# Last camera pitch ("head" player property) sent to the server, throttled.
+var _last_head_sent: float = INF
+# Owner-local prediction of "am I carrying?", to stow/unstow the perforator immediately
+# (the server broadcasts the stow to OTHER players; the owner doesn't echo to itself).
+var _owner_carrying: bool = false
 
 
 @onready var camera = $CameraPivot/Camera3D
@@ -238,6 +249,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("action"):
 		#  action key
 		client_send_action_to_server({"action": "action"})
+		_predict_carry_stow()
 
 	if event.is_action_pressed("spawn_rock_mining"):
 		spawn_box("rock/rock_mining_01", "miningrock", 5.5, 1.2)
@@ -315,6 +327,7 @@ func _process(_delta: float) -> void:
 func _physics_process(delta: float) -> void:
 	if remote_player: return
 	if OS.has_feature("dedicated_server"):
+		_server_update_carried_item()
 		if new_input_from_server:
 			input_direction = input_from_server["input_direction"]
 			global_rotation = input_from_server["rotation"]
@@ -351,6 +364,8 @@ func _physics_process(delta: float) -> void:
 			speed *= mining_tool.aim_speed_factor  # slowed down in aim mode
 		if mining_tool.is_perforating:
 			speed = 0.0  # frozen during perforation
+		if hands_item != null:
+			speed *= carry_speed_factor  # carrying an ore slows you down (issue #124)
 
 		if is_on_floor():
 			if input_direction:
@@ -460,6 +475,13 @@ func _handle_camera_motion():
 		camera_pivot.rotation.x = 0
 		rotate_object_local(Vector3.UP, mouse_motion.x  * camera_sensitivity)
 		rotate_object_local(Vector3.RIGHT, mouse_motion.y  * camera_sensitivity)
+
+	# Replicate the camera pitch ("head") to the server so others see where we look and
+	# the server can aim our interaction ray + place a carried item (tech-debt A / #124).
+	var head_q := snappedf(camera_pivot.rotation.x, 0.02)
+	if head_q != _last_head_sent:
+		_last_head_sent = head_q
+		client_send_action_to_server({"action": "update_property", "head": head_q})
 
 	mouse_motion = Vector2.ZERO
 
@@ -678,6 +700,36 @@ func _find_mining_rock(rock_uuid: String) -> Node:
 			return r
 	return null
 
+## Server: keep the carried item floating in front of the body (yaw only, no camera
+## pitch), held by the middle of its geometry so it sits centered. A cut piece keeps the
+## original rock pivot, so we offset by its geometry center (deterministic -> clients
+## match without extra sync). (#124)
+func _server_update_carried_item() -> void:
+	if hands_item == null:
+		return
+	# Body-relative spot (head height + front) WITHOUT the camera pitch: a carried object
+	# follows the body yaw but not the up/down look (issue #124).
+	var carry_point: Vector3 = camera_pivot.position + carry_offset
+	var center: Vector3 = Vector3.ZERO
+	if hands_item.has_method("get_center_offset"):
+		center = hands_item.get_center_offset()
+	hands_item.position = carry_point - hands_item.basis * center
+
+## Owner-local: predict whether the carry key picks up or drops, to stow/unstow the
+## perforator right away. The server stays authoritative (it may reject, e.g. a piece
+## already taken); a mismatch self-corrects on the next interaction.
+func _predict_carry_stow() -> void:
+	if _owner_carrying:
+		_owner_carrying = false
+		mining_tool.set_stowed(false)
+		return
+	interact_ray.force_raycast_update()
+	var collider = interact_ray.get_collider()
+	var target = collider.get_parent() if collider != null else null
+	if target != null and target.has_method("interact") and target.interact(self):
+		_owner_carrying = true
+		mining_tool.set_stowed(true)
+
 # receive properties from the client, often the actions
 func server_action_received(data: Dictionary) -> void:
 	match data["action"]:
@@ -685,17 +737,19 @@ func server_action_received(data: Dictionary) -> void:
 			is_jumping = true
 		"toggle_flashlight":
 			flashlight.visible = not flashlight.visible
-		"equip_tool":
-			# Authoritative tool state, then replicate it to nearby clients.
-			var tool_id: String = data.get("tools", "")
-			mining_tool.server_set_tool(tool_id)
-			server_send_properties_to_client({"tools": tool_id})
-		"set_head":
-			# Replicate the camera pitch so others see where this player aims.
-			server_send_properties_to_client({"head": data.get("head", 0.0)})
-		"set_perforating":
-			# Replicate the perforation state so others see the jackhammer animation.
-			server_send_properties_to_client({"perforating": data.get("perforating", false)})
+		"update_property":
+			# Generic player-property update (tech-debt A): apply the authoritative
+			# side-effects we know about, then replicate every property to nearby
+			# clients. Replaces the per-property equip_tool/set_head/set_perforating.
+			var props: Dictionary = data.duplicate()
+			props.erase("action")
+			if props.has("tools"):
+				mining_tool.server_set_tool(str(props["tools"]))
+			if props.has("head"):
+				# Apply on the server too so the interaction ray + carried item follow
+				# the gaze (planet only; in 0g the body orientation is used instead).
+				camera_pivot.rotation.x = float(props["head"])
+			server_send_properties_to_client(props)
 		"perforate_rock":
 			# Authoritative fracture: cut the targeted rock along the aimed fault.
 			var rock := _find_mining_rock(str(data.get("uuid", "")))
@@ -710,10 +764,15 @@ func server_action_received(data: Dictionary) -> void:
 			if hands_item != null:
 				# we have something in hands, so release it
 				print("player has an item in hands, dropping it")
+				# Generic: let the object know it is no longer carried (issue #124).
+				if hands_item.has_method("set_carried"):
+					hands_item.set_carried(false)
 				hands_item.server_parent_change(get_parent())
 				hands_item.freeze = false
 				hands_item.send_properties_to_client(get_parent().uuid)
 				hands_item = null
+				# Stop carrying on all clients (perforator comes back) (issue #124).
+				server_send_properties_to_client({"carrying": false})
 			else:
 				# generic action key pressed
 				print("action key pressed for collider")
@@ -731,6 +790,12 @@ func server_action_received(data: Dictionary) -> void:
 							#  send reparent to client
 							parent_node.send_properties_to_client(self.client_uuid)
 							hands_item = parent_node
+							# Generic: mark carriables (e.g. a fault-less ore) as taken so
+							# nobody else can grab them while in hands (issue #124).
+							if parent_node.has_method("set_carried"):
+								parent_node.set_carried(true)
+								# Mark as carrying on all clients (perforator stows) (issue #124).
+								server_send_properties_to_client({"carrying": true})
 
 			# TODO
 			# synchro head/camera

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -62,6 +62,7 @@ events = [SubResource("InputEventKey_2sxo3")]
 script = ExtResource("1_ll2l8")
 walk_speed = 5.0
 sprint_speed = 10.0
+carry_offset = Vector3(0, -0.6, -0.5)
 metadata/client_uuid = ""
 
 [node name="Placeholder_Collider" type="CollisionShape3D" parent="." unique_id=1694334487]
@@ -508,6 +509,7 @@ equipment_hand_offset = Vector3(0.4, 1, 0.1)
 equipment_item_offset = Vector3(0, -0.15, -0.2)
 equipment_item_scale = 1.0
 bit_tip_offset = Vector3(-0.55, 0.24, 0)
+stow_offset = Vector3(-0.16, 0.04, 0.3)
 
 [connection signal="display_debug" from="." to="UserInterface/Debug" method="_on_normal_player_display_debug"]
 [connection signal="display_debug" from="." to="UserInterface/Debug/universe_servers" method="_on_normal_player_display_debug"]

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -34,6 +34,11 @@ var server_last_position = Vector3.ZERO
 var server_last_rotation = Vector3.ZERO
 
 var has_parent: bool = false
+# True while we briefly leave the tree to reparent (carry/drop): tells _exit_tree NOT
+# to emit a delete (the object still exists, it just changed parent). Mirrors Box50cm.
+var server_reparenting: bool = false
+# True while carried by a player (issue #124), so nobody else can grab it meanwhile.
+var carried: bool = false
 
 # The parent we were created under (a valid GORC id, or "" for a root object).
 # Reused for the broken-off half (side2) so Horizon can resolve its parent too:
@@ -252,6 +257,66 @@ func client_channel_data_update(data: Dictionary) -> void:
 		_refresh_cuts()
 
 #####################################################################
+# Carry / drop (issue #124) — carriable contract, same as Box50cm
+#####################################################################
+
+## A piece is "ore" (carriable) only once it has no fault left: every fault fractured
+## means it can't be split anymore.
+func is_fully_fractured() -> bool:
+	for bloc in blocs:
+		if not bloc.get("fractured", false):
+			return false
+	return true
+
+## Carriable contract (same shape as Box50cm.interact): the player asks the object
+## whether it can be picked up — it stays generic, the rule lives here. Only a
+## fault-less, not-already-carried piece can be carried.
+func interact(_interactor: Node = null) -> bool:
+	return is_fully_fractured() and not carried
+
+## Mark/unmark as carried so another player can't grab it while it is in hands.
+## A carried ore must not generate collision (issue #124): a frozen body acts like a
+## static wall in front of the player, so disable its body shape while carried.
+func set_carried(value: bool) -> void:
+	carried = value
+	if rock_shape:
+		rock_shape.disabled = value
+
+## Geometry center relative to the body origin: a cut piece keeps the original rock's
+## pivot, so its mesh sits off to one side. The carrier uses this to hold the ore by its
+## middle. Deterministic from `blocs`, so server and clients agree without extra sync.
+func get_center_offset() -> Vector3:
+	if _mesh_instance != null and is_instance_valid(_mesh_instance):
+		return _mesh_instance.get_aabb().get_center()
+	return _mesh_center
+
+## Reparent on the server (carry into hands / drop back to the world). server_reparenting
+## tells _exit_tree NOT to emit a delete while we momentarily leave the tree.
+func server_parent_change(parent: Node) -> void:
+	server_reparenting = true
+	reparent(parent)
+
+## Tell clients to reparent this piece (into the carrier's hands, or back to the world)
+## and where it sits. Same channel/shape Box50cm uses for carrying.
+func send_properties_to_client(parent_uuid: String) -> void:
+	var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
+	var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
+	emit_signal(
+		"hs_server_prop_update",
+		uuid,
+		{
+			"position": my_position,
+			"rotation": my_rotation,
+			"parent_id": parent_uuid,
+			"weight": 200,
+		},
+		type_name,
+		has_parent
+	)
+	server_last_position = my_position
+	server_last_rotation = my_rotation
+
+#####################################################################
 # Server part
 #####################################################################
 
@@ -401,8 +466,14 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 func _on_area_3d_body_entered(_body: Node3D) -> void:
 	pass
 
-func _exit_tree() -> void:
+func _enter_tree() -> void:
+	# Reparenting (carry/drop) finished re-adding us: clear the guard. Mirrors Box50cm.
 	if GameOrchestrator.is_server():
+		server_reparenting = false
+
+func _exit_tree() -> void:
+	# Don't delete on clients when we're only being reparented (carried/dropped).
+	if GameOrchestrator.is_server() and not server_reparenting:
 		emit_signal(
 			"hs_server_prop_delete",
 			uuid,

--- a/server/client.gd
+++ b/server/client.gd
@@ -763,13 +763,13 @@ func player_update(message: Dictionary) -> void:
 				var player_p = players_list[uuid]
 				if is_instance_valid(player_p):
 					var d: Dictionary = message["data"]
-					var props := {}
-					if d.has("tools"):
-						props["tools"] = d["tools"]
-					if d.has("head"):
-						props["head"] = d["head"]
-					if d.has("perforating"):
-						props["perforating"] = d["perforating"]
+					# Forward every replicated player property generically (tech-debt A):
+					# tools, head, perforating, carrying, ... No per-property whitelist.
+					# Position/rotation/velocity come from the "move" path, so skip them.
+					var props: Dictionary = d.duplicate()
+					props.erase("position")
+					props.erase("rotation")
+					props.erase("velocity")
 					if not props.is_empty():
 						player_p.client_channel_data_update(props)
 			elif message["event_type"] == "move":


### PR DESCRIPTION
## Description

## Porter / lâcher un minerai (#124)

Implémente l'issue #124 : le joueur peut porter et lâcher un morceau de roche miné.

### Gameplay
- **E** pour **porter** / **lâcher** un minerai devant soi (un seul à la fois).
- Seul un **minerai non divisible** (plus aucune faille) peut être porté.
- Impossible de prendre un minerai **déjà porté** par un autre joueur.
- Porter **ralentit** le déplacement (`carry_speed_factor`).
- Le minerai porté **ne génère plus de collision** et **flotte devant** le joueur
  (suit l'orientation du corps, pas le pitch caméra), tenu **centré sur sa géométrie**.
- Le **perforateur** est désormais **toujours visible** : rangé dans une pose fixe
  par défaut et pendant le port (caché pour le porteur lui‑même, visible des autres),
  il ne « sort » et ne suit la caméra que lorsqu'il est équipé.
- Toutes ces actions sont **visibles par les autres joueurs**.

### Technique
- Les propriétés joueur (`tools`, `head`, `perforating`, `carrying`) passent désormais
  par **un seul canal générique `update_property`** au lieu d'une action par propriété
  (suppression de `equip_tool` / `set_head` / `set_perforating`). Le transfert côté
  client est lui aussi générique (plus de liste blanche par propriété).
- Le pitch caméra (`head`) appartient maintenant au joueur (et non au `MiningTool`).
- Le port réutilise le contrat générique existant (`interact` / `server_parent_change`
  / `send_properties_to_client`) : le joueur ne connaît pas le type d'objet porté
  (caisse, minerai, …). La roche implémente simplement ce contrat.

### ⚠️ Dépendance
Nécessite la PR serveur **horizonserver#`feat/player-carrying-prop`** (ajoute la
propriété `carrying` à `player_def.json` pour répliquer le rangement du perforateur).
**À merger ensemble.**

### Tests
- Solo + multijoueur : équiper le perforateur, miner un rocher entièrement, porter le
  minerai (E), le voir suivre / ralentir / sans collision, le lâcher (E).
- Multi : un 2ᵉ client voit le perforateur se ranger et le minerai porté.

Closes #124

## Changelog

<!-- CHANGELOG_EN -->
- Press **E** to **pick up / drop** a mined ore (one at a time).
- Only a **fully mined** ore (no fault left) can be carried; you can't take one already carried by someone else.
- Carrying **slows you down**, the ore **floats in front of you** (no collision), and **everything is visible to other players**.
- The **perforator** is always present: **stowed** by default / while carrying, **out** when equipped.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- **E** pour **porter** ou **lâcher** un minerai (un seul à la fois).
- Seul un minerai **entièrement miné** (sans faille) est portable ; impossible de prendre celui d'un autre joueur.
- Porter **ralentit**, le minerai **flotte devant** soi (sans collision) et **tout est visible des autres joueurs**.
- Le **perforateur** est toujours là : **rangé** par défaut/pendant le port, **sorti** quand on l'équipe.
<!-- /CHANGELOG_FR -->