### PR TITLE
Admin prop cleanup tool + mining depot placeholder hardening (Feat/admin prop cleanup)

### DIFF
--- a/scenes/globals/network_orchestrator.gd
+++ b/scenes/globals/network_orchestrator.gd
@@ -68,6 +68,10 @@ var props_list = {
 	"ship": {}
 }
 
+# UUIDs of world/infrastructure props placed by designers (spawned from editor placeholders).
+# The admin cleanup tool refuses to delete these, so it only removes player-spawned clutter.
+var protected_prop_uuids: Dictionary = {}
+
 var client_change_server = null
 
 var player_scene_path: String = "res://scenes/normal_player/normal_player.tscn"

--- a/scenes/normal_player/admin_cleanup_tool.gd
+++ b/scenes/normal_player/admin_cleanup_tool.gd
@@ -1,0 +1,128 @@
+class_name AdminCleanupTool
+extends Node3D
+
+## Admin cleanup tool (toggle with key 2): casts a ray from the camera, draws a red aim
+## line, and on left click asks the server to permanently delete the targeted prop. It only
+## ever targets player-spawned props (mining rocks, boxes, mining depots) — never world or
+## static props (buildings, planets, players). Emergency prod-cleanup tool.
+##
+## Flow: target prop -> Player.client_send_action_to_server({"action":"delete_prop", ...})
+## -> server RPC removes the node -> existing delete path drops it from GORC and the DB.
+
+## Prop type_name values this tool is allowed to delete. Everything else is ignored.
+const DELETABLE: Array[String] = ["miningrock", "box", "mining_depot"]
+## Max aim distance (meters).
+const REACH: float = 1000.0
+## Right-hand anchor on the player body (matches the mining tool's equipment_hand_offset),
+## where the visible beam originates from.
+const HAND_OFFSET: Vector3 = Vector3(0.4, 1.0, -0.4)
+
+var _camera: Camera3D = null
+var _player: Node = null
+var _ray: RayCast3D = null
+var _line: MeshInstance3D = null
+var _line_mesh: ImmediateMesh = null
+var _line_mat: StandardMaterial3D = null
+var _active: bool = false
+var _target: Node = null
+
+## Wire the tool to the local player's camera and build the ray + beam. Called right after
+## instancing (NOT in _ready, which runs on add_child before the camera is injected).
+func setup(camera: Camera3D, player: Node) -> void:
+	_camera = camera
+	_player = player
+	# Aim ray fired forward from the camera centre (the crosshair direction).
+	_ray = RayCast3D.new()
+	_ray.target_position = Vector3(0.0, 0.0, -REACH)
+	_ray.collision_mask = 0xFFFFFFFF
+	_ray.enabled = true
+	_camera.add_child(_ray)
+	# Unshaded vertex-coloured line, drawn in world space (top_level) each frame.
+	_line_mat = StandardMaterial3D.new()
+	_line_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	_line_mat.vertex_color_use_as_albedo = true
+	_line_mesh = ImmediateMesh.new()
+	_line = MeshInstance3D.new()
+	_line.mesh = _line_mesh
+	_line.material_override = _line_mat
+	_line.top_level = true
+	_line.visible = false
+	add_child(_line)
+
+func _unhandled_input(event: InputEvent) -> void:
+	if _camera == null:
+		return
+	# Key 2 toggles the tool on/off (physical key, so it works on AZERTY too).
+	if event is InputEventKey and event.pressed and not event.echo and event.physical_keycode == KEY_2:
+		set_active(not _active)
+		return
+	# Left click deletes the current target while the tool is active.
+	if _active and event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		_delete_target()
+
+## Activate/deactivate the tool. Activating stows the player's other tool (exclusivity).
+func set_active(on: bool) -> void:
+	if _active == on:
+		return
+	_active = on
+	if _line != null:
+		_line.visible = on
+		if not on:
+			_line_mesh.clear_surfaces()
+	if not on:
+		_target = null
+	elif _player != null and _player.has_method("stow_mining_tool"):
+		_player.stow_mining_tool()  # put the previous tool away before showing this one
+	print("🧹 Admin cleanup tool: %s" % ("ON (click to delete rock/box/depot)" if on else "OFF"))
+
+func _physics_process(_delta: float) -> void:
+	if not _active or _camera == null:
+		return
+	_update_target()
+	_draw_line()
+
+## Resolve what the ray hits to a deletable prop node (walks up to the node carrying uuid).
+func _update_target() -> void:
+	_target = null
+	if _ray == null:
+		return
+	_ray.force_raycast_update()
+	if not _ray.is_colliding():
+		return
+	var node: Node = _ray.get_collider()
+	while node != null and not (("uuid" in node) and ("type_name" in node)):
+		node = node.get_parent()
+	if node != null and node.type_name in DELETABLE and str(node.uuid) != "":
+		_target = node
+
+func _aim_end() -> Vector3:
+	if _ray != null and _ray.is_colliding():
+		return _ray.get_collision_point()
+	return _camera.global_position - _camera.global_transform.basis.z * REACH
+
+## Red line normally; turns yellow when aiming at a deletable prop. The beam starts at the
+## player's right hand and ends where the player is looking (the camera ray hit point).
+func _draw_line() -> void:
+	_line_mesh.clear_surfaces()
+	var col: Color = Color(1.0, 0.85, 0.1) if _target != null else Color(1.0, 0.15, 0.1)
+	var start: Vector3 = (_player as Node3D).to_global(HAND_OFFSET) if _player is Node3D else _camera.global_position
+	_line_mesh.surface_begin(Mesh.PRIMITIVE_LINES, _line_mat)
+	_line_mesh.surface_set_color(col)
+	_line_mesh.surface_add_vertex(start)
+	_line_mesh.surface_set_color(col)
+	_line_mesh.surface_add_vertex(_aim_end())
+	_line_mesh.surface_end()
+
+func _delete_target() -> void:
+	if _target == null:
+		return
+	var prop_type: String = str(_target.type_name)
+	var prop_uuid: String = str(_target.uuid)
+	print("🗑️ Admin delete request: type=%s uuid=%s" % [prop_type, prop_uuid])
+	if _player != null and _player.has_method("client_send_action_to_server"):
+		_player.client_send_action_to_server({
+			"action": "delete_prop",
+			"type": prop_type,
+			"uuid": prop_uuid,
+		})
+	_target = null

