### PR TITLE
Add vehicle head lights, fix the parking brake creep, spill cargo on … (feat/vehicle-headlights-parking)

### DIFF
--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -308,6 +308,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		# Reset the vehicle upright (server-authoritative; driver only).
 		client_send_action_to_server({"action": "reset_vehicle", "target_uuid": _seat_vehicle_uuid})
 
+	if _seat_is_driver and _seat_vehicle_uuid != "" and event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_L:
+		# Toggle the vehicle head lights (server-authoritative; driver only).
+		client_send_action_to_server({"action": "vehicle_lights", "target_uuid": _seat_vehicle_uuid})
+
 	# Capture mouse look even while seated (free look in a vehicle), before the walk guard.
 	if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
 		mouse_motion = -event.relative * 0.001
@@ -317,9 +321,10 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(JUMP):
 		client_send_action_to_server({"action": JUMP})
 
-	if event.is_action_pressed("toggle_flashlight"):
+	if event.is_action_pressed("toggle_flashlight") and _seat_vehicle_uuid == "":
+		# On foot only: L toggles the player's flashlight. In a vehicle, L drives the head lights
+		# instead (see the KEY_L driver handler above), so the two never fire at once.
 		client_send_action_to_server({"action": "toggle_flashlight"})
-		# flashlight.visible = not flashlight.visible
 
 	if event.is_action_pressed("toggle_tool"):
 		if admin_cleanup_tool != null:
@@ -1033,12 +1038,12 @@ func client_channel_data_update(data: Dictionary) -> void:
 			data["rotation"]["y"],
 			data["rotation"]["z"]
 		)
+	if data.has("flashlight"):
+		flashlight.visible = bool(data["flashlight"])  # replicated torch state (owner + remotes)
 	if data.has("action"):
 		match data["action"]:
 			JUMP:
 				is_jumping = true
-			"toggle_flashlight":
-				flashlight.visible = not flashlight.visible
 	# Replicated mining state (tool visibility, camera aim, perforation) is applied
 	# on remote players by the MiningTool component.
 	if remote_player:
@@ -1160,7 +1165,10 @@ func server_action_received(data: Dictionary) -> void:
 		JUMP:
 			is_jumping = true
 		"toggle_flashlight":
+			# Server-authoritative: flip the state and replicate it so the owner AND other players
+			# see the torch (replicated as a state, not the action — a missed event can't desync it).
 			flashlight.visible = not flashlight.visible
+			server_send_properties_to_client({"flashlight": flashlight.visible})
 		"screen_state":
 			# A 3D screen (mining depot) button was pressed: route it to that screen.
 			if screen_interacting and screen_interacting.has_method("update_screen"):
@@ -1250,6 +1258,10 @@ func server_action_received(data: Dictionary) -> void:
 			var veh_h := _find_vehicle(str(data.get("target_uuid", "")))
 			if veh_h != null and veh_h._pilot == self and veh_h.has_method("toggle_handbrake"):
 				veh_h.toggle_handbrake()
+		"vehicle_lights":
+			var veh_l := _find_vehicle(str(data.get("target_uuid", "")))
+			if veh_l != null and veh_l._pilot == self and veh_l.has_method("toggle_headlights"):
+				veh_l.toggle_headlights()
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/normal_player/normal_player.tscn
+++ b/scenes/normal_player/normal_player.tscn
@@ -85,8 +85,9 @@ collide_with_areas = true
 collide_with_bodies = false
 
 [node name="Torch" type="SpotLight3D" parent="CameraPivot/Camera3D" unique_id=1256401590]
+visible = false
 light_energy = 2.0
-spot_range = 200.0
+spot_range = 55.0
 spot_angle = 41.4246
 
 [node name="AreaDetector" type="Area3D" parent="." unique_id=972717439]

--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -93,7 +93,6 @@ mass = 1000.0
 script = ExtResource("1_vehicle")
 engine_power = 850.0
 max_speed_kmh = 55.0
