### PR TITLE
Show the ore inside mining rocks via the rock shader

### DIFF
--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -21,6 +21,25 @@ const INTERSECTION_MARGIN := 0.06
 # as "on a fault". Aiming farther than this = not on a vein -> no cut.
 const FAULT_HIT_THRESHOLD := 0.05
 
+# Ore look (Cryptonite preset) + purity thresholds, validated in the ore bench. A piece's
+# richness drives ore_threshold: ORE_T_RICH = full of ore, ORE_T_POOR = almost none.
+const ORE_COLOR := Color(0.1, 0.8, 0.2)
+const ORE_SCALE := 6.0
+const ORE_SOFTNESS := 0.156
+const ORE_METALLIC := 1.0
+const ORE_ROUGHNESS := 0.059
+const ORE_EMISSION := 9.3
+const ORE_T_RICH := 0.40
+const ORE_T_POOR := 0.72
+# Exterior (uncut surface): a FEW TINY traces only, DECOUPLED from the real richness, so
+# the player must fracture once to see the actual ore inside (Kainan/DDURIEUX).
+const ORE_T_EXTERIOR := 0.7  # high threshold -> very few spots
+const ORE_SCALE_EXTERIOR := 14.0  # high scale -> tiny spots
+# Neutral fault grooves (validated in the bench): darken + carved bump.
+const GROOVE_WIDTH := 0.03
+const GROOVE_DARKNESS := 0.0
+const GROOVE_STRENGTH := 0.1
+
 @export var uuid: String = ""
 
 var type_name = "miningrock"
@@ -44,6 +63,10 @@ var carried: bool = false
 # Reused for the broken-off half (side2) so Horizon can resolve its parent too:
 # a non-empty parent_id that Horizon doesn't know is queued forever (never spawned).
 var created_parent_id: String = ""
+
+# Ore distribution seed (the original rock's id), inherited by broken-off pieces so their
+# exterior stays continuous after a cut. Empty on the original -> it uses its own uuid.
+var ore_seed: String = ""
 
 # Predefined faults (fixed, not random) — shown as red veins; perforating a vein
 # cuts the rock along it. keep_side = which half we keep when cut (the other half
@@ -135,6 +158,7 @@ func _rebuild() -> void:
 	temp.queue_free()
 	if mesh == null or mesh.get_surface_count() == 0:
 		return
+	mesh = _smooth_exterior(mesh)  # keep the exterior smooth (not faceted) after a cut
 	# The first cut replaces the initial full-rock combiner with the baked mesh.
 	if combiner != null and is_instance_valid(combiner):
 		combiner.queue_free()
@@ -143,9 +167,10 @@ func _rebuild() -> void:
 		_mesh_instance = MeshInstance3D.new()
 		add_child(_mesh_instance)
 	_mesh_instance.mesh = mesh
-	var material := _make_vein_material()   # remaining (un-fractured) faults stay visible
-	_mesh_instance.set_surface_override_material(0, material)
-	_mesh_instance.set_surface_override_material(1, material)
+	# Surface 0 = exterior (few tiny traces + fault grooves); surface 1 = cut faces (the
+	# real ore richness). Forces a first fracture to reveal the actual ore (Kainan).
+	_mesh_instance.set_surface_override_material(0, _make_exterior_material())
+	_mesh_instance.set_surface_override_material(1, _make_inner_material())
 	rock_shape.shape = mesh.create_convex_shape(true)
 	# No manual recenter: each piece keeps the rock's transform and occupies its own
 	# half of the original volume (Godot derives the rigid body's center of mass from
@@ -155,6 +180,21 @@ func _rebuild() -> void:
 	if GameOrchestrator.is_server() and _spawn_kick != Vector3.ZERO:
 		linear_velocity += _spawn_kick
 		_spawn_kick = Vector3.ZERO
+
+## A CSG boolean re-triangulates and flattens the exterior normals, so a cut rock looks
+## faceted vs the smooth uncut one. Recompute SMOOTH normals on the exterior (surface 0)
+## and keep the cut faces (surface 1) untouched (they stay flat).
+func _smooth_exterior(mesh: Mesh) -> Mesh:
+	if not (mesh is ArrayMesh) or mesh.get_surface_count() == 0:
+		return mesh
+	var st := SurfaceTool.new()
+	st.create_from(mesh, 0)
+	st.index()              # merge coincident verts so shared normals can be averaged
+	st.generate_normals()   # smooth normals -> the exterior is not faceted
+	var out: ArrayMesh = st.commit()
+	if mesh.get_surface_count() > 1:
+		out.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, mesh.surface_get_arrays(1))
+	return out
 
 ## Server: replicate the full fault state to Horizon & clients after a cut.
 func _replicate_blocs() -> void:
