### PR TITLE
Fix/vehicle not cargo

### DIFF
--- a/scenes/globals/generic_prop.gd
+++ b/scenes/globals/generic_prop.gd
@@ -13,6 +13,10 @@ var spawn_rotation: Vector3 = Vector3.UP
 
 var server_last_position = Vector3.ZERO
 var server_last_rotation = Vector3.ZERO
+# Last parent_id replicated + how many more frames to keep resending it after a change, so a
+# single lost drop/settle message can't strand this prop under its old parent on clients (PropNet).
+var server_last_parent_id: String = ""
+var server_parent_resend: int = 0
 
 var has_parent: bool = false
 var carried: bool = false             # carried by a player (issue #124)
@@ -58,6 +62,22 @@ func server_prop_update(data: Dictionary):
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
 	has_parent = true
+	_apply_carry_collision_exception(parent)
+
+## Client: if WE (the local player) are the new parent, we're carrying this prop — ignore
+## collisions between us and it so our own move_and_slide isn't blocked. Otherwise clear any
+## stale exception so it stays solid to us (on the ground or carried by someone else).
+func _apply_carry_collision_exception(parent: Node) -> void:
+	if GameOrchestrator.is_server():
+		return
+	var agent = NetworkOrchestrator.network_agent
+	var local_player = agent.player_entity if agent != null and "player_entity" in agent else null
+	if local_player == null or not (local_player is PhysicsBody3D):
+		return
+	if parent == local_player:
+		add_collision_exception_with(local_player)
+	else:
+		remove_collision_exception_with(local_player)
 
 # receive the update from server, in this example, we manage position and rotation properties
 func client_channel_data_update(data: Dictionary) -> void:
@@ -80,10 +100,8 @@ func interact(_interactor: Node = null) -> bool:
 
 func set_carried(value: bool) -> void:
 	carried = value
-	# A carried prop generates no collision (a frozen body would block the carrier).
-	for c in get_children():
-		if c is CollisionShape3D:
-			c.disabled = value
+	# A carried prop KEEPS its collision (solid to the world and other players); the carrier
+	# adds a collision exception with it instead, so it isn't blocked by what it carries.
 
 func server_parent_change(parent: Node) -> void:
 	server_reparenting = true

--- a/scenes/globals/prop_net.gd
+++ b/scenes/globals/prop_net.gd
@@ -18,6 +18,7 @@ static func server_tick(prop: Node) -> void:
 	var pos: Vector3 = snapped(prop.position, Vector3(0.001, 0.001, 0.001))
 	var rot: Vector3 = snapped(prop.rotation, Vector3(0.0001, 0.0001, 0.0001))
 	var carrier: Node = prop.get_parent()
+	var tracks_parent: bool = "server_last_parent_id" in prop
 	if carrier is Player:
 		prop.emit_signal(
 			"hs_server_prop_update",
@@ -25,13 +26,38 @@ static func server_tick(prop: Node) -> void:
 			{"position": pos, "rotation": rot, "parent_id": str(carrier.client_uuid)},
 			prop.type_name,
 			true)
+		if tracks_parent:
+			prop.server_last_parent_id = str(carrier.client_uuid)
+			prop.server_parent_resend = 0
 		return
-	if prop.server_last_position != pos or prop.server_last_rotation != rot:
+	if carrier is Vehicle:
+		# Loaded in a bed: its LOCAL position is constant, so the change-throttle below would never
+		# resend -> Horizon's GORC entry goes stale and later updates (e.g. a retrieve+drop) get
+		# dropped. Keep it fresh by re-sending position + parent_id every frame, like carrying.
 		prop.emit_signal(
 			"hs_server_prop_update",
 			prop.uuid,
-			{"position": pos, "rotation": rot},
+			{"position": pos, "rotation": rot, "parent_id": str(carrier.uuid)},
 			prop.type_name,
-			prop.has_parent)
+			true)
+		if tracks_parent:
+			prop.server_last_parent_id = str(carrier.uuid)
+			prop.server_parent_resend = 0
+		return
+	# Not carried. Detect a parent change (dropped to the world, settled into a bed) and resend the
+	# parent_id for a few frames: a single lost drop/settle message must not leave the prop stuck
+	# under its old parent on clients, and at huge planet coordinates the position throttle below can
+	# suppress any other resend. parent_id only travels when it actually changes (no per-frame spam).
+	var pid: String = (str(carrier.uuid) if (carrier != null and "uuid" in carrier) else "")
+	if tracks_parent and pid != prop.server_last_parent_id:
+		prop.server_last_parent_id = pid
+		prop.server_parent_resend = 10
+	var resend_parent: bool = tracks_parent and prop.server_parent_resend > 0
+	if prop.server_last_position != pos or prop.server_last_rotation != rot or resend_parent:
+		var data: Dictionary = {"position": pos, "rotation": rot}
+		if resend_parent:
+			data["parent_id"] = pid
+			prop.server_parent_resend -= 1
+		prop.emit_signal("hs_server_prop_update", prop.uuid, data, prop.type_name, prop.has_parent)
 		prop.server_last_position = pos
 		prop.server_last_rotation = rot

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -334,12 +334,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		# Otherwise pick up / drop. Send the uuid of the carriable under OUR crosshair so the
 		# server grabs exactly that one (its own ray can be slightly off and grab a neighbour).
 		interact_ray.force_raycast_update()
-		var hit = interact_ray.get_collider()
-		var target_uuid := ""
-		if hit != null:
-			var hp = hit.get_parent()
-			if hp != null and hp.has_method("interact") and "uuid" in hp:
-				target_uuid = str(hp.uuid)
+		var aim := _aimed_carriable()
+		var target_uuid := str(aim.uuid) if aim != null else ""
 		client_send_action_to_server({"action": "action", "target_uuid": target_uuid})
 		_predict_carry_stow()
 
@@ -432,6 +428,18 @@ func _process(_delta: float) -> void:
 		else:
 			interact_label.text = "[E] Drive Seat" if _nearby_seat.is_driver_seat() else "[E] Passenger Seat"
 		interact_label.show()