-handbrake_release_speed = null
 wheel_visual_drop = 0.26
 motor_max_rpm = 3000.0
 debug_color_driven_wheels = false
@@ -158,11 +157,59 @@ debug_color = Color(0.70196074, 0.31287596, 0.24275212, 0.41960785)
 [node name="Node3D" type="Node3D" parent="." unique_id=1506017023]
 
 [node name="screen" type="MeshInstance3D" parent="Node3D" unique_id=1870179503]
-transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932205, -2.2902095473902624)
+transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932203, -2.2902095473902624)
 material_override = ExtResource("3_lpt68")
 mesh = SubResource("ArrayMesh_tuoiw")
 
 [node name="screen_001" type="MeshInstance3D" parent="Node3D" unique_id=1356869307]
-transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932205, -2.2902095473902624)
+transform = Transform3D(3.6630819346065263e-17, 0, 0.29065724085451006, 0.17880044975726603, 0.24044399929679136, -5.319075392642577e-18, -0.5709020910732509, 0.07530449772023325, 1.6983577325215963e-17, -0.30728380455130244, 1.8425419393932203, -2.2902095473902624)
 material_override = SubResource("StandardMaterial3D_tuoiw")
 mesh = SubResource("ArrayMesh_j0cs4")
+
+[node name="Retro" type="Node3D" parent="." unique_id=241733783]
+
+[node name="RetroL" type="MeshInstance3D" parent="Retro" unique_id=655497253]
+transform = Transform3D(-0.3170223113008912, -0.21367460653674272, 1.5092741815829104e-17, -1.762937452191217e-33, 1.5427620320199737e-17, 0.29065724085451006, -0.507341751251217, 0.13351871290609493, -9.430991796991935e-18, -1.1450000000040745, 1.8429999999934807, -2.1999999999970896)
+material_override = ExtResource("3_lpt68")
+mesh = SubResource("ArrayMesh_tuoiw")
+
+[node name="RetroD" type="MeshInstance3D" parent="Retro" unique_id=949377116]
+transform = Transform3D(-0.31702231130089115, 0.21367460653674272, -1.50927418158291e-17, 0, 1.5427620320199737e-17, 0.29065724085451006, 0.5073417512512172, 0.1335187129060949, -9.430991796991932e-18, 1.1116747671982483, 1.8429999999934807, -2.1385892980616505)
+material_override = ExtResource("3_lpt68")
+mesh = SubResource("ArrayMesh_tuoiw")
+
+[node name="Recul" type="Node3D" parent="." unique_id=683381723]
+
+[node name="Recul" type="MeshInstance3D" parent="Recul" unique_id=1075437571]
+transform = Transform3D(3.6630819346065263e-17, 0, -0.29065724085451006, 0, 0.2519604813750204, 0, 0.5982464361993399, 0, 1.7797035196745698e-17, 0, 1.796158528473477, -1.6413238987596117)
+material_override = ExtResource("3_lpt68")
+mesh = SubResource("ArrayMesh_tuoiw")
+
+[node name="Light" type="Node3D" parent="." unique_id=2071163623]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5855397533027074, 0)
+
+[node name="SpotLight3DL" type="SpotLight3D" parent="Light" unique_id=850312889 groups=["vehicle_light"]]
+transform = Transform3D(1, 0, 0, 0, 0.9365560045835761, 0.35051797425873754, 0, -0.35051797425873765, 0.9365560045835759, -0.6999999999970896, 0, -2.1999999999970896)
+spot_range = 150.0
+spot_angle = 37.0
+
+[node name="SpotLight3DR" type="SpotLight3D" parent="Light" unique_id=889490272 groups=["vehicle_light"]]
+transform = Transform3D(1, 0, 0, 0, 0.9612616959383189, 0.27563735581699916, 0, -0.27563735581699916, 0.9612616959383189, 0.6999999999970896, 0, -2.1999999999970896)
+spot_range = 150.0
+spot_angle = 37.0
+
+[node name="Cabin" type="OmniLight3D" parent="Light" unique_id=1138993396 groups=["vehicle_light"]]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.0759039289246832, -2.0053647138837216)
+light_energy = 0.3
+
+[node name="RearSpotLight3DL2" type="SpotLight3D" parent="Light" unique_id=1571705372 groups=["vehicle_light"]]
+transform = Transform3D(-1, 4.292465384061989e-17, -1.1469124339235464e-16, 0, 0.9365560045835758, 0.3505179742587379, 1.2246064e-16, 0.3505179742587379, -0.9365560045835758, 0.6999999999970896, 0, 2.269941584191669)
+light_color = Color(1, 0.039215688, 0.0627451, 1)
+spot_range = 10.0
+spot_angle = 37.0
+
+[node name="RearSpotLight3DR2" type="SpotLight3D" parent="Light" unique_id=1027222496 groups=["vehicle_light"]]
+transform = Transform3D(-1, 3.3754725728429654e-17, -1.1771671805321395e-16, 0, 0.9612616959383189, 0.27563735581699916, 1.2246064e-16, 0.27563735581699916, -0.9612616959383189, -0.6999999999970896, 0, 2.269941584191669)
+light_color = Color(1, 0.039215688, 0.0627451, 1)
+spot_range = 10.0
+spot_angle = 37.0