@@ -201,28 +241,68 @@ func _show_faults() -> void:
 		return   # already cut: the veins live on the rebuilt mesh instead
 	var mesh_node = combiner.get_child(0) if combiner.get_child_count() > 0 else null
 	if mesh_node is CSGMesh3D:
-		(mesh_node as CSGMesh3D).material = _make_vein_material()
+		(mesh_node as CSGMesh3D).material = _make_exterior_material()
 
 ## Rock material that draws red veins where the surface is near a not-yet-fractured
 ## fault plane (intersection only -> crack lines, nothing sticking out).
-func _make_vein_material() -> ShaderMaterial:
+## Per-piece ore richness (0..1) = ore quantity = value. Deterministic from the uuid, so
+## every client shows the same amount without replicating anything. A different uuid (the
+## original and each broken-off piece) -> different richness -> the player compares.
+func ore_richness() -> float:
+	if uuid == "":
+		return 0.5
+	return float(absi(uuid.hash()) % 1000) / 1000.0
+
+## Per-rock noise offset (deterministic from uuid) so each rock/piece shows a DIFFERENT
+## ore distribution, identical on every client.
+func _ore_offset() -> Vector3:
+	var s: String = ore_seed if ore_seed != "" else uuid   # pieces inherit the original seed
+	return Vector3(
+		float(absi((s + "x").hash()) % 100000) / 1000.0,
+		float(absi((s + "y").hash()) % 100000) / 1000.0,
+		float(absi((s + "z").hash()) % 100000) / 1000.0)
+
+## Build a rock material. ore_threshold/ore_scale set the ore amount/size; with_grooves
+## adds the neutral fault grooves (only the exterior surface shows them).
+func _make_rock_material(ore_threshold_v: float, ore_scale_v: float, with_grooves: bool) -> ShaderMaterial:
 	var mat := ShaderMaterial.new()
 	mat.shader = preload("res://scenes/props/rock/rock_vein.gdshader")
 	mat.set_shader_parameter("albedo_tex", preload("res://assets/textures/grounds/rock/Rock029_2K_Color.jpg"))
 	mat.set_shader_parameter("tex_scale", 1.0)
+	mat.set_shader_parameter("ore_color", ORE_COLOR)
+	mat.set_shader_parameter("ore_scale", ore_scale_v)
+	mat.set_shader_parameter("ore_threshold", ore_threshold_v)
+	mat.set_shader_parameter("ore_softness", ORE_SOFTNESS)
+	mat.set_shader_parameter("ore_metallic", ORE_METALLIC)
+	mat.set_shader_parameter("ore_roughness", ORE_ROUGHNESS)
+	mat.set_shader_parameter("ore_emission", ORE_EMISSION)
+	mat.set_shader_parameter("noise_offset", _ore_offset())  # per-rock ore distribution
+	mat.set_shader_parameter("groove_width", GROOVE_WIDTH)
+	mat.set_shader_parameter("groove_darkness", GROOVE_DARKNESS)
+	mat.set_shader_parameter("groove_strength", GROOVE_STRENGTH)
 	var normals: Array = []
 	var offsets: Array = []
-	for bloc in blocs:
-		if bloc.get("fractured", false):
-			continue
-		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
-		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
-		normals.append(n)                                            # fault plane normal (rock-local)
-		offsets.append((0.5 - bloc.position) + n.dot(_mesh_center))  # plane offset, centered on the mesh
+	if with_grooves:
+		for bloc in blocs:
+			if bloc.get("fractured", false):
+				continue
+			var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
+			var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
+			normals.append(n)                                            # fault plane normal (rock-local)
+			offsets.append((0.5 - bloc.position) + n.dot(_mesh_center))  # plane offset, centered
 	mat.set_shader_parameter("plane_count", normals.size())
 	mat.set_shader_parameter("plane_normals", normals)
 	mat.set_shader_parameter("plane_offsets", offsets)
 	return mat
+
+## Exterior (uncut surface): a few tiny ore traces, DECOUPLED from the real richness, plus
+## the fault grooves. The player must fracture to reveal the actual ore inside (Kainan).
+func _make_exterior_material() -> ShaderMaterial:
+	return _make_rock_material(ORE_T_EXTERIOR, ORE_SCALE_EXTERIOR, true)
+
+## Inner faces (revealed by a cut): the REAL ore amount = this piece's richness.
+func _make_inner_material() -> ShaderMaterial:
+	return _make_rock_material(lerpf(ORE_T_POOR, ORE_T_RICH, ore_richness()), ORE_SCALE, false)
 
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
@@ -231,6 +311,8 @@ func client_parent_change(parent: Node) -> void:
 func client_channel_data_update(data: Dictionary) -> void:
 	if data.has("parent_id"):
 		created_parent_id = str(data["parent_id"])