+
+	# Carry/drop prompt (no other prompt showing). Carrying -> E drops; hands free and aiming at a
+	# grabbable prop -> E carries it. interact() is the same rule the server uses to allow the grab.
+	if not interact_label.visible:
+		if _owner_carrying:
+			interact_label.text = "[E] Drop"
+			interact_label.show()
+		else:
+			var aim := _aimed_carriable()
+			if aim != null and aim.interact():
+				interact_label.text = "[E] Carry"
+				interact_label.show()
 
 
 	if not OS.has_feature("dedicated_server"):
@@ -889,7 +897,8 @@ func _safe_reparent_and_sync(new_parent: Node) -> void:
 		client_uuid,
 		snapped(position, Vector3(0.001, 0.001, 0.001)),
 		snapped(global_rotation, Vector3(0.0001, 0.0001, 0.0001)),
-		new_parent.uuid,
+		# Robust to the scene layout: a parent without a uuid (e.g. a grouping/test-zone node) = "".
+		str(new_parent.uuid) if "uuid" in new_parent else "",
 		is_parented
 	)
 
@@ -914,7 +923,8 @@ func _on_spawn_selected(data) -> void:
 func _spawn_truck() -> void:
 	var spawn_pos: Vector3 = position + (-global_basis.z * 8.0) + global_basis.y * 1.0
 	var parent = get_parent()