--- a/scenes/vehicles/trucks/truck_ui.tscn
+++ b/scenes/vehicles/trucks/truck_ui.tscn
@@ -284,4 +284,15 @@ texture = ExtResource("3_jrjvv")
 expand_mode = 1
 stretch_mode = 4
 
+[node name="Light" type="Label" parent="." unique_id=143848626]
+layout_mode = 0
+offset_left = 305.0
+offset_top = 415.0
+offset_right = 1626.0
+offset_bottom = 525.0
+text = "Light ON"
+label_settings = SubResource("LabelSettings_7dvew")
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [connection signal="pressed" from="VB/Battery/TriggerCollect" to="." method="_on_trigger_collect_pressed"]

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -34,6 +34,8 @@ const GENERATED := "vehicle_generated"
 # Bench: the real mining rock scene, reused to test loading the bed.
 const ROCK_SCENE := preload("res://scenes/props/rock/rock_mining_01.tscn")
 const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
+## Group a dev adds to any Light3D in their vehicle scene to make it a head light (drop-in, no code).
+const LIGHT_GROUP := "vehicle_light"
 
 # --- Driving ------------------------------------------------------------------
 @export_group("Drive")
@@ -63,6 +65,10 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 ## FULLY cancels motion each frame — a heavy parked truck must NOT move from a player bump or a
 ## gentle slope. Above it (a genuine vehicle ramming) it's only damped, so a real hit still pushes.
 @export var handbrake_release_speed: float = 2.0
+## Once the hand brake has the vehicle below this speed (m/s) it is FROZEN (static) so it can't
+## creep at all — a dynamic body keeps drifting slowly even with the drift cancel. Throttle
+## releases the hand brake and unfreezes it.
+@export var park_freeze_speed: float = 0.4
 ## Maximum steering angle of the front wheels, in degrees.
 @export var max_steer_deg: float = 30.0
 ## How fast the steering reaches its target angle (higher = snappier).
@@ -202,6 +208,9 @@ const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 		_rebuild_deferred()
 ## A body is locked into the bed once it slows below this speed (m/s).
 @export var cargo_settle_speed: float = 0.6
+## Tilt (degrees from upright) past which the bed unlocks and spills its load — a rollover drops
+## the cargo (GDD: the lock releases on a certain inclination). 0 disables.
+@export var cargo_unlock_tilt_deg: float = 65.0
 ## Show a translucent box marking the cargo bay zone.
 @export var debug_show_cargo_bay: bool = true:
 	set(v):
@@ -244,6 +253,8 @@ var _net_last_mass: float = -1.0  # server: last replicated total mass (kg), cha
 var _handbrake: bool = false  # server: hand brake engaged (holds the vehicle until throttle)
 var _net_handbrake: bool = false  # client: replicated hand brake state (for the HUD)
 var _net_last_handbrake: bool = false  # server: last replicated hand brake, change detection
