### PR TITLE
Disable area3D monitoring on boxes and rocks. With that and 200 items…

### DIFF
--- a/scenes/props/rock/rock_mining_01.tscn
+++ b/scenes/props/rock/rock_mining_01.tscn
@@ -19,6 +19,7 @@ mesh = ExtResource("1_yg06r")
 material = ExtResource("2_ty2b3")
 
 [node name="Area3D" type="Area3D" parent="." unique_id=990237276]
+monitoring = false
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D" unique_id=876014578]
 transform = Transform3D(2.43, 0, 0, 0, 2.43, 0, 0, 0, 2.43, 0.00938558976426251, 0.3480817962761856, -0.08526816556489342)
@@ -27,5 +28,4 @@ shape = SubResource("SphereShape3D_kvafs")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=1415174348]
 shape = SubResource("SphereShape3D_ducf2")
 
-[connection signal="area_entered" from="Area3D" to="." method="_on_area_3d_area_entered"]
-[connection signal="body_entered" from="Area3D" to="." method="_on_area_3d_body_entered"]
+

--- a/scenes/props/testbox/box_50cm.tscn
+++ b/scenes/props/testbox/box_50cm.tscn
@@ -20,6 +20,7 @@ surface_material_override/0 = ExtResource("3_ovsim")
 shape = SubResource("BoxShape3D_urcx6")
 
 [node name="Area3D" type="Area3D" parent="." unique_id=1841341630]
+monitoring = false
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D" unique_id=1862840437 groups=["carry"]]
 shape = SubResource("BoxShape3D_urcx6")


### PR DESCRIPTION
…, The "Find Collisions" go from 200ms to 5ms and reduce the CPU usage

## Description

<!-- Describe the changes in this PR -->

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Collision calculation reduction by 50 times (tested on 200 boxes and rocks)
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Réduction du calcul de collision de 50 fois (testé sur 200 boites et rochers)
<!-- /CHANGELOG_FR -->