-	var parentuuid = "" if parent.name == "SystemSandbox" else parent.uuid
+	# Robust to the scene layout: any parent without a uuid (SystemSandbox, a grouping node) = "".
+	var parentuuid = str(parent.uuid) if "uuid" in parent else ""
 	client_send_action_to_server({
 		"action": "spawn_vehicle",
 		"position": {"x": spawn_pos.x, "y": spawn_pos.y, "z": spawn_pos.z},
@@ -925,7 +935,8 @@ func _spawn_truck() -> void:
 func _spawn_depot() -> void:
 	var spawn_pos: Vector3 = position + (-global_basis.z * 10.0)
 	var parent = get_parent()
-	var parentuuid = "" if parent.name == "SystemSandbox" else parent.uuid
+	# Robust to the scene layout: any parent without a uuid (SystemSandbox, a grouping node) = "".
+	var parentuuid = str(parent.uuid) if "uuid" in parent else ""
 	emit_signal(
 		"client_action_requested",
 		{
@@ -941,11 +952,8 @@ func spawn_box(_boxscene: String, _type: String, _coeffz: float, _coeffy: float)
 	# LOCAL DEV (do not commit): re-enabled to spawn mining rocks for testing.
 	var item_spawn_position: Vector3 = position + (-global_basis.z * _coeffz) + global_basis.y * _coeffy
 	var parent = get_parent()
-	var parentuuid = ""
-	if parent.name == "SystemSandbox":
-		parentuuid = ""
-	else:
-		parentuuid = parent.uuid
+	# Robust to the scene layout: any parent without a uuid (SystemSandbox, a grouping node) = "".
+	var parentuuid = str(parent.uuid) if "uuid" in parent else ""
 	emit_signal(
 		"client_action_requested",
 		{
@@ -1088,6 +1096,22 @@ func _find_node_by_uuid(node: Node, target_uuid: String) -> Node:
 		var found: Node = _find_node_by_uuid(child, target_uuid)
 		if found != null:
 			return found
+	return null
+
+## The carriable prop under the crosshair, or null. Checks the hit body itself AND its parent:
+## a prop's collision can be the root (which carries interact(), e.g. a crate in a truck bed where
+## get_parent() is the vehicle) or a child shape (parent carries interact()). (#124)
+func _aimed_carriable() -> Node:
+	if not interact_ray.is_colliding():
+		return null
+	var hit = interact_ray.get_collider()
+	if hit == null:
+		return null
+	if hit.has_method("interact") and "uuid" in hit:
+		return hit
+	var p = hit.get_parent()
+	if p != null and p.has_method("interact") and "uuid" in p:
+		return p
 	return null
 
 ## Find a carriable (group "carriable") by its uuid (server-side). Used to pick up
@@ -1234,9 +1258,12 @@ func server_action_received(data: Dictionary) -> void:
 				# Generic: let the object know it is no longer carried (issue #124).
 				if hands_item.has_method("set_carried"):
 					hands_item.set_carried(false)
-				hands_item.server_parent_change(get_parent())
+				hands_item.remove_collision_exception_with(self)  # it can collide with us again
+				var drop_parent := get_parent()
+				hands_item.server_parent_change(drop_parent)
 				hands_item.freeze = false
-				hands_item.send_properties_to_client(get_parent().uuid)
+				# Robust to the scene layout: a parent without a uuid (grouping/test-zone node) = "".
+				hands_item.send_properties_to_client(str(drop_parent.uuid) if "uuid" in drop_parent else "")
 				hands_item = null
 				# Stop carrying on all clients (perforator comes back) (issue #124).
 				server_send_properties_to_client({"carrying": false})
@@ -1247,7 +1274,15 @@ func server_action_received(data: Dictionary) -> void:
 				var parent_node := _find_carriable(str(data.get("target_uuid", "")))
 				var picked_up := false
 				if parent_node != null and parent_node.has_method("interact") and parent_node.interact(self):
+					# If it's secured in a vehicle bed, take it out of the load first (retrieval).
+					var prev_parent := parent_node.get_parent()
+					if prev_parent is Vehicle and prev_parent.has_method("release_cargo"):
+						prev_parent.release_cargo(parent_node)
 					parent_node.freeze = true
+					parent_node.add_collision_exception_with(self)  # solid to others, not the carrier
+					# Make sure its replication is active: a crate that sat in a bed may have had its
+					# _physics_process paused, which would stop PropNet from replicating a later drop.
+					parent_node.set_physics_process(true)
 					parent_node.server_parent_change(self)
 					parent_node.position = Vector3(0.0, 1.0, -1.0)
 					#  send reparent to client

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -76,6 +76,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.8999999999941792, 0)
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.6541, 0)
 
 [node name="Camera3D" type="Camera3D" parent="CameraPivot" unique_id=2070954965]
+fov = 90.0
 far = 10000000000000.01
 
 [node name="InteractRay" type="RayCast3D" parent="CameraPivot/Camera3D" unique_id=1335224373]

--- a/scenes/props/city/sandbox_capital.tscn
+++ b/scenes/props/city/sandbox_capital.tscn
@@ -210,10 +210,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -345.19291496276855, 66.76164
 size = Vector3(1638.7212916605677, 135.5232830842242, 306.89811270363225)
 material = SubResource("ShaderMaterial_3b5ap")
 
-[node name="MiningDepot" parent="." unique_id=1889403175 instance=ExtResource("14_4lkw2")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.439176267583754, 2.3517123357506797, 88.31635010584525)
-placeholder = true
-
 [node name="Area3D" type="Area3D" parent="." unique_id=1228311395 groups=["player"]]
 script = ExtResource("11_04krg")
 target_volume_db = -30.0
@@ -235,12 +231,6 @@ autoplay = true
 bus = &"Music"
 parameters/looping = true
 
-[node name="OutdoorLamppost2_2005" parent="." unique_id=1239394709 instance=ExtResource("10_uow4d")]
-transform = Transform3D(6.123436222361646e-17, 0, 1, 0, 1, 0, -1, 0, 6.123436222361646e-17, 7.822804687597224, 2.3986518313260676, 93.6169283414612)
-
-[node name="OutdoorLamppost2_2006" parent="." unique_id=550606329 instance=ExtResource("10_uow4d")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.862261152078986, 2.359688368788041, 82.97764537730104)
-
 [node name="Ramp Test Zone" type="Node3D" parent="." unique_id=1918257768]
 
 [node name="Sign_Ramp" type="CSGBox3D" parent="Ramp Test Zone" unique_id=339405881]
@@ -254,78 +244,102 @@ text = "Zone de test
 Rampe"
 font_size = 25
 
-[node name="Node3D" type="Node3D" parent="Ramp Test Zone" unique_id=1896374786]
+[node name="Ramp5" type="Node3D" parent="Ramp Test Zone" unique_id=1896374786]
 
-[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D" unique_id=917812999]
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Ramp5" unique_id=917812999]
 transform = Transform3D(5.855425899235435e-17, 1, 0, 2.5460997760938166e-17, 0, 1, 1, -5.855425899235437e-17, -2.546099776093817e-17, 6.404213595732221, 0.0647294928676323, 129.6153754121903)
 text = "Pente 12°"
 font_size = 100
 
-[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D" unique_id=931145488 instance=ExtResource("10_uow4d")]
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Ramp5" unique_id=931145488 instance=ExtResource("10_uow4d")]
 transform = Transform3D(-1, 0, 1.2112260603285547e-16, 0, 1, 1.2730498880469083e-17, -1.2112260603285547e-16, 1.2730498880469085e-17, -1, 7.444362397220026, -0.06368266690311497, 132.5073749457498)
 
-[node name="DangerLightBox" parent="Ramp Test Zone/Node3D" unique_id=841267721 instance=ExtResource("16_47dne")]
+[node name="DangerLightBox" parent="Ramp Test Zone/Ramp5" unique_id=841267721 instance=ExtResource("16_47dne")]
 transform = Transform3D(0.9781476007338056, -1.1394447605966131e-17, -0.20791169081775931, 0.20791169081775931, 4.716136900847245e-17, 0.9781476007338056, -1.3400516156310428e-18, -1, 4.849981881064978e-17, 35.91299557211116, 6.183317464645585, 129.5827924521981)
 enabled = true
 
-[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D" unique_id=1202562727]
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Ramp5" unique_id=1202562727]
 transform = Transform3D(6.123032e-17, -0.8910065241883679, -0.45399049973954686, 0, -0.45399049973954686, 0.8910065241883679, -1, -5.455661254091335e-17, -2.779798252780227e-17, 19.62062444127508, 8.220065387072173, 129.6153754121903)
 spot_range = 8.224049
 spot_angle = 89.99
 
-[node name="Rampe_12" type="CSGBox3D" parent="Ramp Test Zone/Node3D" unique_id=464973059]
+[node name="Rampe_12" type="CSGBox3D" parent="Ramp Test Zone/Ramp5" unique_id=464973059]
 transform = Transform3D(6.123032e-17, -0.20791169081775931, 0.9781476007338056, 0, 0.9781476007338056, 0.20791169081775931, -1, -1.2730498880469083e-17, 5.98922883417366e-17, 21.79822125523968, 2.9387532665840994, 129.6153754121903)
 material_override = SubResource("ShaderMaterial_3pv0l")
 use_collision = true
 size = Vector3(4, 0.5, 30)
 material = ExtResource("20_g2xcy")
 
-[node name="Node3D2" type="Node3D" parent="Ramp Test Zone" unique_id=466494529]
+[node name="Ramp10" type="Node3D" parent="Ramp Test Zone" unique_id=466494529]
 
-[node name="Rampe_10" type="CSGBox3D" parent="Ramp Test Zone/Node3D2" unique_id=400744106]
+[node name="Rampe_10" type="CSGBox3D" parent="Ramp Test Zone/Ramp10" unique_id=400744106]
 transform = Transform3D(6.123032e-17, -0.17364817766693033, 0.984807753012208, 0, 0.984807753012208, 0.17364817766693033, -1, -1.0632533085029995e-17, 6.030009158161442e-17, 21.817013892574565, 2.3722571684802434, 120.06739759480439)
 material_override = SubResource("ShaderMaterial_3pv0l")
 use_collision = true
 size = Vector3(4, 0.5, 30)
 material = ExtResource("19_vaq7g")
 
-[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D2" unique_id=64698103]
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Ramp10" unique_id=64698103]
 transform = Transform3D(-8.249538386117887e-17, 0.9998788158903285, -0.015567708044358752, 1.2060018316322883e-16, 0.015567708044358752, 0.9998788158903285, 1, 8.06079182899523e-17, -1.2186983238836413e-16, 6.334190694490024, 0.09761631353060274, 120.06739759480439)
 text = "Pente 10°"
 font_size = 100
 
-[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D2" unique_id=635444026 instance=ExtResource("10_uow4d")]
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Ramp10" unique_id=635444026 instance=ExtResource("10_uow4d")]
 transform = Transform3D(-0.9999999999999999, 0, 1.2153040927273328e-16, 0, 0.9999999999999999, 1.0632533085029995e-17, -1.2153040927273328e-16, 1.0632533085029995e-17, -1, 7.367115514582721, -0.12740731227577307, 122.95939712836389)
 
-[node name="DangerLightBox" parent="Ramp Test Zone/Node3D2" unique_id=293144058 instance=ExtResource("16_47dne")]
+[node name="DangerLightBox" parent="Ramp Test Zone/Ramp10" unique_id=293144058 instance=ExtResource("16_47dne")]
 transform = Transform3D(0.984807753012208, -9.704298519006013e-18, -0.17364817766693033, 0.17364817766693033, 4.966720733373556e-17, 0.984807753012208, -9.322483757532308e-19, -1, 5.059778460608887e-17, 36.03642352783194, 5.122246345969259, 120.03481463481221)
 enabled = true
 
-[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D2" unique_id=587990453]
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Ramp10" unique_id=587990453]
 transform = Transform3D(6.123032e-17, -0.9063077870366499, -0.4226182617406995, 0, -0.4226182617406995, 0.9063077870366499, -1, -5.549351372618897e-17, -2.5877050428451456e-17, 19.825058746686185, 7.726349089149127, 120.06739759480439)
 spot_range = 8.224049
 spot_angle = 89.99
 
-[node name="Node3D3" type="Node3D" parent="Ramp Test Zone" unique_id=42894132]
+[node name="Ramp12" type="Node3D" parent="Ramp Test Zone" unique_id=42894132]
 
-[node name="CSGBox3D" type="CSGBox3D" parent="Ramp Test Zone/Node3D3" unique_id=1837986822]
+[node name="CSGBox3D" type="CSGBox3D" parent="Ramp Test Zone/Ramp12" unique_id=1837986822]
 transform = Transform3D(6.123032e-17, -0.17395755557285325, 0.9847531512308644, 0, 0.9847531512308644, 0.17395755557285325, -1, -1.0651476392496269e-17, 6.029674829719625e-17, 21.994046355345162, 2.5083121583594385, 110.29301876756638)
+use_collision = true
 size = Vector3(4, 0.2, 30)
 material = ExtResource("16_a2whl")
 
-[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Node3D3" unique_id=224538594]
+[node name="Label3D" type="Label3D" parent="Ramp Test Zone/Ramp12" unique_id=224538594]
 transform = Transform3D(-7.194179054300576e-17, 0.9961672681478451, -0.08746870223605369, 1.2199127660437309e-16, 0.08746870223605369, 0.9961672681478451, 1, 6.099563830218654e-17, -1.2781637180818118e-16, 6.390114833647257, 0.0972575931008306, 110.29301876756638)
 text = "Pente 5°"
 font_size = 100
 
-[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Node3D3" unique_id=1732295820 instance=ExtResource("10_uow4d")]
+[node name="OutdoorLamppost2_2005" parent="Ramp Test Zone/Ramp12" unique_id=1732295820 instance=ExtResource("10_uow4d")]
 transform = Transform3D(-0.9999999506519783, -0.00031415926019123797, 1.2222998502419448e-16, -0.00031415926019123797, 0.9999999506519783, 5.3560901959521604e-18, -1.2223166165772e-16, 5.3176902499713156e-18, -1, 7.392213327540999, -0.1325422096927431, 113.18501830112588)
 
-[node name="DangerLightBox" parent="Ramp Test Zone/Node3D3" unique_id=257104562 instance=ExtResource("16_47dne")]
+[node name="DangerLightBox" parent="Ramp Test Zone/Ramp12" unique_id=257104562 instance=ExtResource("16_47dne")]
 transform = Transform3D(0.9851183269910428, -5.123071552455654e-18, -0.1718775198400559, 0.1718775198400559, 5.563972499123873e-17, 0.9851183269910428, 4.5163862592663795e-18, -1, 5.569225363001004e-17, 36.19292219332728, 5.124210994758235, 110.2604358075742)
 enabled = true
 
-[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Node3D3" unique_id=1847057749]
+[node name="SpotLight3D" type="SpotLight3D" parent="Ramp Test Zone/Ramp12" unique_id=1847057749]
 transform = Transform3D(6.123032e-17, -0.9395851256187389, -0.3423153395862047, 0, -0.3423153395862047, 0.9395851256187389, -1, -5.753109573948521e-17, -2.096007699340655e-17, 20.48513281768604, 6.609660576623848, 110.29301876756638)
 spot_range = 8.224049
 spot_angle = 89.99
+
+[node name="Mining test Zone" type="Node3D" parent="." unique_id=419391246]
+
+[node name="MiningDepot" parent="Mining test Zone" unique_id=1889403175 instance=ExtResource("14_4lkw2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.439176267583754, 2.3517123357506797, 88.31635010584525)
+placeholder = true
+
+[node name="OutdoorLamppost2_2005" parent="Mining test Zone" unique_id=1239394709 instance=ExtResource("10_uow4d")]
+transform = Transform3D(6.123436222361646e-17, 0, 1, 0, 1, 0, -1, 0, 6.123436222361646e-17, 7.822804687597224, 2.3986518313260676, 93.6169283414612)
+
+[node name="OutdoorLamppost2_2006" parent="Mining test Zone" unique_id=550606329 instance=ExtResource("10_uow4d")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.862261152078986, 2.359688368788041, 82.97764537730104)
+
+[node name="Sign_Ramp" type="CSGBox3D" parent="Mining test Zone" unique_id=1734817137]
+transform = Transform3D(6.123032e-17, 0, 1, 0, 1, 0, -1, 0, 6.123032e-17, 6.968059494806134, 0.7379370289984281, 88.35454224167727)
+size = Vector3(1, 0.5, 0.1)
+
+[node name="Label3D" type="Label3D" parent="Mining test Zone/Sign_Ramp" unique_id=518656997]
+transform = Transform3D(-1, 1.2246064e-16, 1.71536e-32, 1.224606353822377e-16, 1, 0, -4.591235121303105e-49, 0, -1, 0.004136012337443859, 0.010219451424017749, -0.0534855244709785)
+modulate = Color(0.8391672, 0.55991113, 0.23282835, 1)
+text = "Zone de test 
+Minage"
+font_size = 25

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -60,6 +60,10 @@ var spawn_rotation: Vector3 = Vector3.UP
 
 var server_last_position = Vector3.ZERO
 var server_last_rotation = Vector3.ZERO
+# Last parent_id replicated + frames left to keep resending it after a change (PropNet), so a
+# single lost drop/settle message can't strand this piece under its old parent on clients.
+var server_last_parent_id: String = ""
+var server_parent_resend: int = 0
 
 var has_parent: bool = false
 # True while we briefly leave the tree to reparent (carry/drop): tells _exit_tree NOT
@@ -421,6 +425,22 @@ func _make_inner_material() -> ShaderMaterial:
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
 	has_parent = true
+	_apply_carry_collision_exception(parent)
+
+## Client: if WE (the local player) are the new parent, we're carrying this piece — ignore
+## collisions between us and it so our own move_and_slide isn't blocked. Otherwise clear any
+## stale exception so it stays solid to us (on the ground or carried by someone else).
+func _apply_carry_collision_exception(parent: Node) -> void:
+	if GameOrchestrator.is_server():
+		return
+	var agent = NetworkOrchestrator.network_agent
+	var local_player = agent.player_entity if agent != null and "player_entity" in agent else null
+	if local_player == null or not (local_player is PhysicsBody3D):
+		return
+	if parent == local_player:
+		add_collision_exception_with(local_player)
+	else:
+		remove_collision_exception_with(local_player)
 
 func client_channel_data_update(data: Dictionary) -> void:
 	if data.has("parent_id"):
@@ -471,12 +491,10 @@ func interact(_interactor: Node = null) -> bool:
 	return is_fully_fractured() and not carried
 
 ## Mark/unmark as carried so another player can't grab it while it is in hands.
-## A carried ore must not generate collision (issue #124): a frozen body acts like a
-## static wall in front of the player, so disable its body shape while carried.
+## A carried ore KEEPS its collision (solid to the world and other players); the carrier adds a
+## collision exception with it instead, so it isn't blocked by the piece it carries (issue #124).
 func set_carried(value: bool) -> void:
 	carried = value
-	if rock_shape:
-		rock_shape.disabled = value
 
 ## Geometry center relative to the body origin: a cut piece keeps the original rock's
 ## pivot, so its mesh sits off to one side. The carrier uses this to hold the ore by its

--- a/scenes/structures/mining_depot.gd
+++ b/scenes/structures/mining_depot.gd
@@ -53,6 +53,19 @@ func _ready() -> void:
 		if GameOrchestrator.is_server():
 			await get_tree().create_timer(1).timeout
 			var parent = get_parent()
+			# Find the real networked parent up the tree (skip grouping / test-zone folder nodes
+			# that have no uuid), so grouping the placeholder under a folder doesn't break placement.
+			var net_parent: Node = parent
+			while net_parent != null and not ("uuid" in net_parent):
+				net_parent = net_parent.get_parent()
+			var parent_uuid: String = str(net_parent.uuid) if net_parent != null else ""
+			# Express the placement in that parent's frame (global if there is no networked parent),
+			# so the depot lands at the SAME world spot whatever the scene grouping.
+			var place_xform: Transform3D = global_transform
+			if net_parent is Node3D:
+				place_xform = (net_parent as Node3D).global_transform.affine_inverse() * global_transform
+			var place_pos: Vector3 = place_xform.origin
+			var place_rot: Vector3 = place_xform.basis.get_euler()
 
 			# Spawn the real networked depot to replace this editor placeholder. Use
 			# spawn_prop_authoritative so it is registered in Horizon AND created locally on
@@ -64,7 +77,7 @@ func _ready() -> void:
 			# needed). Seed from the explicit stable_id, else from the fixed placement position
 			# so no manual setup is required.
 			var uuid_seed: String = stable_id if stable_id != "" \
-				else "%.3f,%.3f,%.3f" % [position.x, position.y, position.z]
+				else "%.3f,%.3f,%.3f" % [global_position.x, global_position.y, global_position.z]
 			var depot_uuid: String = _stable_uuid(uuid_seed)
 			# Designer-placed depot = world infrastructure: protect it from the admin cleanup
 			# tool (only player-spawned depots should be deletable).
@@ -73,14 +86,14 @@ func _ready() -> void:
 				"type": type_name,
 				"uuid": depot_uuid,
 				"position": {
-					"x": position.x,
-					"y": position.y,
-					"z": position.z
+					"x": place_pos.x,
+					"y": place_pos.y,
+					"z": place_pos.z
 				},
 				"rotation": {
-					"x": rotation.x,
-					"y": rotation.y,
-					"z": rotation.z
+					"x": place_rot.x,
+					"y": place_rot.y,
+					"z": place_rot.z
 				},
 				"data": {
 					"state": "idle",
@@ -91,7 +104,7 @@ func _ready() -> void:
 					"active_player": null
 				},
 				"scenename": "scenes/structures/mining_depot.tscn",
-				"parent_id": parent.uuid,
+				"parent_id": parent_uuid,
 			})
 
 		queue_free()

--- a/scenes/structures/mining_depot.tscn
+++ b/scenes/structures/mining_depot.tscn
@@ -163,7 +163,7 @@ size = Vector2(1.5, 0.95)
 size = Vector3(0.2317254395602504, 0.9081811614742036, 1.4966181594172667)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_ke7ee"]
-size = Vector3(0.8475183838172597, 1.5159430815429005, 1.258038524483709)
+size = Vector3(1.2359055290535252, 1.5159430815429005, 1.258038524483709)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_cywas"]
 size = Vector3(1.6661057030960365, 0.142747382725247, 5.571124174060969)
@@ -256,6 +256,7 @@ debug_fill = false
 [node name="miningdepot" parent="." unique_id=2001283544 instance=ExtResource("1_x63ok")]
 
 [node name="platform" parent="miningdepot" index="0" unique_id=459582021]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.9539688, -0.48168185, 0.010096626745741402)
 material_override = SubResource("StandardMaterial3D_8a0gq")
 
 [node name="ramps" parent="miningdepot" index="1" unique_id=1767211288]
@@ -343,11 +344,11 @@ shape = SubResource("BoxShape3D_7mukx")
 debug_color = Color(0.70196074, 0.31287596, 0.24275212, 0.41960785)
 
 [node name="ScreenDetector" type="Area3D" parent="miningdepot/Gui3D" unique_id=1958200926 groups=["screen_area"]]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5530165457661793, -0.9505507095903476, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.7200000000011642, -0.9510000000009313, 0)
 input_ray_pickable = false
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="miningdepot/Gui3D/ScreenDetector" unique_id=383350684]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.07624082, 0.25797153, -0.00753310322761535)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.11795276670711519, 0.25797153000000006, -0.0075331032276153495)
 shape = SubResource("BoxShape3D_ke7ee")
 
 [node name="BoxSpawnOrigin" type="Marker3D" parent="." unique_id=1419126176]

--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -9,6 +9,12 @@
 [sub_resource type="BoxShape3D" id="BoxShape3D_seat"]
 size = Vector3(0.8699799106043429, 1.889733397892087, 1.1162902846483576)
 
+[sub_resource type="QuadMesh" id="QuadMesh_h8en7"]
+size = Vector2(1.5, 0.95)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_urxpd"]
+size = Vector3(0.2317254395602504, 0.9081811614742036, 1.4966181594172667)
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_0ukuj"]
 
 [sub_resource type="ArrayMesh" id="ArrayMesh_wbdvv"]
@@ -82,12 +88,6 @@ _surfaces = [{
 blend_shape_mode = 0
 shadow_mesh = SubResource("ArrayMesh_lj7vy")
 
-[sub_resource type="QuadMesh" id="QuadMesh_h8en7"]
-size = Vector2(1.5, 0.95)
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_urxpd"]
-size = Vector3(0.2317254395602504, 0.9081811614742036, 1.4966181594172667)
-
 [node name="Truck" type="VehicleBody3D" unique_id=1579985098]
 mass = 1000.0
 script = ExtResource("1_vehicle")
@@ -97,6 +97,7 @@ handbrake_release_speed = null
 wheel_visual_drop = 0.26
 motor_max_rpm = 3000.0
 debug_color_driven_wheels = false
+debug_show_cargo_bay = false
 
 [node name="SeatDriver" type="Area3D" parent="." unique_id=924961125 node_paths=PackedStringArray("sit_point")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 1, -1.625)
@@ -125,21 +126,11 @@ shape = SubResource("BoxShape3D_seat")
 [node name="SitPoint" type="Marker3D" parent="SeatPassenger" unique_id=1273635299]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.799259690764528, 0.4925056898217868, -0.35000000000582077)
 
-[node name="screen" type="MeshInstance3D" parent="." unique_id=1870179503]
-transform = Transform3D(3.663081934606527e-17, 0, 0.2906572408545101, -0.35143766769152013, 0.20390232887818477, 1.0454802841958167e-17, -0.48413878604461746, -0.1480132576926291, 1.440248448462935e-17, -0.30728380455130244, 1.082950559708889, -2.2902095473902624)
-material_override = ExtResource("3_lpt68")
-mesh = SubResource("ArrayMesh_tuoiw")
-
-[node name="screen_001" type="MeshInstance3D" parent="." unique_id=1356869307]
-transform = Transform3D(3.663081934606527e-17, 0, 0.2906572408545101, -0.35143766769152013, 0.20390232887818477, 1.0454802841958167e-17, -0.48413878604461746, -0.1480132576926291, 1.440248448462935e-17, -0.30728380455130244, 1.082950559708889, -2.2902095473902624)
-material_override = SubResource("StandardMaterial3D_tuoiw")
-mesh = SubResource("ArrayMesh_j0cs4")
-
 [node name="Gui3D" parent="." unique_id=438346037 node_paths=PackedStringArray("node_viewport", "node_quad", "node_area") instance=ExtResource("4_nd433")]
 transform = Transform3D(-1.8369095e-16, 0, 1, 0, 1, 0, -1, 0, -1.8369095e-16, 0.8808829, 1.5104302, -3.460434821199259)
 visible = false
 node_viewport = NodePath("SubViewport")
-node_quad = NodePath("../screen_001")
+node_quad = NodePath("../Node3D/screen_001")
 node_area = NodePath("ScreenMesh/TouchScreen")
 
 [node name="SubViewport" type="SubViewport" parent="Gui3D" unique_id=2131469253]
@@ -163,3 +154,15 @@ transform = Transform3D(6.123233995736766e-17, 0, 1, 0, 1, 0, -1, 0, 6.123233995
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00057834386825561, 0, 0)
 shape = SubResource("BoxShape3D_urxpd")
 debug_color = Color(0.70196074, 0.31287596, 0.24275212, 0.41960785)
+
+[node name="Node3D" type="Node3D" parent="." unique_id=1506017023]
+
+[node name="screen" type="MeshInstance3D" parent="Node3D" unique_id=1870179503]
+transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932205, -2.2902095473902624)
+material_override = ExtResource("3_lpt68")
+mesh = SubResource("ArrayMesh_tuoiw")
+
+[node name="screen_001" type="MeshInstance3D" parent="Node3D" unique_id=1356869307]
+transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932205, -2.2902095473902624)
+material_override = SubResource("StandardMaterial3D_tuoiw")
+mesh = SubResource("ArrayMesh_j0cs4")

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -191,13 +191,22 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 @export var overload_immobilize: float = 1.2
 ## Size of the cargo bay box. Any massive body that comes to rest inside is absorbed into
 ## the truck (its mass is added once). Defaults roughly match the bed; tune to taste.
-@export var cargo_bay_size: Vector3 = Vector3(2.0, 1.5, 3.1)
+@export var cargo_bay_size: Vector3 = Vector3(2.0, 1.5, 3.1):
+	set(v):
+		cargo_bay_size = v
+		_rebuild_deferred()
 ## Centre of the cargo bay box, relative to the vehicle origin.
-@export var cargo_bay_offset: Vector3 = Vector3(0.0, 1.0, 0.75)
+@export var cargo_bay_offset: Vector3 = Vector3(0.0, 1.0, 0.75):
+	set(v):
+		cargo_bay_offset = v
+		_rebuild_deferred()
 ## A body is locked into the bed once it slows below this speed (m/s).
 @export var cargo_settle_speed: float = 0.6
 ## Show a translucent box marking the cargo bay zone.
-@export var debug_show_cargo_bay: bool = true
+@export var debug_show_cargo_bay: bool = true:
+	set(v):
+		debug_show_cargo_bay = v
+		_rebuild_deferred()
 
 # Networking (GenericProp contract). uuid is set by the prop spawn pipeline; an EMPTY uuid
 # means bench / standalone mode (the vehicle drives locally instead of being replicated).
@@ -349,6 +358,10 @@ func _build_cargo_area() -> void:
 	var area := Area3D.new()
 	area.name = "CargoBay"
 	area.set_meta(GENERATED, true)
+	# Detect cargo via the MASK only; keep this zone off every collision layer so it doesn't eat
+	# the player's interact ray (collide_with_areas) — otherwise you can't aim at a crate inside it.
+	area.collision_layer = 0
+	area.monitorable = false
 	var col := CollisionShape3D.new()
 	var box := BoxShape3D.new()
 	box.size = cargo_bay_size
@@ -469,8 +482,9 @@ func _lock_cargo(body: RigidBody3D) -> void:
 	_locked_cargo[body] = body.mass
 	body.freeze_mode = RigidBody3D.FREEZE_MODE_KINEMATIC
 	body.freeze = true
-	body.collision_layer = 0
-	body.collision_mask = 0
+	# Keep the crate's collision LAYER (so the carry ray can still target it for retrieval); just
+	# stop the truck body and the crate from fighting each other where they overlap in the bed.
+	add_collision_exception_with(body)
 	# Reparent into the bed WITHOUT the prop's _exit_tree firing a delete (server_parent_change
 	# sets server_reparenting), then replicate the reparent so clients ride it in the bed. A raw
 	# reparent() made the prop vanish in-game (its _exit_tree deleted it from Horizon).
@@ -480,6 +494,15 @@ func _lock_cargo(body: RigidBody3D) -> void:
 			body.send_properties_to_client(str(uuid))
 	else:
 		body.reparent(self)
+	_refresh_mass()
+
+## Release a crate from the bed back into the world / a player's hands (carry retrieval): stop
+## ignoring it and drop it from the load. The caller (the carry pickup) then takes ownership.
+func release_cargo(body: Node) -> void:
+	if not _locked_cargo.has(body):
+		return
+	remove_collision_exception_with(body)
+	_locked_cargo.erase(body)
 	_refresh_mass()
 
 func _refresh_mass() -> void:
@@ -669,11 +692,12 @@ func _physics_process(delta: float) -> void:
 		# has physics off; its smoothing + wheels are done in _process.
 		if not GameOrchestrator.is_server():
 			return
+		_release_vanished_occupants()  # free seats whose player disconnected (node freed)
 		_update_cargo()
 		# Keep the body awake while handbraked so _integrate_forces keeps cancelling drift — a
 		# parked truck that fell asleep would roll on a slope (the brake alone can't hold a skid).
 		can_sleep = not _handbrake
-		if _pilot != null:
+		if is_instance_valid(_pilot):
 			_apply_drive(delta)
 		elif _handbrake:
 			_hold_handbrake(delta)  # parked: the hand brake stays on after the driver leaves
@@ -786,6 +810,8 @@ func server_enter(player: Node, seat_name: String = "") -> void:
 	if seat == null or not seat.is_free():
 		return
 	seat.occupant_uuid = str(player.client_uuid) if "client_uuid" in player else ""
+	seat.occupant = player  # kept so we can free the seat if the player disconnects (node freed)
+	seat.occupant_mass = _player_mass(player)
 	if "piloting" in player:
 		player.piloting = true  # server-side walk lock
 		player._seat_node = seat  # the player rides this seat each frame (server)
@@ -808,6 +834,8 @@ func server_exit(player: Node) -> void:
 	if seat == null:
 		return
 	seat.occupant_uuid = ""
+	seat.occupant = null
+	seat.occupant_mass = 0.0
 	if "piloting" in player:
 		player.piloting = false
 		player._seat_node = null
@@ -860,6 +888,27 @@ func _find_seat_of(player: Node) -> Node:
 
 func _replicate_pilot() -> void:
 	emit_signal("hs_server_prop_update", uuid, {"pilot_uuid": pilot_uuid}, type_name, has_parent)
+
+## Free any seat whose occupant vanished (a player who disconnected while seated has their node
+## freed by the network layer). Without this the seat stays "taken" forever and a freed _pilot
+## would crash the drive code. Cheap: a couple of seats per vehicle, checked each server tick.
+func _release_vanished_occupants() -> void:
+	var changed := false
+	for seat in _seats():
+		if seat.occupant_uuid == "" or is_instance_valid(seat.occupant):
+			continue
+		_occupant_mass = maxf(0.0, _occupant_mass - seat.occupant_mass)
+		seat.occupant_uuid = ""
+		seat.occupant = null
+		seat.occupant_mass = 0.0
+		changed = true
+		if seat.is_driver_seat():
+			_pilot = null
+			pilot_uuid = ""
+			_replicate_pilot()
+		print("🚚 Vehicle %s: freed a seat whose occupant disconnected" % uuid)
+	if changed:
+		_refresh_mass()
 
 ## Read WASD and apply traction / steering / brake. The forward force comes from the chosen
 ## powertrain (electric or thermal). Reused later by the pilot path.

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -456,7 +456,8 @@ func _update_cargo() -> void:
 	if _cargo_area == null:
 		return
 	for body in _cargo_area.get_overlapping_bodies():
-		if body == self or _locked_cargo.has(body):
+		# Never swallow another vehicle as cargo (drivers WILL ram a truck into a bed).
+		if body == self or body is Vehicle or _locked_cargo.has(body):
 			continue
 		if body is RigidBody3D and body.mass > 0.0 and not body.freeze:
 			if body.linear_velocity.length() < cargo_settle_speed:

--- a/scenes/vehicles/vehicle_seat.gd
+++ b/scenes/vehicles/vehicle_seat.gd
@@ -20,6 +20,10 @@ enum Role {DRIVER, PASSENGER}
 
 ## Server-authoritative occupant (a player's client_uuid). "" = free.
 var occupant_uuid: String = ""
+## The occupant's player node, kept so the vehicle can tell when a player vanished (disconnect)
+## and free the seat. occupant_mass is what that player added to the truck, to subtract back.
+var occupant: Node = null
+var occupant_mass: float = 0.0
 
 func _ready() -> void:
 	add_to_group("vehicle_seat")

--- a/server/client.gd
+++ b/server/client.gd
@@ -578,12 +578,15 @@ func create_generic_object(event: Dictionary) -> void:
 
 	if props_list[object_type].has(object_id):
 		var prop_instance = props_list[object_type][object_id]
-		# manage special case for new parent
+		# manage special case for new parent (only when it actually changes — parent_id rides the
+		# 30/s zone-0 channel, so reapplying it every frame would churn the carry).
 		if object_data.has("parent_id"):
 			if object_data["parent_id"] != "":
 				var parent = _search_parent_node(object_data["parent_id"])
-				if parent != null:
+				if parent != null and prop_instance.get_parent() != parent:
 					prop_instance.client_parent_change(parent)
+			elif prop_instance.get_parent() != universe_scene:
+				prop_instance.client_parent_change(universe_scene)
 		#print("client_channel_data_update (1) for existing object %s" % object_id)
 		prop_instance.client_channel_data_update(object_data)
 
@@ -726,15 +729,17 @@ func update_generic_object(event: Dictionary) -> void:
 	if props_list.has(object_type):
 		if props_list[object_type].has(object_id):
 			var prop_instance = props_list[object_type][object_id]
-			# Special case for new parent_id
+			# Reparent ONLY when the parent actually changes. parent_id rides zone 0 (30/s), so without
+			# this guard we'd reparent every prop every frame (spam + churn that fights the carry).
 			if object_data.has("parent_id"):
-				print("Generic object %s parent change to %s" % [object_id, object_data["parent_id"]])
 				if object_data["parent_id"] != "":
-					print("Generic object %s parent not empty" % [object_id])
 					var parent = _search_parent_node(object_data["parent_id"])
-					print("Generic object %s parent found: %s" % [object_id, parent])
-					if parent != null:
+					if parent != null and prop_instance.get_parent() != parent:
 						prop_instance.client_parent_change(parent)
+				elif prop_instance.get_parent() != universe_scene:
+					# parent_id "" -> dropped to the world root. Reparent, else it stays stuck under
+					# its old parent (truck/player) on the client (it was never moved back).
+					prop_instance.client_parent_change(universe_scene)
 
 			#print("client_channel_data_update (5) for existing object %s" % object_id)
 			prop_instance.client_channel_data_update(object_data)


### PR DESCRIPTION
## Description

Makes carriables (crates, rocks) work end-to-end with vehicle beds and makes carry
replication reliable: retrieve an item you put in a bed, cargo no longer vanishes, a
vehicle can't be loaded into another's bed, seated players count in the load, and a seat
is freed when its occupant disconnects. Carried objects are now solid to the world/others
but not to the carrier. Also tolerates any scene grouping (no uuid-crash), fixes the mining
depot placement, and bundles the sandbox test zones + truck tuning used to validate it.
Server-authoritative throughout.

Known limitation: dropping an item that just came out of a bed can stay visually in the
carrier's hand on the client (the server drops it correctly) — a Horizon/GORC replication
quirk to fix server-side, tracked separately.

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
- You can now retrieve a crate or rock you placed in a vehicle's bed.
- Cargo placed in a bed no longer disappears in multiplayer.
- A vehicle can no longer be loaded into another vehicle's bed.
- Seated players now count toward the vehicle's load (OVERLOADED).
- "[E] Carry" / "[E] Drop" prompts when aiming at a grabbable object or holding one.
- Carried objects are solid to the world and other players (but not to the carrier).
- A vehicle seat is freed when its occupant disconnects.
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
- On peut désormais récupérer une caisse ou un rocher déposé dans la benne d'un véhicule.
- Le chargement posé en benne ne disparaît plus en multijoueur.
- Un véhicule ne peut plus être chargé dans la benne d'un autre véhicule.
- Les passagers comptent dans la charge du véhicule (SURCHARGE).
- Invites « [E] Carry » / « [E] Drop » quand on vise un objet ou qu'on en porte un.
- Les objets portés sont solides pour le monde et les autres joueurs (pas pour le porteur).
- Un siège de véhicule se libère quand son occupant se déconnecte.
<!-- /CHANGELOG_FR -->
