### PR TITLE
Feat/truck fixes

### DIFF
--- a/assets/materials/decals/ares_misc_decal_material.tres
+++ b/assets/materials/decals/ares_misc_decal_material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="StandardMaterial3D" load_steps=4 format=3 uid="uid://c71fgaq3itr5i"]
+[gd_resource type="StandardMaterial3D" format=3 uid="uid://c71fgaq3itr5i"]
 
 [ext_resource type="Texture2D" uid="uid://do5ypjlfrhjht" path="res://assets/textures/decals/ares_misc/ares_misc_decal_alpha.png" id="1_t6ofi"]
 [ext_resource type="Texture2D" uid="uid://cueehcqufmf2w" path="res://assets/textures/decals/ares_misc/ares_misc_decal_normal.png" id="3_2v5ff"]

--- a/assets/materials/painted_metal/paint_darkgrey_material.tres
+++ b/assets/materials/painted_metal/paint_darkgrey_material.tres
@@ -1,15 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://cvigq2mjqo7w"]
-
-[ext_resource type="Shader" uid="uid://bdb0hrfumlpwd" path="res://assets/materials/painted_metal/painted_metal.gdshader" id="1_27bcl"]
+[gd_resource type="ShaderMaterial" format=3 uid="uid://cvigq2mjqo7w"]
 
 [resource]
 resource_name = "metal"
-render_priority = 0
-shader = ExtResource("1_27bcl")
-shader_parameter/paint_color = Color(0.25260416, 0.249722, 0.24844372, 1)
-shader_parameter/paint_roughness = 0.20999999530608
-shader_parameter/paint_metallic = 0.0
-shader_parameter/metal_color = Color(0.7, 0.7, 0.7, 1)
-shader_parameter/metal_roughness = 0.249999994412
-shader_parameter/scratch_amount = 0.2
-shader_parameter/uv1_blend_sharpness = 1.0

--- a/assets/materials/painted_metal/paint_yellow_material.tres
+++ b/assets/materials/painted_metal/paint_yellow_material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=3 format=3 uid="uid://dnbpt5f5pj0im"]
+[gd_resource type="ShaderMaterial" format=3 uid="uid://dnbpt5f5pj0im"]
 
 [ext_resource type="Shader" uid="uid://bdb0hrfumlpwd" path="res://assets/materials/painted_metal/painted_metal.gdshader" id="1_tqt7k"]
 [ext_resource type="Texture2D" uid="uid://qr4nm0gwackl" path="res://assets/textures/grunge/scratch_tile.png" id="2_4skrk"]

--- a/levels/devmode/SimpleBoxTest/SimpleBoxTest.tscn
+++ b/levels/devmode/SimpleBoxTest/SimpleBoxTest.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://fxj147p5soqi"]
+[gd_scene format=3 uid="uid://fxj147p5soqi"]
 
 [ext_resource type="Script" uid="uid://bguwknfgm463x" path="res://levels/devmode/SimpleBoxTest/simple_box_test.gd" id="1_m4ygx"]
 [ext_resource type="Material" uid="uid://t823t2dw4owg" path="res://scenes/planet/planet_grey.material" id="2_m4ygx"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://cc8s2k0q8cxf" path="res://scenes/props/StorageBoxes/pallet_crate_120x80x100.tscn" id="5_w0ufy"]
 [ext_resource type="PackedScene" uid="uid://ddr43a2c4deep" path="res://scenes/props/StorageBoxes/container_liquid_1200x240x240.tscn" id="6_bdj2j"]
 [ext_resource type="PackedScene" uid="uid://d37hc6ybk8fsj" path="res://scenes/props/testbox/box_50cm.tscn" id="7_w0ufy"]
+[ext_resource type="PackedScene" uid="uid://dtijoobxv67w2" path="res://scenes/props/rock/rock_mining_01.tscn" id="8_bdj2j"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_xqwsu"]
 size = Vector2(100, 100)
@@ -28,58 +29,46 @@ ambient_light_source = 3
 [sub_resource type="BoxShape3D" id="BoxShape3D_m4ygx"]
 size = Vector3(100, 50, 100)
 
-[node name="SimpleBoxTest" type="Node3D"]
+[node name="SimpleBoxTest" type="Node3D" unique_id=54903359]
 script = ExtResource("1_m4ygx")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=1592737462]
 mesh = SubResource("PlaneMesh_xqwsu")
 surface_material_override/0 = ExtResource("2_m4ygx")
 
-[node name="StaticBody3D" type="StaticBody3D" parent="MeshInstance3D"]
+[node name="StaticBody3D" type="StaticBody3D" parent="MeshInstance3D" unique_id=1663636628]
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="MeshInstance3D/StaticBody3D"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="MeshInstance3D/StaticBody3D" unique_id=608377004]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
 shape = SubResource("BoxShape3D_1k8n2")
 
-[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=2003784867]
 transform = Transform3D(1, 0, 0, 0, 0.258819, 0.965926, 0, -0.965926, 0.258819, 0, 20, 0)
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+[node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=670560332]
 environment = SubResource("Environment_le64j")
 
-[node name="DataPlanet" type="Node" parent="."]
+[node name="DataPlanet" type="Node" parent="." unique_id=400465058]
 metadata/_custom_type_script = "uid://cj5kd1hkfvjrg"
 
-[node name="Area3D" type="Area3D" parent="." groups=["gravity"]]
+[node name="Area3D" type="Area3D" parent="." unique_id=708588488 groups=["gravity"]]
 gravity_space_override = 3
 script = ExtResource("4_jq82d")
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D" unique_id=1386348906]
 shape = SubResource("BoxShape3D_m4ygx")
 