+	if data.has("ore_seed"):
+		ore_seed = str(data["ore_seed"])
 	if data.has("kick"):
 		_spawn_kick = Vector3(data["kick"]["x"], data["kick"]["y"], data["kick"]["z"])
 	if data.has("position"):
@@ -447,6 +529,8 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 		# Same parent as ourselves (a known GORC id, or "" for root) so Horizon can
 		# resolve it instead of queuing the side2 forever.
 		"parent_id": created_parent_id,
+		# Inherit our ore distribution seed so the piece's exterior stays continuous.
+		"ore_seed": ore_seed if ore_seed != "" else uuid,
 	}
 	# 1) Register the side2 in Horizon (GORC) so the OTHER players receive it. Horizon
 	#    keeps spawn_in_gameserver=false: GORC is players-only, so it does NOT send the

--- a/scenes/props/rock/rock_vein.gdshader
+++ b/scenes/props/rock/rock_vein.gdshader
@@ -1,17 +1,31 @@
 shader_type spatial;
 render_mode cull_back;
-// Rock material: local-space triplanar albedo (matches the original rock material)
-// + red veins where the SURFACE is near a predefined fault plane, so faults read
-// as crack lines ON the mesh. Each fault plane is { normal, offset } in LOCAL space:
+// Mining rock: local-space triplanar albedo + ORE pockets (3D object-space noise, shows
+// on the surface AND on cut faces) + NEUTRAL fault grooves that DARKEN the rock and CARVE
+// a groove (procedural normal bump). Faults are neutral on purpose: they do NOT reveal
+// which ore the rock holds. Each fault plane is { normal, offset } in LOCAL space:
 //   distance(fragment) = dot(normal, local_pos) - offset
 
 uniform sampler2D albedo_tex : source_color;
 uniform float tex_scale = 1.0;
-uniform vec3 vein_color : source_color = vec3(1.0, 0.15, 0.12);
-uniform float vein_width = 0.02;
+
+// ── Ore ──────────────────────────────────────────────────────────────────────
+uniform vec3 ore_color : source_color = vec3(0.1, 0.8, 0.2);
+uniform float ore_scale = 6.0;
+uniform float ore_threshold = 0.55;   // lower = more ore (richer piece)
+uniform float ore_softness = 0.156;
+uniform float ore_metallic = 1.0;
+uniform float ore_roughness = 0.059;
+uniform float ore_emission = 9.3;
+uniform vec3 noise_offset = vec3(0.0);   // per-rock offset so each rock's ore differs
+
+// ── Neutral fault grooves (carved cracks) ────────────────────────────────────
 uniform int plane_count = 0;
 uniform vec3 plane_normals[8];
 uniform float plane_offsets[8];
+uniform float groove_width = 0.03;
+uniform float groove_darkness = 0.0;   // albedo multiplier at the crack (0 = black)
+uniform float groove_strength = 0.1;   // bump depth (negative flips dug/raised)
 
 varying vec3 v_local;
 varying vec3 v_normal;
@@ -21,8 +35,37 @@ void vertex() {
 	v_normal = NORMAL;
 }
 
