### PR TITLE
PR 2 - Unify prop replication into PropNet and a GenericProp base class

### DIFF
--- a/scenes/globals/generic_prop.gd
+++ b/scenes/globals/generic_prop.gd
@@ -33,17 +33,7 @@ func _ready() -> void:
 	add_to_group("carriable")
 
 func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-	# this part send the position or rotation if changed since last frame
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			server_prop_update({
-				"position": my_position,
-				"rotation": my_rotation,
-			})
-			server_last_position = my_position
-			server_last_rotation = my_rotation
+	PropNet.server_tick(self)
 
 func _exit_tree() -> void:
 	# Don't delete on clients when only reparenting (carried/dropped).

--- a/scenes/globals/prop_net.gd
+++ b/scenes/globals/prop_net.gd
@@ -1,0 +1,37 @@
+class_name PropNet
+extends RefCounted
+
+## Shared server-side replication helpers for networked props (DRY: GDScript has single
+## inheritance and props extend different bodies — RigidBody3D / StaticBody3D / VehicleBody3D —
+## so they can't share a base class; they call these static helpers instead).
+##
+## A prop using server_tick MUST expose: `uuid`, `type_name`, `has_parent`,
+## `server_last_position`, `server_last_rotation` and the `hs_server_prop_update` signal.
+
+## Call from a prop's _physics_process. Replicates position/rotation when they change. While
+## the prop is CARRIED (parented to a Player), re-sends position + parent_id every frame so
+## Horizon recomputes its global from the carrier's current position (otherwise the prop's
+## GORC zone goes stale and it despawns for everyone over distance).
+static func server_tick(prop: Node) -> void:
+	if not GameOrchestrator.is_server():
+		return
+	var pos: Vector3 = snapped(prop.position, Vector3(0.001, 0.001, 0.001))
+	var rot: Vector3 = snapped(prop.rotation, Vector3(0.0001, 0.0001, 0.0001))
+	var carrier: Node = prop.get_parent()
+	if carrier is Player:
+		prop.emit_signal(
+			"hs_server_prop_update",
+			prop.uuid,
+			{"position": pos, "rotation": rot, "parent_id": str(carrier.client_uuid)},
+			prop.type_name,
+			true)
+		return
+	if prop.server_last_position != pos or prop.server_last_rotation != rot:
+		prop.emit_signal(
+			"hs_server_prop_update",
+			prop.uuid,
+			{"position": pos, "rotation": rot},
+			prop.type_name,
+			prop.has_parent)
+		prop.server_last_position = pos
+		prop.server_last_rotation = rot

--- a/scenes/globals/prop_net.gd.uid
+++ b/scenes/globals/prop_net.gd.uid
@@ -1,0 +1,1 @@
+uid://dxhriql8ow5d2