-[node name="PalletLiquid120x80x100" parent="." instance=ExtResource("4_1uj1c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.622590192634482, 9.147364821160409e-08, 0.6245682824668704)
+[node name="PalletLiquid120x80x100" parent="." unique_id=1168125104 instance=ExtResource("4_1uj1c")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.703731769385667, 9.147364821160409e-08, -2.5019927579967858)
 
-[node name="PalletCrate120x80x100" parent="." instance=ExtResource("5_w0ufy")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.408846799152517, 9.147364821160409e-08, -0.9447545420112792)
+[node name="PalletCrate120x80x100" parent="." unique_id=834719290 instance=ExtResource("5_w0ufy")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.2302968384118245, 9.147364821160409e-08, -2.49872982105125)
 
-[node name="ContainerLiquid1200x240x240" parent="." instance=ExtResource("6_bdj2j")]
+[node name="ContainerLiquid1200x240x240" parent="." unique_id=732764926 instance=ExtResource("6_bdj2j")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.620415631549978, -1.628210419690913e-07, -5.098595560688037)
 
-[node name="box_50cm" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.2413228662517195, 1.4256433264896695, -0.940671208729605)
+[node name="box_50cm6" parent="." unique_id=1842183148 instance=ExtResource("7_w0ufy")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6.735164876670789, 0.2534957252035914, -2.7383454924542456)
 
-[node name="box_50cm6" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.2413228662517195, 1.9426793335489547, -0.940671208729605)
-
-[node name="box_50cm2" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(-0.9963824715083254, 0, -0.08498217737244182, 0, 1, 0, 0.08498217737244182, 0, -0.9963824715083254, -11.03902261777635, 0.4541092641372315, -0.89921582742164)
-
-[node name="box_50cm3" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(-0.9963824715083254, 0, -0.08498217737244182, 0, 1, 0, 0.08498217737244182, 0, -0.9963824715083254, -12.616585249601092, 0.6574659588307408, -0.89921582742164)
-
-[node name="box_50cm4" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(-0.9963824715083254, 0, -0.08498217737244182, 0, 1, 0, 0.08498217737244182, 0, -0.9963824715083254, -14.24209256725082, 0.6574659588307408, -0.89921582742164)
-
-[node name="box_50cm5" parent="." instance=ExtResource("7_w0ufy")]
-transform = Transform3D(-0.9963824715083254, 0, -0.08498217737244182, 0, 1, 0, 0.08498217737244182, 0, -0.9963824715083254, -14.24209256725082, 1.4583401875747837, -0.89921582742164)
+[node name="RockMining01" parent="." unique_id=525353877 instance=ExtResource("8_bdj2j")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.266701659982466, 0.019420739792025077, -2.469626312868717)

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -22,9 +22,16 @@ const PAUSE: String = "pause"
 
 const UUID_UTIL = preload("res://addons/uuid/uuid.gd")
 
+# Hand brake: a long press on the brake (Space) at low speed toggles the vehicle's hand brake.
+const HANDBRAKE_HOLD_SECS: float = 0.4
+const HANDBRAKE_MAX_KMH: float = 3.0
+
 @export_group("Controls map names")
 
 @export_group("Customizable player stats")
+## Body mass (kg) added to a vehicle's total weight when seated. Mass is gravity-independent
+## (75 kg everywhere); only the WEIGHT changes with gravity. CharacterBody3D has no built-in mass.
+@export var mass: float = 75.0
 @export var walk_back_speed: float = 1.5
 @export var walk_speed: float = 2.5
 @export var player_thruster_force = 10
@@ -126,6 +133,8 @@ var _nearby_seat: Node = null
 var _last_throttle: float = INF  # last drive input sent (to send only on change)
 var _last_steer: float = INF
 var _last_brake: bool = false
+var _space_held_time: float = 0.0  # driver: how long the brake (Space) has been held
+var _handbrake_sent: bool = false  # driver: hand brake toggle already fired for this hold
 var _seated_saved: bool = false
 var _saved_collision_layer: int = 1
 var _saved_collision_mask: int = 1
@@ -282,6 +291,12 @@ func _unhandled_input(event: InputEvent) -> void:
 		active = true  # walking again
 		set_seated(false)
 		camera_pivot.rotation = Vector3.ZERO  # restore walking look (yaw goes back on the body)
+		# Un-parent from the vehicle, back into the world (the server repositions us beside it).
+		if is_instance_valid(_seat_vehicle_node) and get_parent() == _seat_vehicle_node:
+			var world: Node = _seat_vehicle_node.get_parent()
+			if world != null:
+				reparent(world)
+				net_reset_interp()
 		if _seat_is_driver and is_instance_valid(_seat_vehicle_node) and _seat_vehicle_node.has_method("set_driver_hud"):
 			_seat_vehicle_node.set_driver_hud(false)
 		_seat_vehicle_uuid = ""
@@ -360,6 +375,7 @@ func _process(_delta: float) -> void:
 	# Seated in a vehicle: ride the seat HERE, in sync with the vehicle's own _process
 	# interpolation, so the camera stays glued to the (smoothly moving) cabin — no jitter/blur.
 	if is_instance_valid(_seat_node):
+		interact_label.hide()  # seated: clear any leftover "[E] Drive/Passenger Seat" prompt
 		_ride_seat(_seat_node)
 		return
 	# On foot: smooth our server-driven position (no client prediction yet) — position only, so
@@ -409,9 +425,12 @@ func _process(_delta: float) -> void:
 					collider.interact(self)
 					interact_label.hide()
 
-	# Standing in a seat box (on foot): tell the player what E will do.
+	# Standing in a seat box (on foot): tell the player what E will do, or that it's taken.
 	if is_instance_valid(_nearby_seat) and _seat_vehicle_uuid == "":
-		interact_label.text = "[E] Drive Seat" if _nearby_seat.is_driver_seat() else "[E] Passenger Seat"
+		if _seat_is_taken(_nearby_seat):
+			interact_label.text = "Driver seat taken"
+		else:
+			interact_label.text = "[E] Drive Seat" if _nearby_seat.is_driver_seat() else "[E] Passenger Seat"
 		interact_label.show()
 
 
@@ -460,6 +479,23 @@ func _send_drive_input() -> void:
 		"brake": braking,
 	})
 
+## Driver: a long press on Space at low speed toggles the vehicle's hand brake (once per hold).
+func _update_handbrake_input(delta: float) -> void:
+	if not Input.is_physical_key_pressed(KEY_SPACE):
+		_space_held_time = 0.0
+		_handbrake_sent = false
+		return
+	_space_held_time += delta
+	if _handbrake_sent or _space_held_time < HANDBRAKE_HOLD_SECS:
+		return
+	var speed_kmh: float = 999.0
+	if is_instance_valid(_seat_vehicle_node) and _seat_vehicle_node.has_method("get_display_speed_kmh"):
+		speed_kmh = _seat_vehicle_node.get_display_speed_kmh()
+	if speed_kmh > HANDBRAKE_MAX_KMH:
+		return
+	_handbrake_sent = true
+	client_send_action_to_server({"action": "vehicle_handbrake", "target_uuid": _seat_vehicle_uuid})
+
 ## Disable our collision while seated so we don't shove the vehicle's physics body.
 func set_seated(seated: bool) -> void:
 	if seated:
@@ -474,11 +510,21 @@ func set_seated(seated: bool) -> void:
 		collision_mask = _saved_collision_mask
 		_seated_saved = false
 
+## True when the seat is occupied (E won't work). Only the DRIVER seat's occupancy is
+## replicated (via the vehicle's pilot_uuid); a passenger seat reads as free for now.
+func _seat_is_taken(seat: Node) -> bool:
+	if seat == null or not seat.is_driver_seat():
+		return false
+	var veh: Node = seat.vehicle() if seat.has_method("vehicle") else null
+	return veh != null and "pilot_uuid" in veh and str(veh.pilot_uuid) != ""
+
 ## Take the seat we are standing in: tell the server, lock walking, start riding locally.
 func _enter_seat(seat: Node) -> void:
 	var veh: Node = seat.vehicle()
 	if veh == null or not ("uuid" in veh):
 		return
+	if _seat_is_taken(seat):
+		return  # driver seat already occupied (server-replicated) — don't enter optimistically
 	_seat_node = seat
 	_seat_vehicle_node = veh
 	_seat_vehicle_uuid = str(veh.uuid)
@@ -490,6 +536,11 @@ func _enter_seat(seat: Node) -> void:
 	})
 	active = false  # lock walking while seated
 	set_seated(true)
+	# Ride by transform inheritance: parent to the vehicle so we move WITH it (no jitter). The
+	# vehicle stays server-authoritative; this is the local camera ride.
+	if veh is Node3D and get_parent() != veh:
+		reparent(veh)
+		net_reset_interp()
 	if _seat_is_driver and veh.has_method("set_driver_hud"):
 		veh.set_driver_hud(true)
 
@@ -515,8 +566,16 @@ func net_reset_interp() -> void:
 
 func _ride_seat(seat: Node3D) -> void:
 	var eye: Transform3D = seat.sit_transform()
-	global_transform.basis = eye.basis
-	global_position = eye.origin - eye.basis * camera_pivot.position
+	var veh: Node = seat.vehicle() if seat.has_method("vehicle") else null
+	if veh != null and get_parent() == veh:
+		# Parented to the vehicle: ride in LOCAL space so we move WITH it by transform
+		# inheritance (no per-frame world fight against the parent's smoothing) — kills the jitter.
+		var local_eye: Transform3D = (veh as Node3D).global_transform.affine_inverse() * eye
+		transform.basis = local_eye.basis
+		transform.origin = local_eye.origin - local_eye.basis * camera_pivot.position
+	else:
+		global_transform.basis = eye.basis
+		global_position = eye.origin - eye.basis * camera_pivot.position
 	# Free look from the seat: the mouse turns the camera pivot (yaw + pitch) relative to the
 	# vehicle forward, so the view is no longer locked straight ahead.
 	camera_pivot.rotation.y += mouse_motion.x * camera_sensitivity
@@ -643,6 +702,7 @@ func _physics_process(delta: float) -> void:
 			# here we only relay drive input (driver) and skip walking.
 			if _seat_is_driver:
 				_send_drive_input()
+				_update_handbrake_input(delta)
 			return
 		if !active: return
 
@@ -1162,6 +1222,10 @@ func server_action_received(data: Dictionary) -> void:
 			var veh_r := _find_vehicle(str(data.get("target_uuid", "")))
 			if veh_r != null and veh_r._pilot == self and veh_r.has_method("reset_upright"):
 				veh_r.reset_upright()
+		"vehicle_handbrake":
+			var veh_h := _find_vehicle(str(data.get("target_uuid", "")))
+			if veh_h != null and veh_h._pilot == self and veh_h.has_method("toggle_handbrake"):
+				veh_h.toggle_handbrake()
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/props/city/sandbox_capital.tscn
+++ b/scenes/props/city/sandbox_capital.tscn
@@ -14,6 +14,10 @@
 [ext_resource type="AudioStream" uid="uid://ciwe4yq6ux1pi" path="res://assets/_universe/audio/ambience/sandstorm_001.ogg" id="12_yc6ci"]
 [ext_resource type="AudioStream" uid="uid://jfgcabkqn6rm" path="res://assets/_universe/audio/music/sandbox_peacefull_explo_1-DUDUK.ogg" id="13_yc6ci"]
 [ext_resource type="PackedScene" uid="uid://dduoljfgr6sjn" path="res://scenes/structures/mining_depot.tscn" id="14_4lkw2"]
+[ext_resource type="PackedScene" uid="uid://cynv06ddhi8kr" path="res://scenes/props/furniture/danger_light.tscn" id="16_47dne"]
+[ext_resource type="Material" uid="uid://0j1nxxxq4kpn" path="res://assets/_universe/environment/terrain/regolith_grey_2.tres" id="16_a2whl"]
+[ext_resource type="Material" uid="uid://cfw4xedexidi0" path="res://assets/_universe/environment/terrain/regolith_grey_simple.tres" id="19_vaq7g"]
+[ext_resource type="Material" uid="uid://bnthx4tb3gfkk" path="res://assets/_universe/environment/terrain/biome_plateau.tres" id="20_g2xcy"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_4sslq"]
 size = Vector3(5000, 50, 5000)
@@ -72,6 +76,9 @@ shader_parameter/fog_speed = 1.5
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_4lkw2"]
 size = Vector3(1638.72, 135.52, 279.48)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_3pv0l"]
+resource_name = "metal"
 
 [node name="SandoxCapital" type="StaticBody3D" unique_id=300574500]
 script = ExtResource("1_hvdt3")
@@ -199,7 +206,7 @@ transform = Transform3D(-1, 0, 1.2246467991473532e-16, 0, 1, 0, -1.2246467991473
 transform = Transform3D(-1, 0, 1.2246467991473532e-16, 0, 1, 0, -1.2246467991473532e-16, 0, -1, 25.343606081717677, -2.7370208783850103e-06, 1121.459452987462)
 
 [node name="FogVolume" type="FogVolume" parent="." unique_id=1570834981]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -345.19291496276855, 66.76164340795899, 231.46307270281363)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -345.19291496276855, 66.76164340795899, 317.1437686789682)
 size = Vector3(1638.7212916605677, 135.5232830842242, 306.89811270363225)
 material = SubResource("ShaderMaterial_3b5ap")
 
@@ -233,3 +240,92 @@ transform = Transform3D(6.123436222361646e-17, 0, 1, 0, 1, 0, -1, 0, 6.123436222
 
 [node name="OutdoorLamppost2_2006" parent="." unique_id=550606329 instance=ExtResource("10_uow4d")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.862261152078986, 2.359688368788041, 82.97764537730104)
+
+[node name="Ramp Test Zone" type="Node3D" parent="." unique_id=1918257768]
+
+[node name="Sign_Ramp" type="CSGBox3D" parent="Ramp Test Zone" unique_id=339405881]
+transform = Transform3D(0.8302263826515942, 0, 0.5574263660334419, 0, 1, 0, -0.5574263660334419, 0, 0.8302263826515942, 7.365020918726053, 1.0526118096230785, 107.01071290953415)
+size = Vector3(1, 0.5, 0.1)
+
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Sign_Ramp" unique_id=1040362285]
+transform = Transform3D(-1, 1.2246064e-16, 1.71536e-32, 1.224606353822377e-16, 1, 0, -4.591235121303105e-49, 0, -1, 0.004136012337443859, 0.010219451424017749, -0.0534855244709785)
+modulate = Color(0.8391672, 0.55991113, 0.23282835, 1)
+text = "Zone de test 
+Rampe"
+font_size = 25
+
+[node name="Node3D" type="Node3D" parent="Ramp Test Zone" unique_id=1896374786]
+
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D" unique_id=917812999]
+transform = Transform3D(5.855425899235435e-17, 1, 0, 2.5460997760938166e-17, 0, 1, 1, -5.855425899235437e-17, -2.546099776093817e-17, 6.404213595732221, 0.0647294928676323, 129.6153754121903)
+text = "Pente 12°"
+font_size = 100
+
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D" unique_id=931145488 instance=ExtResource("10_uow4d")]
+transform = Transform3D(-1, 0, 1.2112260603285547e-16, 0, 1, 1.2730498880469083e-17, -1.2112260603285547e-16, 1.2730498880469085e-17, -1, 7.444362397220026, -0.06368266690311497, 132.5073749457498)
+
+[node name="DangerLightBox" parent="Ramp Test Zone/Node3D" unique_id=841267721 instance=ExtResource("16_47dne")]
+transform = Transform3D(0.9781476007338056, -1.1394447605966131e-17, -0.20791169081775931, 0.20791169081775931, 4.716136900847245e-17, 0.9781476007338056, -1.3400516156310428e-18, -1, 4.849981881064978e-17, 35.91299557211116, 6.183317464645585, 129.5827924521981)
+enabled = true
+
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D" unique_id=1202562727]
+transform = Transform3D(6.123032e-17, -0.8910065241883679, -0.45399049973954686, 0, -0.45399049973954686, 0.8910065241883679, -1, -5.455661254091335e-17, -2.779798252780227e-17, 19.62062444127508, 8.220065387072173, 129.6153754121903)
+spot_range = 8.224049
+spot_angle = 89.99
+
+[node name="Rampe_12" type="CSGBox3D" parent="Ramp Test Zone/Node3D" unique_id=464973059]
+transform = Transform3D(6.123032e-17, -0.20791169081775931, 0.9781476007338056, 0, 0.9781476007338056, 0.20791169081775931, -1, -1.2730498880469083e-17, 5.98922883417366e-17, 21.79822125523968, 2.9387532665840994, 129.6153754121903)
+material_override = SubResource("ShaderMaterial_3pv0l")
+use_collision = true
+size = Vector3(4, 0.5, 30)
+material = ExtResource("20_g2xcy")
+
+[node name="Node3D2" type="Node3D" parent="Ramp Test Zone" unique_id=466494529]
+
+[node name="Rampe_10" type="CSGBox3D" parent="Ramp Test Zone/Node3D2" unique_id=400744106]
+transform = Transform3D(6.123032e-17, -0.17364817766693033, 0.984807753012208, 0, 0.984807753012208, 0.17364817766693033, -1, -1.0632533085029995e-17, 6.030009158161442e-17, 21.817013892574565, 2.3722571684802434, 120.06739759480439)
+material_override = SubResource("ShaderMaterial_3pv0l")
+use_collision = true
+size = Vector3(4, 0.5, 30)
+material = ExtResource("19_vaq7g")
+
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D2" unique_id=64698103]
+transform = Transform3D(-8.249538386117887e-17, 0.9998788158903285, -0.015567708044358752, 1.2060018316322883e-16, 0.015567708044358752, 0.9998788158903285, 1, 8.06079182899523e-17, -1.2186983238836413e-16, 6.334190694490024, 0.09761631353060274, 120.06739759480439)
+text = "Pente 10°"
+font_size = 100
+
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D2" unique_id=635444026 instance=ExtResource("10_uow4d")]
+transform = Transform3D(-0.9999999999999999, 0, 1.2153040927273328e-16, 0, 0.9999999999999999, 1.0632533085029995e-17, -1.2153040927273328e-16, 1.0632533085029995e-17, -1, 7.367115514582721, -0.12740731227577307, 122.95939712836389)
+
+[node name="DangerLightBox" parent="Ramp Test Zone/Node3D2" unique_id=293144058 instance=ExtResource("16_47dne")]
+transform = Transform3D(0.984807753012208, -9.704298519006013e-18, -0.17364817766693033, 0.17364817766693033, 4.966720733373556e-17, 0.984807753012208, -9.322483757532308e-19, -1, 5.059778460608887e-17, 36.03642352783194, 5.122246345969259, 120.03481463481221)
+enabled = true
+
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D2" unique_id=587990453]
+transform = Transform3D(6.123032e-17, -0.9063077870366499, -0.4226182617406995, 0, -0.4226182617406995, 0.9063077870366499, -1, -5.549351372618897e-17, -2.5877050428451456e-17, 19.825058746686185, 7.726349089149127, 120.06739759480439)
+spot_range = 8.224049
+spot_angle = 89.99
+
+[node name="Node3D3" type="Node3D" parent="Ramp Test Zone" unique_id=42894132]
+
+[node name="CSGBox3D" type="CSGBox3D" parent="Ramp Test Zone/Node3D3" unique_id=1837986822]
+transform = Transform3D(6.123032e-17, -0.17395755557285325, 0.9847531512308644, 0, 0.9847531512308644, 0.17395755557285325, -1, -1.0651476392496269e-17, 6.029674829719625e-17, 21.994046355345162, 2.5083121583594385, 110.29301876756638)
+size = Vector3(4, 0.2, 30)
+material = ExtResource("16_a2whl")
+
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D3" unique_id=224538594]
+transform = Transform3D(-7.194179054300576e-17, 0.9961672681478451, -0.08746870223605369, 1.2199127660437309e-16, 0.08746870223605369, 0.9961672681478451, 1, 6.099563830218654e-17, -1.2781637180818118e-16, 6.390114833647257, 0.0972575931008306, 110.29301876756638)
+text = "Pente 5°"
+font_size = 100
+
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D3" unique_id=1732295820 instance=ExtResource("10_uow4d")]
+transform = Transform3D(-0.9999999506519783, -0.00031415926019123797, 1.2222998502419448e-16, -0.00031415926019123797, 0.9999999506519783, 5.3560901959521604e-18, -1.2223166165772e-16, 5.3176902499713156e-18, -1, 7.392213327540999, -0.1325422096927431, 113.18501830112588)
+
+[node name="DangerLightBox" parent="Ramp Test Zone/Node3D3" unique_id=257104562 instance=ExtResource("16_47dne")]
+transform = Transform3D(0.9851183269910428, -5.123071552455654e-18, -0.1718775198400559, 0.1718775198400559, 5.563972499123873e-17, 0.9851183269910428, 4.5163862592663795e-18, -1, 5.569225363001004e-17, 36.19292219332728, 5.124210994758235, 110.2604358075742)
+enabled = true
+
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D3" unique_id=1847057749]
+transform = Transform3D(6.123032e-17, -0.9395851256187389, -0.3423153395862047, 0, -0.3423153395862047, 0.9395851256187389, -1, -5.753109573948521e-17, -2.096007699340655e-17, 20.48513281768604, 6.609660576623848, 110.29301876756638)
+spot_range = 8.224049
+spot_angle = 89.99

--- a/scenes/props/furniture/danger_light.gd
+++ b/scenes/props/furniture/danger_light.gd
@@ -10,4 +10,3 @@ func _process(delta: float) -> void:
 
 	$danger_light/light_bulb/SpotLight3D.visible = enabled
 	$danger_light/light_bulb/SpotLight3D2.visible = enabled
-

--- a/scenes/props/testbox/box_50cm.tscn
+++ b/scenes/props/testbox/box_50cm.tscn
@@ -8,7 +8,7 @@
 size = Vector3(0.5, 0.5, 0.5)
 
 [node name="box_50cm" type="RigidBody3D" unique_id=188699454 groups=["containable"]]
-mass = 0.25
+mass = 15.0
 continuous_cd = true
 script = ExtResource("1_o2evt")
 

--- a/scenes/structures/mining_depot.tscn
+++ b/scenes/structures/mining_depot.tscn
@@ -305,6 +305,7 @@ material_override = ExtResource("3_vptbq")
 instance_shader_parameters/animation_speed = 0.0
 
 [node name="door" parent="miningdepot" index="15" unique_id=590761947]
+transform = Transform3D(1.1779184, 0, 0, 0, 1.1779184, 0, 0, 0, 1.1779184, 3.2296023, 3.2643256, -2.5604084)
 material_override = SubResource("StandardMaterial3D_8a0gq")
 
 [node name="screen_001" parent="miningdepot" index="16" unique_id=1301817355]

--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -91,7 +91,12 @@ size = Vector3(0.2317254395602504, 0.9081811614742036, 1.4966181594172667)
 [node name="Truck" type="VehicleBody3D" unique_id=1579985098]
 mass = 1000.0
 script = ExtResource("1_vehicle")
-engine_power = 570.0
+engine_power = 850.0
+max_speed_kmh = 55.0
+handbrake_release_speed = null
+wheel_visual_drop = 0.26
+motor_max_rpm = 3000.0
+debug_color_driven_wheels = false
 
 [node name="SeatDriver" type="Area3D" parent="." unique_id=924961125 node_paths=PackedStringArray("sit_point")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 1, -1.625)
@@ -145,7 +150,6 @@ size_2d_override_stretch = true
 render_target_update_mode = 4
 
 [node name="VehiculeDashboard" parent="Gui3D/SubViewport" unique_id=957292936 instance=ExtResource("5_d2vf6")]
-anchors_preset = 15
 
 [node name="ScreenMesh" type="MeshInstance3D" parent="Gui3D" unique_id=1688130196]
 transform = Transform3D(6.123233995736766e-17, 0, -1, 0, 1, 0, 1, 0, 6.123233995736766e-17, -0.1049409435543579, 0, 0.00330258909847298)

--- a/scenes/vehicles/trucks/truck_ui.tscn
+++ b/scenes/vehicles/trucks/truck_ui.tscn
@@ -25,13 +25,37 @@ repeat = 1
 base_font = ExtResource("2_77xpl")
 variation_embolden = 0.63
 
+[sub_resource type="LabelSettings" id="LabelSettings_hf21d"]
+font = SubResource("FontVariation_kxw7v")
+font_size = 50
+font_color = Color(0.8098958, 0.8098958, 0.8098958, 1)
+
 [sub_resource type="LabelSettings" id="LabelSettings_q7ufo"]
 font = SubResource("FontVariation_kxw7v")
 font_size = 100
 font_color = Color(0.8098958, 0.8098958, 0.8098958, 1)
 
-[sub_resource type="LabelSettings" id="LabelSettings_nctt3"]
+[sub_resource type="LabelSettings" id="LabelSettings_nm016"]
+font = SubResource("FontVariation_kxw7v")
 font_size = 50
+font_color = Color(0.8098958, 0.8098958, 0.8098958, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_nctt3"]
+font_size = 80
+
+[sub_resource type="LabelSettings" id="LabelSettings_mnwnm"]
+font_size = 80
+font_color = Color(1, 0, 0.25882354, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_k5r17"]
+font_size = 50
+
+[sub_resource type="LabelSettings" id="LabelSettings_ttjpe"]
+font_size = 50
+
+[sub_resource type="LabelSettings" id="LabelSettings_7dvew"]
+font_size = 80
+font_color = Color(0.4627451, 0.96862745, 0, 1)
 
 [sub_resource type="LabelSettings" id="LabelSettings_vptbq"]
 font = ExtResource("2_77xpl")
@@ -53,7 +77,7 @@ variation_embolden = 0.73
 
 [node name="vehicule_UI" type="Panel" unique_id=957292936]
 custom_minimum_size = Vector2(1400, 720)
-anchors_preset = -1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -66,14 +90,27 @@ metadata/_edit_use_anchors_ = true
 modulate = Color(0.26822916, 0.26822916, 0.26822916, 1)
 layout_mode = 1
 anchors_preset = -1
-anchor_left = -0.009895833333333333
-anchor_top = 0.0027777777777777775
+anchor_left = -0.00989583333333333
+anchor_top = 0.00277777777777777
 anchor_right = 1.0058184523809526
 anchor_bottom = 0.11574074074074074
 texture = SubResource("GradientTexture2D_qtvga")
 expand_mode = 1
 stretch_mode = 1
 metadata/_edit_use_anchors_ = true
+
+[node name="speed2" type="Label" parent="." unique_id=837518597]
+custom_minimum_size = Vector2(0, 400)
+layout_mode = 0
+offset_left = 115.0
+offset_top = 196.0
+offset_right = 619.0
+offset_bottom = 767.0
+text = "Speed"
+label_settings = SubResource("LabelSettings_hf21d")
+horizontal_alignment = 1
+vertical_alignment = 1
+uppercase = true
 
 [node name="speed" type="Label" parent="." unique_id=1795226927]
 custom_minimum_size = Vector2(0, 400)
@@ -84,6 +121,19 @@ offset_right = 619.0
 offset_bottom = 873.0
 text = "45 Km/h"
 label_settings = SubResource("LabelSettings_q7ufo")
+horizontal_alignment = 1
+vertical_alignment = 1
+uppercase = true
+
+[node name="RPM2" type="Label" parent="." unique_id=1585115087]
+custom_minimum_size = Vector2(0, 400)
+layout_mode = 0
+offset_left = 1283.0
+offset_top = 195.0
+offset_right = 1861.0
+offset_bottom = 766.0
+text = "RPM"
+label_settings = SubResource("LabelSettings_nm016")
 horizontal_alignment = 1
 vertical_alignment = 1
 uppercase = true
@@ -104,10 +154,10 @@ uppercase = true
 [node name="Load" type="Label" parent="." unique_id=635994537]
 layout_mode = 0
 offset_left = 716.0
-offset_top = 975.0
+offset_top = 925.0
 offset_right = 1216.0
-offset_bottom = 1046.5
-text = "Charge"
+offset_bottom = 1035.0
+text = "0/1350 kg"
 label_settings = SubResource("LabelSettings_nctt3")
 horizontal_alignment = 1
 vertical_alignment = 1
@@ -119,29 +169,62 @@ offset_top = 169.0
 offset_right = 1630.0
 offset_bottom = 240.5
 text = "overloaded"
-label_settings = SubResource("LabelSettings_nctt3")
+label_settings = SubResource("LabelSettings_mnwnm")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Elec_Therm_Type" type="Label" parent="." unique_id=1880924138]
+layout_mode = 0
+offset_left = 1486.0
+offset_top = 874.0
+offset_right = 1885.0
+offset_bottom = 984.0
+text = "Motor"
+label_settings = SubResource("LabelSettings_k5r17")
 horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="Elec_THerm" type="Label" parent="." unique_id=556447191]
 layout_mode = 0
-offset_left = 1254.0
-offset_top = 976.0
-offset_right = 1653.0
-offset_bottom = 1047.5
+offset_left = 1480.0
+offset_top = 937.0
+offset_right = 1879.0
+offset_bottom = 1047.0
 text = "Electrique"
 label_settings = SubResource("LabelSettings_nctt3")
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="Transmission_Type" type="Label" parent="." unique_id=802735000]
+layout_mode = 0
+offset_left = 83.0
+offset_top = 874.0
+offset_right = 482.0
+offset_bottom = 984.0
+text = "Transmission"
+label_settings = SubResource("LabelSettings_ttjpe")
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="Transmission" type="Label" parent="." unique_id=1450128450]
 layout_mode = 0
-offset_left = 259.0
-offset_top = 980.0
-offset_right = 658.0
-offset_bottom = 1051.5
+offset_left = 81.0
+offset_top = 949.0
+offset_right = 480.0
+offset_bottom = 1059.0
 text = "4x4"
 label_settings = SubResource("LabelSettings_nctt3")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="hanbreak" type="Label" parent="." unique_id=723791449]