--- a/scenes/normal_player/admin_cleanup_tool.gd.uid
+++ b/scenes/normal_player/admin_cleanup_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://b8yocwdfdjhwa

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -244,12 +244,19 @@ func update_local(_delta: float) -> void:
 
 ## Owner only: toggle the equipped tool and replicate the state.
 func toggle_equip() -> void:
-	if _perforator == null:
+	set_equipped(not _equipped)
+
+## Explicitly equip/unequip (used for tool exclusivity: selecting another tool stows this one).
+func set_equipped(on: bool) -> void:
+	if _perforator == null or _equipped == on:
 		return
-	_equipped = not _equipped  # visibility is derived in _process (also depends on stow)
+	_equipped = on  # visibility is derived in _process (also depends on stow)
 	# Send the equipped tool as a STATE (not a one-shot event) so other clients
 	# always converge to the right state via the replicated "tools" property.
 	sync_requested.emit({"action": "update_property", "tools": ("perforator" if _equipped else "")})
+
+func is_equipped() -> bool:
+	return _equipped
 
 ## Server (authoritative): apply the equipped-tool state. The player rebroadcasts it.
 func server_set_tool(tool_id: String) -> void:

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -86,6 +86,9 @@ var active = false
 
 var hands_item: Node3D = null
 
+# Admin cleanup tool (key 2). Built at runtime for the local player only (see _ready).
+var admin_cleanup_tool: AdminCleanupTool = null
+
 # The 3D screen (e.g. a mining depot) the player is currently in front of, or null. Set
 # by the screen's interaction Area; while set, the mouse is freed to click the screen.
 var screen_interacting = null
@@ -163,6 +166,12 @@ func _ready() -> void:
 		_spawn_wheel.title = "Spawn"
 		$UserInterface.add_child(_spawn_wheel)
 		_spawn_wheel.option_selected.connect(_on_spawn_selected)
+
+		# Admin cleanup tool (key 2): raycast + red aim line, left click deletes the
+		# targeted player-spawned prop (rock / box / depot) down to the database.
+		admin_cleanup_tool = AdminCleanupTool.new()
+		add_child(admin_cleanup_tool)
+		admin_cleanup_tool.setup(camera, self)
 
 		global_position = spawn_position
 		look_at(global_transform.origin + Vector3.FORWARD, spawn_up)
@@ -256,6 +265,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		# flashlight.visible = not flashlight.visible
 
 	if event.is_action_pressed("toggle_tool"):
+		if admin_cleanup_tool != null:
+			admin_cleanup_tool.set_active(false)  # stow the admin tool when equipping the perforator
 		mining_tool.toggle_equip()
 
 	if event.is_action_pressed("action"):