+float _hash(vec3 p) {
+	p = fract(p * 0.3183099 + 0.1);
+	p *= 17.0;
+	return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+}
+
+float _vnoise(vec3 x) {
+	vec3 i = floor(x);
+	vec3 f = fract(x);
+	f = f * f * (3.0 - 2.0 * f);
+	return mix(
+		mix(mix(_hash(i + vec3(0,0,0)), _hash(i + vec3(1,0,0)), f.x),
+			mix(_hash(i + vec3(0,1,0)), _hash(i + vec3(1,1,0)), f.x), f.y),
+		mix(mix(_hash(i + vec3(0,0,1)), _hash(i + vec3(1,0,1)), f.x),
+			mix(_hash(i + vec3(0,1,1)), _hash(i + vec3(1,1,1)), f.x), f.y),
+		f.z);
+}
+
+float _fbm(vec3 p) {
+	float v = 0.0;
+	float a = 0.5;
+	for (int i = 0; i < 4; i++) {
+		v += a * _vnoise(p);
+		p *= 2.0;
+		a *= 0.5;
+	}
+	return v;
+}
+
 void fragment() {
-	// Local-space triplanar albedo (blend the 3 axis projections by the normal).
+	// Local-space triplanar albedo.
 	vec3 bw = abs(normalize(v_normal));
 	bw /= max(bw.x + bw.y + bw.z, 0.0001);
 	vec3 p = v_local * tex_scale;
@@ -30,14 +73,35 @@ void fragment() {
 	         + texture(albedo_tex, p.xz).rgb * bw.y
 	         + texture(albedo_tex, p.xy).rgb * bw.z;
 
-	// Red veins at the fault planes.
-	float vein = 0.0;
-	for (int i = 0; i < plane_count; i++) {
-		float d = abs(dot(plane_normals[i], v_local) - plane_offsets[i]);
-		vein = max(vein, 1.0 - smoothstep(vein_width * 0.4, vein_width, d));
-	}
+	// Ore pockets (3D noise; appears on the surface AND on cut faces). noise_offset shifts
+	// the pattern per rock so they don't all look identical.
+	float n = _fbm((v_local + noise_offset) * ore_scale);
+	float ore = smoothstep(ore_threshold, ore_threshold + ore_softness, n);
+	col = mix(col, ore_color, ore);
 
-	ALBEDO = mix(col, vein_color, vein);
-	EMISSION = vein_color * vein * 1.5;
-	ROUGHNESS = 0.9;
+	// Neutral fault grooves: crack mask + cross-groove gradient.
+	float crack = 0.0;
+	vec3 grad = vec3(0.0);
+	for (int i = 0; i < plane_count; i++) {
+		float sd = dot(plane_normals[i], v_local) - plane_offsets[i];
+		float a = 1.0 - smoothstep(groove_width * 0.3, groove_width, abs(sd));
+		crack = max(crack, a);
+		grad += plane_normals[i] * (-sign(sd)) * a;
+	}
+	col *= mix(1.0, groove_darkness, crack);   // darken the rock along the faults
+
+	ALBEDO = col;
+	METALLIC = ore * ore_metallic;
+	ROUGHNESS = mix(0.9, ore_roughness, ore);
+	EMISSION = ore_color * ore * ore_emission;
+
+	// Carve the groove by tilting the normal toward the crack center (fake bump map).
+	if (crack > 0.001) {
+		vec3 nrm = normalize(v_normal);
+		vec3 tgrad = grad - dot(grad, nrm) * nrm;
+		if (length(tgrad) > 1e-5) {
+			vec3 tgrad_view = (VIEW_MATRIX * MODEL_MATRIX * vec4(normalize(tgrad), 0.0)).xyz;
+			NORMAL = normalize(NORMAL - tgrad_view * crack * groove_strength);
+		}
+	}
 }


### PR DESCRIPTION
The rock shader now renders ore pockets (3D object-space noise, visible on the surface and on cut faces) and NEUTRAL fault grooves (darken + a carved normal bump) instead of the red veins.

The exterior shows only a few tiny traces, decoupled from the real richness, so the player must fracture a rock to reveal how much ore is actually inside. Cut faces show the piece's richness. Ore amount and distribution are deterministic from the uuid (a seed the broken-off pieces inherit, so their exterior stays continuous after a cut).

## Description


Le rocher minier affiche désormais le **minerai qu'il contient**, directement via son shader.

- Pépites de minerai (noise 3D) visibles **en surface et sur les faces de coupe**, et **failles neutres** (assombrissement + sillon creusé par bump) à la place des veines rouges.
- L'**extérieur ne montre que quelques petites traces**, **décorrélées** de la vraie richesse → le joueur doit **fracturer** le rocher pour voir la quantité réelle à l'intérieur.
- Les **faces de coupe** révèlent la **richesse** du morceau (chaque morceau diffère).
- Quantité et répartition du minerai **déterministes à partir de l'uuid** (une *seed* héritée par les morceaux cassés → leur extérieur reste continu) : cohérent en multijoueur, **sans réplication supplémentaire**.
- Extérieur relissé après coupe (plus de facettes).

Lié à #116. Réglages calés via un banc d'essai local (non inclus).

## Changelog

<!-- CHANGELOG_EN -->
Mining rocks now show their ore: a few small traces on the surface, while the real amount is revealed by breaking the rock — richer pieces contain more ore.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Les rochers miniers montrent désormais leur minerai : quelques petites traces en surface, et la vraie quantité se révèle en cassant le rocher — les morceaux les plus riches contiennent plus de minerai.
<!-- /CHANGELOG_FR -->