+layout_mode = 0
+offset_left = 305.0
+offset_top = 527.0
+offset_right = 1626.0
+offset_bottom = 637.0
+text = "handbrake"
+label_settings = SubResource("LabelSettings_7dvew")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -55,6 +55,14 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 @export var torque_response: float = 2.5
 ## Brake force per wheel (hand brake = jump action for now).
 @export var brake_force: float = 30.0
+## Parking brake hold (m/s per second): how hard the engaged hand brake damps motion ABOVE the
+## release speed — a real collision impulse exceeds this so a hit truck still gets pushed (it
+## just re-settles). Kept dynamic, never frozen.
+@export var handbrake_hold: float = 30.0
+## Parking-brake "static friction": horizontal speed (m/s) below which the engaged hand brake
+## FULLY cancels motion each frame — a heavy parked truck must NOT move from a player bump or a
+## gentle slope. Above it (a genuine vehicle ramming) it's only damped, so a real hit still pushes.
+@export var handbrake_release_speed: float = 2.0
 ## Maximum steering angle of the front wheels, in degrees.
 @export var max_steer_deg: float = 30.0
 ## How fast the steering reaches its target angle (higher = snappier).
@@ -121,6 +129,10 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 	set(v):
 		wheel_width = v
 		_rebuild_deferred()