+var _headlights_on: bool = false  # server: head lights on/off
+var _net_last_headlights: bool = false  # server: last replicated head lights, change detection
 var _interp := NetInterpolator.new()  # client-side smoothing of the replica
 var _hud: VehicleDebugHud = null  # driver HUD (pilot client only)
 var _powertrain := VehiclePowertrain.new()
@@ -255,6 +266,7 @@ func _ready() -> void:
 		return
 	add_to_group("vehicle")  # so a pilot can find and enter us
 	_sync_powertrain()
+	set_headlights(_headlights_on)  # start in a known state (off) on the server and every client
 	if _is_networked():
 		# Replicated prop: place it where the server spawned it (client_channel_data_update
 		# also applies position/rotation, this is the initial fallback).
@@ -505,6 +517,31 @@ func release_cargo(body: Node) -> void:
 	_locked_cargo.erase(body)
 	_refresh_mass()
 
+## Spill the whole load when the vehicle tips past cargo_unlock_tilt_deg (GDD: the bed lock
+## releases on a rollover). Each piece becomes a free dynamic prop again, back in the world.
+func _check_rollover_unlock() -> void:
+	if _locked_cargo.is_empty() or cargo_unlock_tilt_deg <= 0.0:
+		return
+	if global_transform.basis.y.dot(Vector3.UP) > cos(deg_to_rad(cargo_unlock_tilt_deg)):
+		return  # still upright enough
+	for body in _locked_cargo.keys():
+		_spill_cargo(body)
+
+## Drop one locked piece back into the world (un-freeze, reparent, replicate) — no new carrier.
+func _spill_cargo(body: Node) -> void:
+	release_cargo(body)  # remove from the load + stop ignoring it
+	if body is RigidBody3D:
+		(body as RigidBody3D).freeze = false
+	if body.has_method("set_carried"):
+		body.set_carried(false)
+	var world: Node = get_parent()
+	if body.has_method("server_parent_change"):
+		body.server_parent_change(world)
+		if body.has_method("send_properties_to_client"):
+			body.send_properties_to_client(str(world.uuid) if "uuid" in world else "")
+	elif body is Node3D:
+		(body as Node3D).reparent(world)
+
 func _refresh_mass() -> void:
 	mass = _empty_mass + get_cargo_mass()
 
@@ -694,21 +731,22 @@ func _physics_process(delta: float) -> void:
 			return
 		_release_vanished_occupants()  # free seats whose player disconnected (node freed)
 		_update_cargo()
-		# Keep the body awake while handbraked so _integrate_forces keeps cancelling drift — a
-		# parked truck that fell asleep would roll on a slope (the brake alone can't hold a skid).
-		can_sleep = not _handbrake
+		_check_rollover_unlock()  # spill the load if the truck is tipped over
 		if is_instance_valid(_pilot):
 			_apply_drive(delta)
 		elif _handbrake:
 			_hold_handbrake(delta)  # parked: the hand brake stays on after the driver leaves
+		_apply_park_freeze()  # freeze once stopped so a parked truck can't creep
 		_replicate_transform()
 		return
 	# Bench / standalone: drive locally.
 	_update_cargo()  # absorb settled cargo into the truck (always, even when not driving)
+	_check_rollover_unlock()
 	if _pilot != null:
 		_apply_drive(delta)
 	elif _handbrake:
 		_hold_handbrake(delta)
+	_apply_park_freeze()
 
 ## Server: replicate position/rotation to clients when they change (same shape as a rock).
 ## Client: the replica is frozen (no physics), so roll + steer the wheels visually from
@@ -752,7 +790,8 @@ func _replicate_transform() -> void:
 	var my_mass: float = snappedf(mass, 0.1)  # total weight (empty + cargo + seated players)
 	if my_pos == _net_last_position and my_rot == _net_last_rotation \
 			and my_speed == _net_last_speed and my_cargo == _net_last_cargo_mass \