@@ -744,6 +755,12 @@ func server_send_properties_to_client(data: Dictionary):
 		data,
 	)
 
+## Put the mining tool away. Used for tool exclusivity: selecting the admin cleanup tool
+## (key 2) stows the perforator before showing itself.
+func stow_mining_tool() -> void:
+	if mining_tool != null:
+		mining_tool.set_equipped(false)
+
 # Send action of the client to the server part (Horizon / godot server)
 # data example:
 # {
@@ -795,6 +812,22 @@ func _find_mining_rock(rock_uuid: String) -> Node:
 	for r in get_tree().get_nodes_in_group("miningrock"):
 		if "uuid" in r and str(r.uuid) == rock_uuid:
 			return r
+	return null
+
+## Find a player-spawned prop by uuid for the admin cleanup tool (server-side). Looks in the
+## prop registry (any type) first, then the "carriable" group (rocks/boxes), so it works
+## regardless of how the prop was registered.
+func _find_deletable_prop(target_uuid: String) -> Node:
+	if target_uuid == "":
+		return null
+	for ptype in NetworkOrchestrator.props_list.keys():
+		if NetworkOrchestrator.props_list[ptype].has(target_uuid):
+			var n = NetworkOrchestrator.props_list[ptype][target_uuid]
+			if is_instance_valid(n):
+				return n
+	for n in get_tree().get_nodes_in_group("carriable"):
+		if "uuid" in n and str(n.uuid) == target_uuid:
+			return n
 	return null
 
 ## Find a carriable (group "carriable") by its uuid (server-side). Used to pick up
@@ -870,6 +903,27 @@ func server_action_received(data: Dictionary) -> void:
 				rock.server_perforate(
 					Vector3(h.get("x", 0.0), h.get("y", 0.0), h.get("z", 0.0)),
 					Vector3(dd.get("x", 0.0), dd.get("y", 0.0), dd.get("z", 0.0)))
+		"delete_prop":
+			# Admin cleanup tool: permanently remove a player-spawned prop.
+			var del_type: String = str(data.get("type", ""))
+			var del_uuid: String = str(data.get("uuid", ""))
+			if del_uuid == "" or not (del_type in ["miningrock", "box", "mining_depot"]):
+				print("🗑️ Admin delete refused: type=%s uuid=%s" % [del_type, del_uuid])
+			elif NetworkOrchestrator.protected_prop_uuids.has(del_uuid):
+				# World infrastructure placed by designers (e.g. a depot in the city): keep it.
+				print("🗑️ Admin delete refused: %s is protected world infrastructure" % del_uuid)
+			else:
+				var prop := _find_deletable_prop(del_uuid)
+				if prop != null and is_instance_valid(prop):
+					# Held by this server: free it; _exit_tree replicates the delete to
+					# Horizon (GORC) and the database, like a rock dropped into a depot.
+					print("🗑️ Admin delete: freeing local node %s %s" % [del_type, del_uuid])
+					prop.queue_free()
+				elif NetworkOrchestrator.network_agent.has_method("_on_prop_delete"):
+					# Not held locally (e.g. loaded from the database): tell Horizon directly
+					# so it leaves the GORC and the database anyway.
+					print("🗑️ Admin delete: forwarding to Horizon %s %s" % [del_type, del_uuid])
+					NetworkOrchestrator.network_agent._on_prop_delete(del_uuid, del_type)
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/props/city/sandbox_capital.tscn
+++ b/scenes/props/city/sandbox_capital.tscn
@@ -14,7 +14,6 @@
 [ext_resource type="AudioStream" uid="uid://ciwe4yq6ux1pi" path="res://assets/_universe/audio/ambience/sandstorm_001.ogg" id="12_yc6ci"]
 [ext_resource type="AudioStream" uid="uid://jfgcabkqn6rm" path="res://assets/_universe/audio/music/sandbox_peacefull_explo_1-DUDUK.ogg" id="13_yc6ci"]
 [ext_resource type="PackedScene" uid="uid://dduoljfgr6sjn" path="res://scenes/structures/mining_depot.tscn" id="14_4lkw2"]