--- a/scenes/props/StorageBoxes/generic_storagebox.gd
+++ b/scenes/props/StorageBoxes/generic_storagebox.gd
@@ -19,22 +19,7 @@ var has_parent: bool = false
 # 	position = spawn_position
 
 func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			emit_signal(
-				"hs_server_prop_update",
-				uuid,
-				{
-					"position": my_position,
-					"rotation": my_rotation,
-				},
-				type_name,
-				has_parent
-			)
-			server_last_position = my_position
-			server_last_rotation = my_rotation
+	PropNet.server_tick(self)
 
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -568,22 +568,7 @@ func server_perforate(hit_local: Vector3, push_dir_local: Vector3 = Vector3.ZERO
 	_replicate_blocs()
 
 func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			emit_signal(
-				"hs_server_prop_update",
-				uuid,
-				{
-					"position": my_position,
-					"rotation": my_rotation,
-				},
-				type_name,
-				has_parent
-			)
-			server_last_position = my_position
-			server_last_rotation = my_rotation
+	PropNet.server_tick(self)
 
 func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 	# Create the complementary half as its own networked rock. It inherits ALL our

--- a/scenes/props/testbox/box_4m.gd
+++ b/scenes/props/testbox/box_4m.gd
@@ -27,22 +27,7 @@ func _ready() -> void:
 	global_rotation = spawn_rotation
 
 func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			emit_signal(
-				"hs_server_prop_update",
-				uuid,
-				{
-					"position": my_position,
-					"rotation": my_rotation,
-				},
-				type_name,
-				has_parent
-			)
-			server_last_position = my_position
-			server_last_rotation = my_rotation
+	PropNet.server_tick(self)
 
 func _on_box_entered(body: Node3D):
 	if body.is_in_group("containable"):

--- a/scenes/props/testbox/box_50_cm.gd
+++ b/scenes/props/testbox/box_50_cm.gd
@@ -1,99 +1,10 @@
 class_name Box50cm
+extends GenericProp
 
-extends RigidBody3D
+## A carriable 50 cm box. Everything — networking (uuid, replication, PropNet tick), the
+## "carriable" group, carry/interact and collision-while-carried — is inherited from
+## GenericProp. A new carriable prop only needs `extends GenericProp` + its type name.
 
-signal hs_server_prop_update
-signal hs_server_prop_delete
-
-@export var uuid: String = ""
-
-var type_name = "box"
-
-var spawn_position: Vector3 = Vector3.ZERO
-var spawn_rotation: Vector3 = Vector3.UP
-
-var server_last_position = Vector3.ZERO
-var server_last_rotation = Vector3.ZERO
-
-var has_parent: bool = false
-var server_reparenting: bool = false
-
-@onready var is_inside_box4m: bool = false
-
-#func _ready() -> void:
-	#position = spawn_position
-
-func _physics_process(_delta: float) -> void:
-	if GameOrchestrator.is_server():
-		var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-		var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-		if server_last_position != my_position or server_last_rotation != my_rotation:
-			emit_signal(
-				"hs_server_prop_update",
-				uuid,
-				{
-					"position": my_position,
-					"rotation": my_rotation,
-				},
-				type_name,
-				has_parent
-			)
-			server_last_position = my_position
-			server_last_rotation = my_rotation
-
-func send_properties_to_client(parent_uuid: String) -> void:
-	var my_position = snapped(position, Vector3(0.001, 0.001, 0.001))
-	var my_rotation = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
-	emit_signal(
-		"hs_server_prop_update",
-		uuid,
-		{
-			"position": my_position,
-			"rotation": my_rotation,
-			"parent_id": parent_uuid,
-			"weight": 200,
-		},
-		type_name,
-		has_parent
-	)
-	print("REPARENT POSITION (1): %s" % my_position)
-	server_last_position = my_position
-	server_last_rotation = my_rotation
-
-func _exit_tree() -> void:
-	if GameOrchestrator.is_server() and server_reparenting == false:
-		emit_signal(
-			"hs_server_prop_delete",
-			uuid,
-			type_name
-		)
-
-func _enter_tree() -> void:
-	if GameOrchestrator.is_server():
-		print("REPARENT POSITION (2): %s" % position)
-		server_reparenting = false
-
-func client_parent_change(parent: Node) -> void:
-	reparent(parent)
-	has_parent = true
-
-func server_parent_change(parent: Node) -> void:
-	server_reparenting = true
-	reparent(parent)
-
-func client_channel_data_update(data: Dictionary) -> void:
-	if data.has("position"):
-		position = Vector3(
-			data["position"]["x"],
-			data["position"]["y"],
-			data["position"]["z"]
-		)
-	if data.has("rotation"):
-		rotation = Vector3(
-			data["rotation"]["x"],
-			data["rotation"]["y"],
-			data["rotation"]["z"]
-		)
-
-func interact(_interactor: Node = null):
-	return true
+func _ready() -> void:
+	type_name = "box"
+	super()

--- a/server/client.gd
+++ b/server/client.gd
@@ -470,6 +470,11 @@ func delete_object(event: Dictionary) -> void:
 			var type = event["object_type"]
 			if props_list[type].has(event["object_id"]):
 				var prop_instance = props_list[type][event["object_id"]]
+				# A carried object is parented to a player and follows it locally; its GORC zone
+				# position goes stale while carried, so ignore this despawn (otherwise it vanishes
+				# from the carrier's hands over distance). It is freed with its player anyway.
+				if is_instance_valid(prop_instance) and prop_instance.get_parent() is Player:
+					return
 				prop_instance.queue_free()
 				props_list[type].erase(event["object_id"])
 				return


### PR DESCRIPTION
## Description

Carriable props duplicated the whole networking contract. This extracts the server-side replication into a static `PropNet.server_tick` helper and adds a `GenericProp` base class (signals, uuid/type_name state, the carry contract,
per-frame replication). While carried, a prop now re-sends position + parent_id every frame so Horizon recomputes its global from the carrier and the prop no longer despawns over distance for other clients. `Box50cm` becomes `extends GenericProp`; the mining rock stays custom (fracture) but reuses `PropNet`. Net: +54 / −155 lines.

## Changelog

<!-- CHANGELOG_EN -->
Fix carried props (boxes, ore) despawning for other players over distance.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Correction du problème de disparition des objets transportés (caisses, minerai) pour les autres joueurs au fil de la distance.
<!-- /CHANGELOG_FR -->