+## CLIENT-replica visual only: how far to drop the wheel meshes below their hub. On a replica the
+## physics is off, so VehicleWheel3D never lowers the wheels to the suspension contact — they'd
+## float at the hub. This drops the visual to ~ground level. Tune so the replica's wheels touch.
+@export_range(0.0, 1.5, 0.01) var wheel_visual_drop: float = 0.5
 ## Distance between the front and rear axles.
 @export var wheelbase: float = 3.0:
 	set(v):
@@ -147,8 +159,9 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 ## ELECTRIC only. Full torque from a standstill up to this speed (constant-torque region),
 ## then torque tapers to zero at max_speed_kmh (constant-power region) — the real EV curve.
 @export var base_speed_kmh: float = 25.0
-## ELECTRIC only. Motor RPM at top speed (single-speed reduction — gauge only, no gears).
-@export var motor_max_rpm: float = 9000.0
+## ELECTRIC only. Motor RPM shown on the gauge at top speed (single-speed reduction, no gears).
+## RPM = motor_max_rpm * (speed / max_speed_kmh). Slider so the gauge feel is easy to tune.
+@export_range(0.0, 12000.0, 100.0) var motor_max_rpm: float = 4500.0
 
 @export_group("Thermal gearbox")
 ## THERMAL only. Per-gear torque multiplier, 1st to last (1st = strongest/slowest). Shifts