-[ext_resource type="PackedScene" uid="uid://xud5xo51ir5r" path="res://scenes/spaceship/test_spaceship/test_spaceship.tscn" id="15_lr8y8"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_4sslq"]
 size = Vector3(5000, 50, 5000)
@@ -231,9 +230,6 @@ parameters/looping = true
 
 [node name="OutdoorLamppost2_2005" parent="." unique_id=1239394709 instance=ExtResource("10_uow4d")]
 transform = Transform3D(6.123436222361646e-17, 0, 1, 0, 1, 0, -1, 0, 6.123436222361646e-17, 7.822804687597224, 2.3986518313260676, 93.6169283414612)
-
-[node name="TestSpaceship" parent="." unique_id=2073676086 instance=ExtResource("15_lr8y8")]
-transform = Transform3D(0.9997293765358438, 0.02326314018470022, 0, -0.02326314018470022, 0.9997293765358438, 0, 0, 0, 1, -3.1358716406444245, 1.4188067656949395, 84.21842827799098)
 
 [node name="OutdoorLamppost2_2006" parent="." unique_id=550606329 instance=ExtResource("10_uow4d")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.862261152078986, 2.359688368788041, 82.97764537730104)

--- a/scenes/props/city/sandbox_capital.tscn
+++ b/scenes/props/city/sandbox_capital.tscn
@@ -13,6 +13,8 @@
 [ext_resource type="Script" uid="uid://5l13eh73avyv" path="res://scenes/props/city/area_3d.gd" id="11_04krg"]
 [ext_resource type="AudioStream" uid="uid://ciwe4yq6ux1pi" path="res://assets/_universe/audio/ambience/sandstorm_001.ogg" id="12_yc6ci"]
 [ext_resource type="AudioStream" uid="uid://jfgcabkqn6rm" path="res://assets/_universe/audio/music/sandbox_peacefull_explo_1-DUDUK.ogg" id="13_yc6ci"]
+[ext_resource type="PackedScene" uid="uid://dduoljfgr6sjn" path="res://scenes/structures/mining_depot.tscn" id="14_4lkw2"]
+[ext_resource type="PackedScene" uid="uid://xud5xo51ir5r" path="res://scenes/spaceship/test_spaceship/test_spaceship.tscn" id="15_lr8y8"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_4sslq"]
 size = Vector3(5000, 50, 5000)
@@ -90,6 +92,9 @@ debug_fill = false
 
 [node name="tree_01" parent="." unique_id=571341142 instance=ExtResource("3_4sslq")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.226101478604594, -0.5, 21.464000000007218)
+
+[node name="tree_02" parent="." unique_id=342366094 instance=ExtResource("3_4sslq")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.175644109279991, -0.9999999999999928, 80.83497045085555)
 
 [node name="tree001" parent="." unique_id=2044165351 instance=ExtResource("4_khu6c")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.485970901456582, -0.5, 7.739022793261851)
@@ -195,9 +200,13 @@ transform = Transform3D(-1, 0, 1.2246467991473532e-16, 0, 1, 0, -1.2246467991473
 transform = Transform3D(-1, 0, 1.2246467991473532e-16, 0, 1, 0, -1.2246467991473532e-16, 0, -1, 25.343606081717677, -2.7370208783850103e-06, 1121.459452987462)
 
 [node name="FogVolume" type="FogVolume" parent="." unique_id=1570834981]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -345.19291496276855, 66.76164340795899, -113.61418764843752)
-size = Vector3(1638.7212916605677, 135.5232830842242, 279.4780060026578)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -345.19291496276855, 66.76164340795899, 231.46307270281363)
+size = Vector3(1638.7212916605677, 135.5232830842242, 306.89811270363225)
 material = SubResource("ShaderMaterial_3b5ap")
+
+[node name="MiningDepot" parent="." unique_id=1889403175 instance=ExtResource("14_4lkw2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.439176267583754, 2.3517123357506797, 88.31635010584525)
+placeholder = true
 
 [node name="Area3D" type="Area3D" parent="." unique_id=1228311395 groups=["player"]]
 script = ExtResource("11_04krg")
@@ -219,3 +228,12 @@ volume_db = -20.0
 autoplay = true
 bus = &"Music"
 parameters/looping = true
+
+[node name="OutdoorLamppost2_2005" parent="." unique_id=1239394709 instance=ExtResource("10_uow4d")]
+transform = Transform3D(6.123436222361646e-17, 0, 1, 0, 1, 0, -1, 0, 6.123436222361646e-17, 7.822804687597224, 2.3986518313260676, 93.6169283414612)
+
+[node name="TestSpaceship" parent="." unique_id=2073676086 instance=ExtResource("15_lr8y8")]
+transform = Transform3D(0.9997293765358438, 0.02326314018470022, 0, -0.02326314018470022, 0.9997293765358438, 0, 0, 0, 1, -3.1358716406444245, 1.4188067656949395, 84.21842827799098)
+
+[node name="OutdoorLamppost2_2006" parent="." unique_id=550606329 instance=ExtResource("10_uow4d")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.862261152078986, 2.359688368788041, 82.97764537730104)

--- a/scenes/props/outdoor_lamppost_2.2_001.tscn
+++ b/scenes/props/outdoor_lamppost_2.2_001.tscn
@@ -10,25 +10,25 @@ size = Vector3(0.2979846285795702, 2.210542026400617, 0.25893124825574887)
 
 [node name="outdoor_lamppost_2_2m_001" parent="." unique_id=1650813234 instance=ExtResource("1_pk050")]
 
-[node name="outdoor_lamppost_LOD0" parent="outdoor_lamppost_2_2m_001" index="0" unique_id=2118352748]
+[node name="outdoor_lamppost_LOD0" parent="outdoor_lamppost_2_2m_001" index="0" unique_id=1024295265]
 surface_material_override/0 = ExtResource("2_3u0aj")
 surface_material_override/1 = ExtResource("2_3u0aj")
 
-[node name="outdoor_lamppost_LOD1" parent="outdoor_lamppost_2_2m_001" index="1" unique_id=324318342]
+[node name="outdoor_lamppost_LOD1" parent="outdoor_lamppost_2_2m_001" index="1" unique_id=1273871110]
 surface_material_override/0 = ExtResource("2_3u0aj")
 surface_material_override/1 = ExtResource("2_3u0aj")
 
-[node name="outdoor_lamppost_LOD2" parent="outdoor_lamppost_2_2m_001" index="2" unique_id=170163643]
+[node name="outdoor_lamppost_LOD2" parent="outdoor_lamppost_2_2m_001" index="2" unique_id=1566781162]
 surface_material_override/0 = ExtResource("2_3u0aj")
 surface_material_override/1 = ExtResource("2_3u0aj")
 
-[node name="outdoor_lamppost_LOD3" parent="outdoor_lamppost_2_2m_001" index="3" unique_id=2045539194]
+[node name="outdoor_lamppost_LOD3" parent="outdoor_lamppost_2_2m_001" index="3" unique_id=609741367]
 surface_material_override/0 = ExtResource("2_3u0aj")
 surface_material_override/1 = ExtResource("2_3u0aj")
 
 [node name="SpotLight3D" type="SpotLight3D" parent="." unique_id=210378545]
 transform = Transform3D(1, 0, 0, 0, 6.123233995736766e-17, 1, 0, -1, 6.123233995736766e-17, 0, 2.184606538898136, 0)
-light_energy = 60.0
+light_energy = 9.969
 light_indirect_energy = 10.0
 spot_range = 60.0
 spot_angle = 80.0

--- a/scenes/structures/mining_depot.gd
+++ b/scenes/structures/mining_depot.gd
@@ -6,6 +6,10 @@ const UUID_UTIL = preload("res://addons/uuid/uuid.gd")
 const CRATE_SCENE = preload("res://scenes/props/cargo/palette_container.tscn")
 
 @export var placeholder = false
+## Optional explicit network id for a designer-placed depot. Leave EMPTY and it is derived
+## automatically from the depot's fixed position (stable across restarts, no setup needed).
+## Set a unique string only if you want a readable id or to keep identity when moving it.
+@export var stable_id: String = ""
 
 var uuid: String = ""
 var has_parent: bool = false
@@ -50,44 +54,57 @@ func _ready() -> void:
 			await get_tree().create_timer(1).timeout
 			var parent = get_parent()
 
-			var message = {
-				"namespace": "props",
-				"event": "create_object",
-				"amessagenb": 1,
-				"data": [
-					{
-						"type": type_name,
-						"uuid": UUID_UTIL.new().as_string(),
-						"position": {
-							"x": position[0],
-							"y": position[1],
-							"z": position[2]
-						},
-						"rotation": {
-							"x": rotation[0],
-							"y": rotation[1],
-							"z": rotation[2]
-						},
-						"data": {
-							"state": "idle",
-							"rocks_on_conveyor": 0,
-							"rock_volume": 0.0,
-							"ore_volume": 0.0,
-							"extracted_volume": 0.0,
-							"active_player": null
-						},
-						"scenename": "scenes/structures/mining_depot.tscn",
-						"parent_id": parent.uuid,
-					}
-				]
-			}
-			ServerNetwork.send_message(message, "devmodecreate_object")
+			# Spawn the real networked depot to replace this editor placeholder. Use
+			# spawn_prop_authoritative so it is registered in Horizon AND created locally on
+			# this game server (the server copy is what holds the collision and the detectors
+			# / collect / SEND logic). Sending only to Horizon would leave the server without
+			# a depot node, since Horizon does not echo create_object back.
+			# Deterministic, VALID-format uuid so this depot is always the SAME object across
+			# restarts (the database upserts by uuid -> no duplicate pile-up, and no delete is
+			# needed). Seed from the explicit stable_id, else from the fixed placement position
+			# so no manual setup is required.
+			var uuid_seed: String = stable_id if stable_id != "" \
+				else "%.3f,%.3f,%.3f" % [position.x, position.y, position.z]
+			var depot_uuid: String = _stable_uuid(uuid_seed)
+			# Designer-placed depot = world infrastructure: protect it from the admin cleanup
+			# tool (only player-spawned depots should be deletable).
+			NetworkOrchestrator.protected_prop_uuids[depot_uuid] = true
+			NetworkOrchestrator.spawn_prop_authoritative({
+				"type": type_name,
+				"uuid": depot_uuid,
+				"position": {
+					"x": position.x,
+					"y": position.y,
+					"z": position.z
+				},
+				"rotation": {
+					"x": rotation.x,
+					"y": rotation.y,
+					"z": rotation.z
+				},
+				"data": {
+					"state": "idle",
+					"rocks_on_conveyor": 0,
+					"rock_volume": 0.0,
+					"ore_volume": 0.0,
+					"extracted_volume": 0.0,
+					"active_player": null
+				},
+				"scenename": "scenes/structures/mining_depot.tscn",
+				"parent_id": parent.uuid,
+			})
 
 		queue_free()
 
 	if GameOrchestrator.is_server():
 		box_detector.body_exited.connect(box_exited)
 		rock_detector.body_exited.connect(_on_rock_exited)
+
+## Build a deterministic, valid-format uuid from a seed string. Same seed -> same uuid
+## across restarts, so the depot is upserted (not duplicated) and Horizon can resolve it.
+func _stable_uuid(uuid_seed: String) -> String:
+	var h: String = uuid_seed.sha256_text()
+	return "%s-%s-%s-%s-%s" % [h.substr(0, 8), h.substr(8, 4), h.substr(12, 4), h.substr(16, 4), h.substr(20, 12)]
 
 ## In collect mode, a rock that slides off the conveyor end (leaves the detector) is
 ## collected. Skip rocks a player just picked up (carried) so grabbing one off the belt


### PR DESCRIPTION
## Description
Adds an admin cleanup tool (key 2) to permanently delete player-spawned
clutter (mining rocks, boxes, mining depots) down to the database, and
hardens the designer-placed mining depot so it spawns a real networked,
server-authoritative depot without piling up duplicates across restarts.

## Changelog

<!-- CHANGELOG_EN -->
- Add admin cleanup tool: ray from the player's hand, red/yellow aim line, click to delete the targeted prop (rock / box / depot only).
- Server-authoritative delete: frees the node (or forwards to Horizon) -> removed from GORC + database. World infrastructure is protected.
- Tools 1 (perforator) and 2 (cleanup) are now mutually exclusive.
- Mining depot placeholder spawns its networked copy on the game server (collision + collect/SEND logic), with a deterministic uuid (optional stable_id) to avoid duplicate accumulation; placed in Sandbox Capital.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- Ajout d'un outil de nettoyage pour les administrateurs : un rayon partant de la main du joueur, une ligne de visée rouge/jaune, cliquez pour supprimer l'élément ciblé (rocher/boîte/dépôt uniquement).
- Suppression autorisée par le serveur : libère le nœud (ou le transfère à Horizon) -> supprimé de GORC et de la base de données. L'infrastructure du monde est protégée.
- Les outils 1 (perforateur) et 2 (nettoyage) sont désormais incompatibles.
- L'emplacement réservé au dépôt minier génère sa copie réseau sur le serveur de jeu (logique de collision et de collecte/envoi), avec un UUID déterministe (optionnel :
stable_id) pour éviter l'accumulation de doublons ; placé dans Sandbox Capital.
<!-- /CHANGELOG_FR -->

## Known limitation (follow-up)
The delete action is reachable by any client (no admin gate yet). To
restrict before production: check the requesting player's uuid against an
admin allowlist server-side, or ship the tool only on an admin build.