-			and _handbrake == _net_last_handbrake and my_mass == _net_last_mass:
+			and _handbrake == _net_last_handbrake and my_mass == _net_last_mass \
+			and _headlights_on == _net_last_headlights:
 		return
 	_net_last_position = my_pos
 	_net_last_rotation = my_rot
@@ -760,9 +799,11 @@ func _replicate_transform() -> void:
 	_net_last_cargo_mass = my_cargo
 	_net_last_handbrake = _handbrake
 	_net_last_mass = my_mass
+	_net_last_headlights = _headlights_on
 	var data := {
 		"position": my_pos, "rotation": my_rot, "steering": snapped(steering, 0.001),
 		"speed": my_speed, "cargo_mass": my_cargo, "handbrake": _handbrake, "mass": my_mass,
+		"headlights": _headlights_on,
 	}
 	emit_signal("hs_server_prop_update", uuid, data, type_name, has_parent)
 
@@ -791,6 +832,8 @@ func client_channel_data_update(data: Dictionary) -> void:
 		mass = float(data["mass"])  # replica: show the server's real total weight on the HUD
 	if data.has("handbrake"):
 		_net_handbrake = bool(data["handbrake"])
+	if data.has("headlights"):
+		set_headlights(bool(data["headlights"]))  # mirror the head lights on this replica
 	if data.has("pilot_uuid"):
 		pilot_uuid = str(data["pilot_uuid"])
 
@@ -980,12 +1023,48 @@ func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
 	state.linear_velocity = v_up + v_flat
 	state.angular_velocity = state.angular_velocity.move_toward(Vector3.ZERO, handbrake_hold * state.step)
 
-## Parked hand brake with no driver: lock the wheels + kill the drive. The drift cancel (and the
-## velocity threshold that keeps it pushable by a real hit) is in _integrate_forces, which keeps
-## firing because we hold the body awake (see _physics_process). From _physics_process.
+## Parked hand brake with no driver: lock the wheels + kill the drive. The drift cancel during the
+## stop is in _integrate_forces; once stopped, _apply_park_freeze freezes the body. From _physics_process.
 func _hold_handbrake(_delta: float) -> void:
 	engine_force = 0.0
 	brake = brake_force
+
+## Freeze the vehicle once the hand brake has it nearly stopped, so a parked truck can't creep
+## (a dynamic RigidBody keeps drifting slowly on a slope even with the drift cancel; a fresh
+## sleeping one doesn't). Throttle clears _handbrake in _apply_drive, which unfreezes it here.
+func _apply_park_freeze() -> void:
+	var should_freeze: bool = _handbrake and linear_velocity.length() < park_freeze_speed
+	if should_freeze != freeze:
+		freeze = should_freeze
+
+## Head lights — drop-in like seats: add any Light3D(s) to the group "vehicle_light" anywhere under
+## the vehicle scene (no code). The driver toggles them (L); the state is replicated so every client
+## sees them. Lights are found by group, filtered to this vehicle's own descendants.
+func _headlights() -> Array:
+	var out: Array = []
+	# May be called from client_channel_data_update BEFORE the node is in the tree (spawn): no tree
+	# yet -> no lights. set_headlights still records _headlights_on, applied again in _ready().
+	if not is_inside_tree():
+		return out
+	for n in get_tree().get_nodes_in_group(LIGHT_GROUP):
+		if n is Node3D and is_ancestor_of(n):
+			out.append(n)
+	return out
+
+## Apply the head-light state to every vehicle_light node (runs on the server AND each client replica).
+func set_headlights(on: bool) -> void:
+	_headlights_on = on
+	for light in _headlights():
+		(light as Node3D).visible = on
+
+## Server: flip the head lights; _replicate_transform then pushes the new state to clients.
+func toggle_headlights() -> void:
+	set_headlights(not _headlights_on)
+
+## True when the head lights are on — server state, or the replicated state on a client replica
+## (the dashboard reads this). set_headlights keeps _headlights_on in sync on both sides.
+func is_headlights_on() -> bool:
+	return _headlights_on
 
 ## Forward speed in km/h (positive when driving toward the cab, -Z).
 func _forward_speed_kmh() -> float:

--- a/scenes/vehicles/vehicle_dashboard.gd
+++ b/scenes/vehicles/vehicle_dashboard.gd
@@ -7,7 +7,7 @@ extends Panel
 ## about it (the screen is just another child). Put this script on the UI scene's root.
 ##
 ## Expects these child Labels (rename here if your scene differs):
-## speed, RPM, Load, Overloaded, Elec_THerm, Transmission, hanbreak.
+## speed, RPM, Load, Overloaded, Elec_THerm, Transmission, hanbreak, Light.
 
 var _vehicle: Vehicle = null
 
@@ -18,6 +18,7 @@ var _vehicle: Vehicle = null
 @onready var _powertrain: Label = $Elec_THerm
 @onready var _transmission: Label = $Transmission
 @onready var _handbrake: Label = $hanbreak
+@onready var _light: Label = $Light
 
 func _ready() -> void:
 	_vehicle = _find_vehicle()
@@ -32,6 +33,7 @@ func _process(_delta: float) -> void:
 	_powertrain.text = _vehicle.get_propulsion_name()
 	_transmission.text = _vehicle.get_drive_mode_name()
 	_handbrake.text = "HANDBRAKE" if _vehicle.is_handbraked() else ""
+	_light.text = "LIGHTS" if _vehicle.is_headlights_on() else ""
 
 ## Walk up the tree (through the SubViewport) to the owning Vehicle.
 func _find_vehicle() -> Vehicle:

--- a/scenes/vehicles/vehicle_debug_hud.gd
+++ b/scenes/vehicles/vehicle_debug_hud.gd
@@ -40,7 +40,7 @@ func _process(_delta: float) -> void:
 	var in_game: bool = _vehicle.uuid != ""
 	var trans_suffix := "" if in_game else "   (N)"
 	var keys := (
-		"[Y] exit   [Space] brake   [Hold Space <3km/h] handbrake   [R] flip" if in_game
+		"[Y] exit   [Space] brake   [Hold Space <3km/h] handbrake   [R] flip   [L] lights" if in_game
 		else "[T] rock   [N] drive mode   [Space] brake   [Hold Space <3km/h] handbrake   [R] flip")
 	_label.text = (
 		"Speed: %3.0f km/h%s\nEngine: %5.0f rpm\n%sTransmission: %s%s\nPowertrain: %s\n"


### PR DESCRIPTION
## Description

Adds vehicle head lights (drop-in, like seats), makes L contextual (head lights while driving /
player flashlight on foot), fixes the parking-brake creep (the truck is frozen once stopped so it
can't drift), and spills the bed's load when the vehicle rolls over. Server-authoritative
throughout. Pairs with horizonserver `feat/vehicle-player-light-defs` (vehicle_def `headlights` +
player_def `flashlight`) — merge together.

## Changelog


<!-- CHANGELOG_EN -->
- Vehicle head lights: a dev just drops Light3D(s) into the "vehicle_light" group of their vehicle
  scene (no code); the driver toggles them with L. Shown on the HUD and the in-cab dashboard.
- L is contextual: head lights while driving, the player's flashlight on foot. The flashlight is
  now visible to other players and starts off.
- A parked truck no longer creeps with the hand brake on (it freezes once stopped).
- The bed spills its whole load when the vehicle tips over.
<!-- /CHANGELOG_EN -->


<!-- CHANGELOG_FR -->
- Phares de véhicule : le dev pose juste des Light3D dans le groupe "vehicle_light" de sa scène
  (aucun code) ; le conducteur les bascule avec L. Affichés sur le HUD et le tableau de bord.
- L est contextuel : phares en conduite, torche du joueur à pied. La torche est maintenant visible
  par les autres joueurs et démarre éteinte.
- Un camion à l'arrêt ne flue plus avec le frein à main (il se fige une fois stoppé).
- La benne déverse tout son chargement quand le véhicule se renverse.
<!-- /CHANGELOG_FR -->