@@ -204,6 +217,7 @@ var _chase_cam: Node3D = null
 var _cab_cam: Camera3D = null
 var _view: ViewMode = ViewMode.CHASE
 var _empty_mass: float = 0.0
+var _occupant_mass: float = 0.0  # kg of seated players (driver + passengers), added to the mass
 var _locked_cargo: Dictionary = {}
 var _cargo_area: Area3D = null
 var _net_last_position: Vector3 = Vector3.ZERO
@@ -215,6 +229,12 @@ var _net_steering: float = 0.0  # replicated front-wheel steer angle (rad)
 var _wheel_last_pos: Vector3 = Vector3.ZERO  # client: to derive wheel spin from speed
 var _net_speed: float = 0.0  # client: real speed (km/h) replicated from the server
 var _net_last_speed: float = 0.0  # server: last replicated speed (km/h), change detection
+var _net_cargo_mass: float = 0.0  # client: real cargo load (kg) replicated from the server
+var _net_last_cargo_mass: float = -1.0  # server: last replicated cargo load (kg), change detection
+var _net_last_mass: float = -1.0  # server: last replicated total mass (kg), change detection
+var _handbrake: bool = false  # server: hand brake engaged (holds the vehicle until throttle)
+var _net_handbrake: bool = false  # client: replicated hand brake state (for the HUD)
+var _net_last_handbrake: bool = false  # server: last replicated hand brake, change detection
 var _interp := NetInterpolator.new()  # client-side smoothing of the replica
 var _hud: VehicleDebugHud = null  # driver HUD (pilot client only)
 var _powertrain := VehiclePowertrain.new()
@@ -450,18 +470,31 @@ func _lock_cargo(body: RigidBody3D) -> void:
 	body.freeze = true
 	body.collision_layer = 0
 	body.collision_mask = 0
-	body.reparent(self)
+	# Reparent into the bed WITHOUT the prop's _exit_tree firing a delete (server_parent_change
+	# sets server_reparenting), then replicate the reparent so clients ride it in the bed. A raw
+	# reparent() made the prop vanish in-game (its _exit_tree deleted it from Horizon).
+	if body.has_method("server_parent_change"):
+		body.server_parent_change(self)
+		if body.has_method("send_properties_to_client"):
+			body.send_properties_to_client(str(uuid))
+	else:
+		body.reparent(self)
 	_refresh_mass()
 
 func _refresh_mass() -> void:
-	var total := _empty_mass
-	for body in _locked_cargo:
-		total += _locked_cargo[body]
-	mass = total
+	mass = _empty_mass + get_cargo_mass()
 
-## Total mass (kg) of the cargo locked in the bed (HUD + load limiter).
+## Body mass (kg) of a seated player, added to the truck's weight while they ride.
+func _player_mass(player: Node) -> float:
+	return float(player.mass) if "mass" in player else 75.0
+
+## Total PAYLOAD (kg) the truck is carrying = bed cargo + seated players. This is what the load
+## limiter (max_payload / OVERLOADED) checks and what the dashboard "Load" shows. On the client
+## replica the bed isn't simulated, so use the value replicated from the server.
 func get_cargo_mass() -> float:
-	var total := 0.0
+	if _is_networked() and not GameOrchestrator.is_server():
+		return _net_cargo_mass
+	var total := _occupant_mass
 	for body in _locked_cargo:
 		total += _locked_cargo[body]
 	return total
@@ -473,6 +506,16 @@ func is_overloaded() -> bool:
 ## True when the cargo is so far over the limit that the vehicle can no longer move (GDD).
 func is_immobilized() -> bool:
 	return get_cargo_mass() > max_payload * overload_immobilize
+
+## Server: the pilot toggles the hand brake (long press at low speed, relayed as an action).
+func toggle_handbrake() -> void:
+	_handbrake = not _handbrake
+
+## True when the hand brake is engaged — server state, or the replicated one on a client (HUD).
+func is_handbraked() -> bool:
+	if _is_networked() and not GameOrchestrator.is_server():
+		return _net_handbrake
+	return _handbrake
 
 ## Drop a real mining rock above the bed so it falls in and loads the truck (bench load
 ## test, reusing the actual rock_mining scene). Called by the bench debug node; in game the
@@ -612,10 +655,9 @@ func _process(delta: float) -> void:
 		return
 	if not _is_networked() or GameOrchestrator.is_server():
 		return
-	if _is_local_driver():
-		_interp.snap_to(self)  # we drive it: stay responsive, no smoothing lag
-	else:
-		_interp.update(self, delta)  # passenger / remote viewer: smooth
+	# Smooth for everyone, driver included: the driver is parented to the vehicle, so the camera
+	# rides the smoothly-interpolated body (no per-frame world jitter). Server stays authoritative.
+	_interp.update(self, delta)
 	_update_wheels_visual(delta)
 
 func _physics_process(delta: float) -> void:
@@ -627,14 +669,21 @@ func _physics_process(delta: float) -> void:
 		if not GameOrchestrator.is_server():
 			return
 		_update_cargo()
+		# Keep the body awake while handbraked so _integrate_forces keeps cancelling drift — a
+		# parked truck that fell asleep would roll on a slope (the brake alone can't hold a skid).
+		can_sleep = not _handbrake
 		if _pilot != null:
 			_apply_drive(delta)
+		elif _handbrake:
+			_hold_handbrake(delta)  # parked: the hand brake stays on after the driver leaves
 		_replicate_transform()
 		return
 	# Bench / standalone: drive locally.
 	_update_cargo()  # absorb settled cargo into the truck (always, even when not driving)
 	if _pilot != null:
 		_apply_drive(delta)
+	elif _handbrake:
+		_hold_handbrake(delta)
 
 ## Server: replicate position/rotation to clients when they change (same shape as a rock).
 ## Client: the replica is frozen (no physics), so roll + steer the wheels visually from
@@ -648,7 +697,9 @@ func _update_wheels_visual(delta: float) -> void:
 		if wheel.use_as_steering:
 			wheel.rotation.y = _net_steering
 		if wheel.get_child_count() > 0:
-			wheel.get_child(0).rotate_object_local(Vector3.UP, -spin)
+			var tire: Node3D = wheel.get_child(0)
+			tire.position.y = -wheel_visual_drop  # replica has no suspension → drop to ~ground
+			tire.rotate_object_local(Vector3.UP, -spin)
 
 ## Speed shown on the HUD: real physics speed on the server/bench; on a client replica (frozen,
 ## linear_velocity is 0) use the speed replicated by the server — deriving it from the
@@ -672,12 +723,22 @@ func _replicate_transform() -> void:
 	var my_pos: Vector3 = snapped(position, Vector3(0.001, 0.001, 0.001))
 	var my_rot: Vector3 = snapped(rotation, Vector3(0.0001, 0.0001, 0.0001))
 	var my_speed: float = snappedf(linear_velocity.length() * 3.6, 0.1)
-	if my_pos == _net_last_position and my_rot == _net_last_rotation and my_speed == _net_last_speed:
+	var my_cargo: float = snappedf(get_cargo_mass(), 0.1)
+	var my_mass: float = snappedf(mass, 0.1)  # total weight (empty + cargo + seated players)
+	if my_pos == _net_last_position and my_rot == _net_last_rotation \
+			and my_speed == _net_last_speed and my_cargo == _net_last_cargo_mass \
+			and _handbrake == _net_last_handbrake and my_mass == _net_last_mass:
 		return
 	_net_last_position = my_pos
 	_net_last_rotation = my_rot
 	_net_last_speed = my_speed
-	var data := {"position": my_pos, "rotation": my_rot, "steering": snapped(steering, 0.001), "speed": my_speed}
+	_net_last_cargo_mass = my_cargo
+	_net_last_handbrake = _handbrake
+	_net_last_mass = my_mass
+	var data := {
+		"position": my_pos, "rotation": my_rot, "steering": snapped(steering, 0.001),
+		"speed": my_speed, "cargo_mass": my_cargo, "handbrake": _handbrake, "mass": my_mass,
+	}
 	emit_signal("hs_server_prop_update", uuid, data, type_name, has_parent)
 
 ## Server: tell the clients to despawn this vehicle when it leaves the world.
@@ -699,6 +760,12 @@ func client_channel_data_update(data: Dictionary) -> void:
 		_net_steering = float(data["steering"])
 	if data.has("speed"):
 		_net_speed = float(data["speed"])
+	if data.has("cargo_mass"):
+		_net_cargo_mass = float(data["cargo_mass"])
+	if data.has("mass"):
+		mass = float(data["mass"])  # replica: show the server's real total weight on the HUD
+	if data.has("handbrake"):
+		_net_handbrake = bool(data["handbrake"])
 	if data.has("pilot_uuid"):
 		pilot_uuid = str(data["pilot_uuid"])
 
@@ -723,6 +790,8 @@ func server_enter(player: Node, seat_name: String = "") -> void:
 		player._seat_node = seat  # the player rides this seat each frame (server)
 	if player.has_method("set_seated"):
 		player.set_seated(true)  # drop the player's collision so it can't shove the truck
+	_occupant_mass += _player_mass(player)  # the seated player adds their weight to the truck
+	_refresh_mass()
 	if seat.is_driver_seat():
 		_pilot = player
 		pilot_uuid = str(player.client_uuid) if "client_uuid" in player else ""
@@ -743,11 +812,25 @@ func server_exit(player: Node) -> void:
 		player._seat_node = null
 	if player.has_method("set_seated"):
 		player.set_seated(false)  # restore the player's collision
+	_occupant_mass = maxf(0.0, _occupant_mass - _player_mass(player))  # they take their weight back
+	_refresh_mass()
 	if seat.is_driver_seat() and _pilot == player:
 		_pilot = null
 		pilot_uuid = ""
 		_replicate_pilot()
+		# NOTE: the hand brake stays engaged on exit (real parking brake) — _hold_handbrake keeps
+		# the parked truck still even with no driver. It releases on throttle when someone drives.
+	# Put the player back on the ground beside the vehicle, on the side of the seat it used.
+	if player is Node3D:
+		(player as Node3D).global_position = _exit_position_for_seat(seat)
 	print("🚚 Vehicle %s: seat exit" % uuid)
+
+## Drop position beside the vehicle, on the side of the given seat (left vs right, derived from
+## the seat's local X so any layout works), raised so the player lands on the ground on exit.
+func _exit_position_for_seat(seat: Node) -> Vector3:
+	var seat_local: Vector3 = to_local((seat as Node3D).global_position)
+	var side: float = -1.0 if seat_local.x <= 0.0 else 1.0
+	return to_global(Vector3(side * (body_width * 0.5 + 1.0), 1.0, seat_local.z))
 
 ## All seats of this vehicle (designer-placed VehicleSeat children).
 func _seats() -> Array:
@@ -797,6 +880,9 @@ func _apply_drive(delta: float) -> void:
 		throttle_in = Input.get_axis("move_back", "move_forward")  # bench: local input
 		turn = Input.get_axis("move_right", "move_left")
 		braking = Input.is_physical_key_pressed(KEY_SPACE)
+	# Hand brake holds the vehicle until the pilot presses the throttle again.
+	if _handbrake and absf(throttle_in) > 0.05:
+		_handbrake = false
 	# Ramp the applied torque toward the throttle (tempers the launch on any powertrain).
 	_throttle = move_toward(_throttle, throttle_in, torque_response * delta)
 	var forward_kmh: float = _forward_speed_kmh()
@@ -806,14 +892,14 @@ func _apply_drive(delta: float) -> void:
 
 	# Overloaded past the hard limit: the vehicle can't move — kill the drive and hold it.
 	var immobilized: bool = is_immobilized()
-	if immobilized:
+	if immobilized or _handbrake:
 		force = 0.0
 
 	# VehicleBody3D drives toward +Z for a positive engine_force; our cab faces -Z, so negate.
 	engine_force = -force
 	_steer_target = turn * deg_to_rad(max_steer_deg)
 	steering = move_toward(steering, _steer_target, steer_speed * delta)
-	brake = brake_force if (immobilized or braking) else 0.0
+	brake = brake_force if (immobilized or braking or _handbrake) else 0.0
 
 	# IRL a powered wheel keeps spinning once it leaves the ground. VehicleWheel3D stops the
 	# visual with no contact, so spin powered airborne wheels ourselves (about their axle).
@@ -821,6 +907,35 @@ func _apply_drive(delta: float) -> void:
 		for wheel in _wheels:
 			if wheel.use_as_traction and not wheel.is_in_contact() and wheel.get_child_count() > 0:
 				wheel.get_child(0).rotate_object_local(Vector3.UP, -signf(_throttle) * 25.0 * delta)
+
+## Cancel the hand-brake drift HERE (after the physics step), NOT in _physics_process — setting
+## linear_velocity before the step fought the wheel suspension and made the body sink onto its
+## chassis. We damp only the HORIZONTAL drift (in the body's plane) and keep the vertical, so the
+## suspension keeps holding the truck up. Stays DYNAMIC: a collision impulse is far bigger than
+## handbrake_hold * step, so a hit still pushes it (it then re-settles).
+func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
+	if not _handbrake:
+		return
+	var up: Vector3 = global_transform.basis.y
+	var v: Vector3 = state.linear_velocity
+	var v_up: Vector3 = up * v.dot(up)
+	var v_flat: Vector3 = v - v_up
+	# Static-friction style: a small horizontal speed (a player bump, slope creep) is killed
+	# outright so the parked 2 t truck doesn't budge; a large one (a real ramming) is only damped,
+	# so a genuine hit still pushes it. Vertical is kept so the suspension holds the truck up.
+	if v_flat.length() < handbrake_release_speed:
+		v_flat = Vector3.ZERO
+	else:
+		v_flat = v_flat.move_toward(Vector3.ZERO, handbrake_hold * state.step)
+	state.linear_velocity = v_up + v_flat
+	state.angular_velocity = state.angular_velocity.move_toward(Vector3.ZERO, handbrake_hold * state.step)
+
+## Parked hand brake with no driver: lock the wheels + kill the drive. The drift cancel (and the
+## velocity threshold that keeps it pushable by a real hit) is in _integrate_forces, which keeps
+## firing because we hold the body awake (see _physics_process). From _physics_process.
+func _hold_handbrake(_delta: float) -> void:
+	engine_force = 0.0
+	brake = brake_force
 
 ## Forward speed in km/h (positive when driving toward the cab, -Z).
 func _forward_speed_kmh() -> float:
@@ -844,7 +959,9 @@ func _sync_powertrain() -> void:
 	_powertrain.redline_rpm = redline_rpm
 
 func get_engine_rpm() -> float:
-	return _powertrain.engine_rpm(_forward_speed_kmh())
+	# Base it on the DISPLAY speed (replicated) so the gauge works on the client replica too —
+	# there linear_velocity is 0 (physics off). RPM uses |speed|, so the magnitude is fine.
+	return _powertrain.engine_rpm(get_display_speed_kmh())
 
 ## HUD label: the current gear (THERMAL) or empty (ELECTRIC has no gears).
 func get_gear_label() -> String:
@@ -852,14 +969,14 @@ func get_gear_label() -> String:
 
 ## HUD label of the powertrain (electric or thermal).
 func get_propulsion_name() -> String:
-	return "Électrique" if propulsion_type == PropulsionType.ELECTRIC else "Thermique"
+	return "Electric" if propulsion_type == PropulsionType.ELECTRIC else "Thermal"
 
 ## Human-readable label of the current drive mode (for the debug HUD).
 func get_drive_mode_name() -> String:
 	match drive_mode:
 		DriveMode.FRONT:
-			return "FWD (avant)"
+			return "FWD"
 		DriveMode.REAR:
-			return "RWD (arrière)"
+			return "RWD"
 		_:
 			return "4x4"

--- a/scenes/vehicles/vehicle_dashboard.gd
+++ b/scenes/vehicles/vehicle_dashboard.gd
@@ -7,7 +7,7 @@ extends Panel
 ## about it (the screen is just another child). Put this script on the UI scene's root.
 ##
 ## Expects these child Labels (rename here if your scene differs):
-## speed, RPM, Load, Overloaded, Elec_THerm, Transmission.
+## speed, RPM, Load, Overloaded, Elec_THerm, Transmission, hanbreak.
 
 var _vehicle: Vehicle = null
 
@@ -17,6 +17,7 @@ var _vehicle: Vehicle = null
 @onready var _overloaded: Label = $Overloaded
 @onready var _powertrain: Label = $Elec_THerm
 @onready var _transmission: Label = $Transmission
+@onready var _handbrake: Label = $hanbreak
 
 func _ready() -> void:
 	_vehicle = _find_vehicle()
@@ -25,11 +26,12 @@ func _process(_delta: float) -> void:
 	if _vehicle == null or not is_instance_valid(_vehicle):
 		return
 	_speed.text = "%.0f km/h" % _vehicle.get_display_speed_kmh()
-	_rpm.text = "%.0f tr/min" % _vehicle.get_engine_rpm()
+	_rpm.text = "%.0f rpm" % _vehicle.get_engine_rpm()
 	_load.text = "%.0f / %.0f kg" % [_vehicle.get_cargo_mass(), _vehicle.max_payload]
-	_overloaded.text = "SURCHARGE" if _vehicle.is_overloaded() else ""
+	_overloaded.text = "OVERLOADED" if _vehicle.is_overloaded() else ""
 	_powertrain.text = _vehicle.get_propulsion_name()
 	_transmission.text = _vehicle.get_drive_mode_name()
+	_handbrake.text = "HANDBRAKE" if _vehicle.is_handbraked() else ""
 
 ## Walk up the tree (through the SubViewport) to the owning Vehicle.
 func _find_vehicle() -> Vehicle:

--- a/scenes/vehicles/vehicle_debug_hud.gd
+++ b/scenes/vehicles/vehicle_debug_hud.gd
@@ -30,19 +30,20 @@ func _process(_delta: float) -> void:
 	var overloaded: bool = _vehicle.is_overloaded()
 	var warn := ""
 	if _vehicle.is_immobilized():
-		warn = "   ⛔ IMMOBILISÉ"
+		warn = "   ⛔ IMMOBILIZED"
 	elif overloaded:
-		warn = "   ⚠ SURCHARGE"
+		warn = "   ⚠ OVERLOADED"
+	var handbrake := "   🅿 HANDBRAKE" if _vehicle.is_handbraked() else ""
 	_label.add_theme_color_override("font_color", Color(1, 0.3, 0.2) if overloaded else Color(1, 1, 1))
 	# In-game (networked replica) the bench debug keys are off, so only advertise what the
 	# player -> server control path handles. An empty uuid means the local bench.
 	var in_game: bool = _vehicle.uuid != ""
 	var trans_suffix := "" if in_game else "   (N)"
 	var keys := (
-		"[Y] sortir   [Espace] freiner   [R] redresser" if in_game
-		else "[T] rocher   [N] traction   [Espace] freiner   [R] redresser")
+		"[Y] exit   [Space] brake   [Hold Space <3km/h] handbrake   [R] flip" if in_game
+		else "[T] rock   [N] drive mode   [Space] brake   [Hold Space <3km/h] handbrake   [R] flip")
 	_label.text = (
-		"Vitesse : %3.0f km/h\nMoteur : %5.0f tr/min\n%sTransmission : %s%s\nMotorisation : %s\n"
-		+ "Poids total : %.0f kg\nCharge : %.0f / %.0f kg%s\n%s") % [
-		speed, rpm, _vehicle.get_gear_label(), _vehicle.get_drive_mode_name(), trans_suffix,
+		"Speed: %3.0f km/h%s\nEngine: %5.0f rpm\n%sTransmission: %s%s\nPowertrain: %s\n"
+		+ "Total weight: %.0f kg\nLoad: %.0f / %.0f kg%s\n%s") % [
+		speed, handbrake, rpm, _vehicle.get_gear_label(), _vehicle.get_drive_mode_name(), trans_suffix,
 		_vehicle.get_propulsion_name(), total, cargo, _vehicle.max_payload, warn, keys]

--- a/scenes/vehicles/vehicle_powertrain.gd
+++ b/scenes/vehicles/vehicle_powertrain.gd
@@ -44,7 +44,7 @@ func engine_rpm(forward_kmh: float) -> float:
 ## HUD label: the current gear (THERMAL) or empty (ELECTRIC has no gears).
 func gear_label() -> String:
 	if type == Type.THERMAL:
-		return "Rapport : %d\n" % (current_gear + 1)
+		return "Gear: %d\n" % (current_gear + 1)
 	return ""
 
 ## ELECTRIC powertrain: single-speed, full torque up to base_speed then taper (constant power).

--- a/scenes/vehicles/vehicle_seat.gd
+++ b/scenes/vehicles/vehicle_seat.gd
@@ -26,7 +26,10 @@ func _ready() -> void:
 	# The player's physics body (CharacterBody3D) sits on collision layer 1, so scan that
 	# layer. Set here so every seat auto-detects the player — no per-vehicle mask setup.
 	collision_mask = 1
-	if Engine.is_editor_hint():
+	# The "press E here" body detection is CLIENT-ONLY (it sets the local player's prompt). The
+	# server is authoritative via occupant_uuid (server_enter); running it there would also crash,
+	# since the server's network_agent has no player_entity.
+	if Engine.is_editor_hint() or OS.has_feature("dedicated_server"):
 		return
 	# Detect the local player walking into the box (depot pattern), so it knows which seat its
 	# E will take. Wired here so a vehicle scene only needs the node, not a manual connection.
@@ -66,4 +69,4 @@ func _on_body_exited(body: Node3D) -> void:
 ## remote players' bodies, which also exist on this client).
 func _is_local_player(body: Node) -> bool:
 	var agent = NetworkOrchestrator.network_agent
-	return agent != null and body == agent.player_entity
+	return agent != null and "player_entity" in agent and body == agent.player_entity


### PR DESCRIPTION
## Description

Improves the truck (generic Vehicle): finalised parking hand brake, seated-player
parenting to remove camera jitter, player/cargo weight in the load, and a fully
English vehicle UI. Server-authoritative throughout (the client only applies the
replicated state). Also bundles the test areas used to validate it (sandbox city
dressing, a devmode box-test level).

Pairs with horizonserver `feat/vehicle-cargo-handbrake` (adds cargo_mass / handbrake
/ mass to the vehicle replication def) — both PRs must be merged together.

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
- New truck parking hand brake: long-press Space under 3 km/h, released by throttle,
  stays engaged when you leave the truck. Shown on the dashboard, HUD and shortcut hint.
- Seated players now add their weight (75 kg) to the truck's load and total weight;
  OVERLOADED accounts for passengers + bed cargo.
- Smoother ride: no more camera jitter once seated, and the truck moves smoothly for
  everyone (driver included).
- "Driver seat taken" message when the driver seat is occupied; the enter-seat prompt
  no longer shows while already seated. You now exit beside the seat you used.
- Fixed: cargo no longer disappears when dropped into the bed in multiplayer.
- The vehicle UI is now in English.
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
- Nouveau frein à main du camion : appui long sur Espace sous 3 km/h, relâché par
  l'accélération, reste actif quand on sort. Affiché sur le tableau de bord, le HUD et l'aide.
- Les passagers assis ajoutent leur poids (75 kg) à la charge et au poids total ;
  SURCHARGE prend en compte passagers + chargement de la benne.
- Conduite plus fluide : plus de tremblement de caméra une fois assis, et le camion
  bouge de façon lisse pour tout le monde (conducteur compris).
- Message « Driver seat taken » quand le siège conducteur est occupé ; l'invite pour
  monter ne s'affiche plus quand on est déjà assis. On ressort à côté du siège utilisé.
- Correction : le chargement ne disparaît plus quand on le pose dans la benne en multijoueur.
- L'interface du véhicule est désormais en anglais.
<!-- /CHANGELOG_FR -->
