### PR TITLE
Feat/text chat

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -135,10 +135,13 @@ jobs:
           cp client.ini "${{ matrix.build_dir }}/client.ini"
           if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             WS_URL="ws://server.dyingstar-game.space:7040"
+            CHAT_URL="ws://chat.dyingstar-game.space:7080"
           else
             WS_URL="ws://server-preprod.dyingstar-game.space:7040"
+            CHAT_URL="ws://chat-preprod.dyingstar-game.space:7080"
           fi
           sed -i "s|websocket_url=.*|websocket_url=\"${WS_URL}\"|" "${{ matrix.build_dir }}/client.ini"
+          sed -i "s|broker_url=.*|broker_url=\"${CHAT_URL}\"|" "${{ matrix.build_dir }}/client.ini"
 
       - name: Write version.json
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ IncrementalSoundBankData.xml
 *.windows.editor.profile.dll
 
 # Specific DyingStar
-client.ini
+#client.ini
 
 # Prebaked chunk cache (copied locally to speed up Docker builds)
 chunk_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ IncrementalSoundBankData.xml
 *.windows.editor.profile.dll
 
 # Specific DyingStar
-#client.ini
+client.ini
 
 # Prebaked chunk cache (copied locally to speed up Docker builds)
 chunk_cache/

--- a/client.ini
+++ b/client.ini
@@ -8,3 +8,6 @@
 
 [network]
 websocket_url="ws://192.168.49.2:7040"
+
+[chat]
+broker_url="ws://127.0.0.1:9001"

--- a/project.godot
+++ b/project.godot
@@ -30,6 +30,7 @@ SettingsManager="*res://scenes/globals/settings_manager.gd"
 Globals="*res://scenes/globals/globals.gd"
 GameOrchestrator="*res://scenes/globals/game_orchestrator.gd"
 NetworkOrchestrator="*res://scenes/globals/network_orchestrator.gd"
+ChatNetwork="*res://scenes/globals/chat_network.gd"
 uuid="*res://addons/uuid/uuid.gd"
 Endtoend="*res://scenes/globals/endtoend.gd"
 ServerNetwork="*res://server/server_network.gd"
@@ -172,7 +173,7 @@ exit={
 }
 write_in_chat={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":116,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194309,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 toggle_flashlight={

--- a/scenes/globals/chat_network.gd
+++ b/scenes/globals/chat_network.gd
@@ -1,0 +1,194 @@
+extends Node
+
+## Dedicated MQTT transport for the in-game text chat.
+##
+## Single responsibility: own the broker connection, publish outgoing messages and
+## re-emit incoming ones. The UI (DirectChat) binds to this; gameplay networking
+## stays in NetworkOrchestrator. Clients connect DIRECTLY to the broker — the
+## broker (+ JWT auth in production) is the authority for chat, not the game server.
+##
+## Multi-channel "sockets": GENERAL works today. REGION/GROUP/ALLIANCE/DM need a
+## context id (which group? which alliance?). Those gameplay systems do not exist
+## yet, so their channels stay INACTIVE until someone registers an id provider via
+## set_id_provider() — then the channel subscribes and becomes selectable on its
+## own, with no other change. That is the extension point for the future design.
+
+signal message_received(message: ChatMessage)
+## Emitted when the set of usable channels changes (a provider was (un)registered),
+## so the UI can refresh which channels are selectable.
+signal channels_changed
+
+const _MQTT_SCENE := preload("res://addons/mqtt/mqtt.tscn")
+
+# Default broker endpoint (local dev). Overridable via client.ini [chat] broker_url.
+const _DEFAULT_BROKER_URL := "ws://127.0.0.1:9001"
+
+# Channels reachable with a fixed topic (no context id needed).
+const _STATIC_TOPICS := {
+	DirectChat.ChannelE.GENERAL: "chat/general",
+}
+
+# Channels whose topic needs a context id supplied by a provider (the "sockets").
+const _TOPIC_TEMPLATES := {
+	DirectChat.ChannelE.REGION: "chat/region/%s",
+	DirectChat.ChannelE.GROUP: "chat/group/%s",
+	DirectChat.ChannelE.ALLIANCE: "chat/alliance/%s",
+}
+
+var _client: Node = null
+var _connected: bool = false
+# channel (int) -> Callable() returning the context id (String), or "" when none.
+var _id_providers: Dictionary = {}
+
+## Connect to the broker if not already connecting/connected. Safe to call many
+## times. No-op on the headless dedicated server (chat is a client feature).
+func ensure_connected() -> void:
+	if OS.has_feature("dedicated_server"):
+		return
+	if _client != null:
+		return
+
+	var url := _DEFAULT_BROKER_URL
+	var config := ConfigFile.new()
+	if config.load("client.ini") == OK and config.has_section_key("chat", "broker_url"):
+		url = str(config.get_value("chat", "broker_url", url))
+
+	_client = _MQTT_SCENE.instantiate()
+	add_child(_client)
+	_client.received_message.connect(_on_broker_message)
+	_client.broker_connected.connect(_on_broker_connected)
+	_client.broker_connection_failed.connect(_on_broker_connection_failed)
+
+	# Auth: reuse the game JWT (set on the client network agent from --token=).
+	# The broker is anonymous in local dev, so an empty token is fine for now.
+	var token := _player_token()
+	if token != "":
+		_client.user = Globals.player_uuid if Globals.player_uuid != "" else "player"
+		_client.pswd = token
+	if Globals.player_uuid != "":
+		_client.client_id = "ds-" + Globals.player_uuid
+
+	var proto := "ws://"
+	var host := "127.0.0.1"
+	var port := 9001
+	var parsed := _parse_broker_url(url)
+	if not parsed.is_empty():
+		proto = parsed["proto"]
+		host = parsed["host"]
+		port = parsed["port"]
+	print("[chat] connecting to broker %s%s:%d" % [proto, host, port])
+	_client.connect_to_broker(proto, host, port)
+
+## Publish a message on its channel's topic. The author is stamped here from the
+## local player identity so the UI never has to know it. Ignored if the channel is
+## inactive or the broker is not connected.
+func publish_message(message: ChatMessage) -> void:
+	if not _connected or _client == null:
+		return
+	var topic := topic_for_channel(message.channel)
+	if topic == "":
+		return
+	message.author = Globals.player_name
+	_client.publish(topic, JSON.stringify({
+		"author": message.author,
+		"content": message.content,
+		"channel": message.channel,
+	}))
+
+## Register the id provider for a context channel (REGION/GROUP/ALLIANCE/DM).
+## This is the extension point: call it when the matching gameplay system knows
+## the player's group/alliance/region id; the channel then subscribes and shows up.
+func set_id_provider(channel: int, provider: Callable) -> void:
+	_id_providers[channel] = provider
+	if _connected:
+		_subscribe_active_channels()
+	channels_changed.emit()
+
+## Channels currently usable (have a resolvable, non-empty topic). The UI greys out
+## everything not in this list.
+func active_channels() -> Array:
+	var result: Array = []
+	for channel in _STATIC_TOPICS:
+		result.append(channel)
+	for channel in _TOPIC_TEMPLATES:
+		if _resolve_id(channel) != "":
+			result.append(channel)
+	return result
+
+## Resolve a channel to its MQTT topic, or "" when the channel is inactive.
+func topic_for_channel(channel: int) -> String:
+	if _STATIC_TOPICS.has(channel):
+		return _STATIC_TOPICS[channel]
+	if _TOPIC_TEMPLATES.has(channel):
+		var id := _resolve_id(channel)
+		if id != "":
+			return _TOPIC_TEMPLATES[channel] % id
+	return ""
+
+func _resolve_id(channel: int) -> String:
+	if not _id_providers.has(channel):
+		return ""
+	var provider: Callable = _id_providers[channel]
+	if not provider.is_valid():
+		return ""
+	return str(provider.call())
+
+func _player_token() -> String:
+	var agent = NetworkOrchestrator.network_agent
+	if agent != null and "token" in agent:
+		return str(agent.token)
+	return ""
+
+func _subscribe_active_channels() -> void:
+	for channel in active_channels():
+		var topic := topic_for_channel(channel)
+		if topic != "":
+			_client.subscribe(topic)
+
+func _on_broker_connected() -> void:
+	_connected = true
+	print("[chat] broker connected")
+	_subscribe_active_channels()
+
+func _on_broker_connection_failed() -> void:
+	_connected = false
+	push_warning("[chat] broker connection failed (is the textchat broker running / port-forwarded?)")
+
+func _on_broker_message(topic: String, payload: String) -> void:
+	var channel := _channel_for_topic(topic)
+	if channel == DirectChat.ChannelE.UNSPECIFIED:
+		return
+	var data = JSON.parse_string(payload)
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	message_received.emit(ChatMessage.new(
+		str(data.get("content", "")),
+		int(data.get("channel", channel)),
+		str(data.get("author", "")),
+		0.0
+	))
+
+func _channel_for_topic(topic: String) -> int:
+	for channel in _STATIC_TOPICS:
+		if _STATIC_TOPICS[channel] == topic:
+			return channel
+	for channel in _TOPIC_TEMPLATES:
+		if topic_for_channel(channel) == topic:
+			return channel
+	return DirectChat.ChannelE.UNSPECIFIED
+
+## Parse "ws://host:port" into {proto, host, port}. Returns {} on a malformed url.
+func _parse_broker_url(url: String) -> Dictionary:
+	var sep := url.find("://")
+	if sep == -1:
+		return {}
+	var proto := url.substr(0, sep + 3)
+	var rest := url.substr(sep + 3)
+	var colon := rest.rfind(":")
+	if colon == -1:
+		return {}
+	return {
+		"proto": proto,
+		"host": rest.substr(0, colon),
+		"port": int(rest.substr(colon + 1)),
+	}

--- a/scenes/globals/chat_network.gd
+++ b/scenes/globals/chat_network.gd
@@ -60,11 +60,13 @@ func ensure_connected() -> void:
 	_client.broker_connection_failed.connect(_on_broker_connection_failed)
 
 	# Auth: reuse the game JWT (set on the client network agent from --token=).
-	# The broker is anonymous in local dev, so an empty token is fine for now.
+	# mosquitto-go-auth (jwt backend) reads the token from the MQTT USERNAME and just
+	# needs the password to be non-empty. The anonymous dev broker ignores both, so an
+	# empty token (local dev) is fine — we simply connect without credentials then.
 	var token := _player_token()
 	if token != "":
-		_client.user = Globals.player_uuid if Globals.player_uuid != "" else "player"
-		_client.pswd = token
+		_client.user = token
+		_client.pswd = "jwt"
 	if Globals.player_uuid != "":
 		_client.client_id = "ds-" + Globals.player_uuid
 

--- a/scenes/globals/chat_network.gd.uid
+++ b/scenes/globals/chat_network.gd.uid
@@ -1,0 +1,1 @@
+uid://duat4k5partnu

--- a/scenes/globals/network_orchestrator.gd
+++ b/scenes/globals/network_orchestrator.gd
@@ -39,7 +39,6 @@ var metrics_password = ""
 var metrics_verbose_level = 2
 
 var mqtt = preload("res://addons/mqtt/mqtt.tscn")
-var mqtt_client
 var mqtt_client_sdo
 var mqtt_client_metrics
 
@@ -218,83 +217,9 @@ func _on_entity_spawned(entity: Node) -> void:
 func update_all_text_client():
 	get_gameserver_number_players.rpc(network_agent.players_list.size())
 
-###################
-# Chat part       #
-
-func connect_chat_mqtt():
-	mqtt_client = mqtt.instantiate()
-	GameOrchestrator.get_tree().get_current_scene().add_child(mqtt_client)
-
-	mqtt_client.broker_connected.connect(_on_mqtt_broker_connected)
-	mqtt_client.broker_connection_failed.connect(_on_mqtt_broker_connection_failed)
-	mqtt_client.received_message.connect(_on_mqtt_received_message)
-	mqtt_client.verbose_level = server_mqtt_verbose_level
-	#mqtt_client.connect_to_broker("tcp://", "192.168.20.158", 1883)
-	mqtt_client.connect_to_broker("ws://", server_mqtt_url, server_mqtt_port)
-
-func _on_mqtt_received_message(topic, message):
-	if topic == "chat/GENERAL":
-		var chat_data = JSON.parse_string(message)
-		var chat_message = ChatMessage.new(chat_data.msg, 0, chat_data.pseudo, 0.0)
-		var chat_message_for_rpc: Dictionary = {
-			"content": chat_message["content"],
-			"author": chat_message["author"],
-			"channel": chat_message["channel"],
-			"creation_schedule": chat_message["creation_schedule"]
-		}
-		receive_chat_message_from_server.rpc(chat_message_for_rpc)
-	else:
-		print(topic)
-		print(message)
-
-func _on_mqtt_broker_connected():
-	print("[chat] MQTT chat connected")
-	mqtt_client.subscribe("chat/GENERAL")
-	mqtt_client.publish("test", "I'm here NOW")
-
-func _on_mqtt_broker_connection_failed():
-	print("[chat] MQTT chat failed to connecte :(")
-
-@rpc("any_peer", "call_remote", "unreliable")
-func send_chat_message_to_server(message: Dictionary) -> void:
-
-	if not GameOrchestrator.is_server():
-		return
-
-	####################
-	# TRAITER LE MESSAGE SI BESOIN
-	####################
-
-	###################
-	# ENVOI VIA MQTT
-	var channel_name: String = ""
-	if message.has("channel"):
-		match message["channel"]:
-			0:
-				channel_name = "GENERAL"
-				mqtt_client.publish("chat/" + channel_name, JSON.stringify({
-					"pseudo": message["author"],
-					"msg": message["content"],
-				}))
-
-	###################
-	# ENVOI VIA LE SERVEUR LOCAL
-	#receive_chat_message_from_server.rpc(message)
-	###################
-
-# Receives a message from the server
-@rpc("authority", "call_remote", "unreliable")
-func receive_chat_message_from_server(message: Dictionary) -> void:
-	if not GameOrchestrator.is_server():
-		var chat_message = ChatMessage.new(
-			message["content"],
-			message["channel"],
-			message["author"],
-			message["creation_schedule"]
-		)
-		network_agent.receive_chat_message(chat_message)
-
-#endregion
+# Chat transport now lives in the dedicated ChatNetwork autoload
+# (scenes/globals/chat_network.gd): clients connect DIRECTLY to the MQTT broker,
+# so the old server-relay path that used to live here was removed.
 
 #########################
 # SDO / server meshing  #

--- a/server/client.gd
+++ b/server/client.gd
@@ -441,8 +441,6 @@ func create_object(event: Dictionary) -> void:
 		"player":
 			if int(event["channel"]) == 0:
 				create_player(event)
-			# if event["channel"] == 2:
-			# 	set_player_name(event)
 
 		_:
 			# for all props
@@ -495,6 +493,10 @@ func create_player(event: Dictionary) -> void:
 		return
 
 	if event["object_id"] == my_player_uuid:
+		# The server (Horizon) provides our display name (a generated pseudo when the
+		# token is bypassed in dev). It is the single source of truth for the player
+		# name — chat author, labels, HOME plates, future character screens.
+		Globals.player_name = str(player_data.get("name", Globals.player_name))
 		# await get_tree().create_timer(1).timeout
 		var spawned_entity_instance = player_scene.instantiate()
 		spawned_entity_instance.spawn_position = Vector3(

--- a/server/client.gd
+++ b/server/client.gd
@@ -330,11 +330,9 @@ func complete_client_initialization(entity) -> void:
 	player_instance = entity
 	player_instance.player_display_name = ""
 	player_instance.label_player_name.text = player_instance.player_display_name
-	player_instance.direct_chat.connect("send_message", _on_message_from_player)
 	player_instance.connect("hs_client_action_move", _on_client_action_move)
-
-func receive_chat_message(message: ChatMessage) -> void:
-	player_instance.direct_chat.receive_message_from_server(message)
+	# Chat is wired directly to the broker by the ChatNetwork autoload (see
+	# direct_chat.gd / chat_network.gd) — no game-server relay here anymore.
 
 ########################################################################
 # Signal connections
@@ -373,15 +371,6 @@ func _on_client_action_requested(datas: Dictionary) -> void:
 						"ship":
 							var ship_instance_path: String = datas["entity_node"].get_path() if datas.has("entity_node") else ""
 							NetworkOrchestrator.request_release.rpc_id(peer_id, player_instance.get_path(), ship_instance_path)
-
-func _on_message_from_player(message: ChatMessage) -> void:
-	var dictionnary_message = {
-		"content": message.content,
-		"author": player_instance.player_display_name,
-		"channel": message.channel,
-		"creation_schedule": message.creation_schedule
-	}
-	NetworkOrchestrator.send_chat_message_to_server.rpc_id(1, dictionnary_message)
 
 func _on_client_action_move(move_direction: Vector2, move_rotation: Vector3) -> void:
 	# print("action move")

--- a/ui/direct_chat/direct_chat.gd
+++ b/ui/direct_chat/direct_chat.gd
@@ -46,59 +46,135 @@ func _ready():
 	visible = false
 	is_shown = visible
 
-	# Adding different channels to the selector
-	for channel_name in ChannelE.keys():
-		channel_selector.add_item(channel_name)
-	logg("selection du canal par défautl: " + str(ChannelE.keys()[0]))
-	channel_selector.selected = 0
+	# Populate the channel selector (inactive channels are greyed — see _refresh_channels).
+	_refresh_channels()
+
+	# Bind the UI to the chat transport for the local player only (not remote copies,
+	# not the headless server). The owning Player's remote_player flag is the reliable
+	# local/remote signal here (clients talk to Horizon over WebSocket, not Godot's
+	# multiplayer peer, so is_multiplayer_authority() is not usable).
+	if _is_local():
+		send_message.connect(ChatNetwork.publish_message)
+		ChatNetwork.message_received.connect(receive_message_from_server)
+		ChatNetwork.channels_changed.connect(_refresh_channels)
+		ChatNetwork.ensure_connected()
+
+## True only for the local player's chat (not remote player copies, not the server).
+func _is_local() -> bool:
+	return not OS.has_feature("dedicated_server") and owner is Player and not owner.remote_player
 
 func _on_visibility_changed() -> void:
 	pass
 
-func _on_input_text_text_submitted(message: String) -> void:
-	if message.strip_edges() == "":
+## Rebuild the channel dropdown: every channel is listed, but the ones with no
+## active topic (GROUP/ALLIANCE/REGION/DM, whose gameplay systems don't exist yet)
+## are greyed out. They light up automatically once ChatNetwork.set_id_provider()
+## is called for them — this is the multi-channel extension point.
+func _refresh_channels() -> void:
+	channel_selector.clear()
+	var active: Array = ChatNetwork.active_channels()
+	for channel in ChannelE.values():
+		if channel == ChannelE.UNSPECIFIED:
+			continue
+		var index: int = channel_selector.item_count
+		# Use the enum value as the item id so get_selected_id() returns the channel.
+		channel_selector.add_item(ChannelE.keys()[channel], channel)
+		if not (channel in active):
+			channel_selector.set_item_disabled(index, true)
+			channel_selector.set_item_tooltip(index, "À venir")
+	var general_index: int = channel_selector.get_item_index(ChannelE.GENERAL)
+	if general_index != -1:
+		channel_selector.select(general_index)
+
+## Select the next ACTIVE (non-greyed) channel, wrapping around. Inactive channels
+## are skipped so the player never lands on a channel they cannot post to.
+func _cycle_channel() -> void:
+	var count: int = channel_selector.item_count
+	if count == 0:
 		return
-	var channel = channel_selector.get_selected_id()
-	var chat_message = ChatMessage.new(message,channel)
-	emit_signal("send_message", chat_message)
-	#send_message_to_server(nt)
+	var current: int = channel_selector.selected
+	for offset in range(1, count + 1):
+		var next: int = (current + offset) % count
+		if not channel_selector.is_item_disabled(next):
+			channel_selector.select(next)
+			return
+
+func _on_input_text_text_submitted(message: String) -> void:
+	# Enter inside the input line: send (when not empty), then leave write mode.
+	if message.strip_edges() != "":
+		var chat_message = ChatMessage.new(message, channel_selector.get_selected_id())
+		send_message.emit(chat_message)
 	input_field.text = ""
+	_stop_writing()
+
+## TAB, while typing, cycles the chat channel. It is caught here (in _input, before
+## the GUI focus system) so it does NOT move keyboard focus. TAB is intentionally a
+## fixed key (a text-field convention), not a rebindable InputMap action.
+func _input(event: InputEvent) -> void:
+	if not _is_local() or not can_write:
+		return
+	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_TAB:
+		_cycle_channel()
+		get_viewport().set_input_as_handled()
 
 func _unhandled_input(event):
-	if not is_multiplayer_authority(): return
+	if not _is_local(): return
 
-	if is_shown:
+	if not is_shown:
+		# F12 reveals the chat.
 		if event.is_action_pressed("toggle_chat"):
-			visible = false
-			is_shown = false
-			mouse_filter = Control.MOUSE_FILTER_IGNORE
+			_show_chat()
+			get_viewport().set_input_as_handled()
+		return
 
-		if event.is_action_pressed("pause"):
-			GameOrchestrator.change_game_state(GameOrchestrator.GameStates.PAUSE_MENU)
+	# Chat is visible.
+	if event.is_action_pressed("toggle_chat"):
+		_hide_chat()
+		get_viewport().set_input_as_handled()
+		return
 
-		if not can_write:
-			if event.is_action_pressed("write_in_chat"):
-				can_write = true
-				Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-				input_field.grab_focus()
-		else:
-			if event.is_action_pressed("write_in_chat"):
-				input_field.release_focus()
-				can_write = false
-				Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+	if event.is_action_pressed("pause"):
+		_stop_writing()
+		GameOrchestrator.change_game_state(GameOrchestrator.GameStates.PAUSE_MENU)
+		return
 
-			if event is InputEventMouseButton:
-				Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
-				input_field.release_focus()
-				can_write = false
-
+	if not can_write:
+		# Enter opens the input line for typing.
+		if event.is_action_pressed("write_in_chat"):
+			_start_writing()
 			get_viewport().set_input_as_handled()
 	else:
-		if event.is_action_pressed("toggle_chat"):
-			visible = true
-			is_shown = true
-			mouse_filter = Control.MOUSE_FILTER_STOP
-			get_viewport().set_input_as_handled()
+		# While writing, Enter is consumed by the LineEdit (-> _on_input_text_text_submitted,
+		# which sends and closes). A mouse click cancels writing without sending.
+		if event is InputEventMouseButton:
+			_stop_writing()
+		get_viewport().set_input_as_handled()
+
+## Show the chat panel (messages visible, not yet in write mode).
+func _show_chat() -> void:
+	visible = true
+	is_shown = true
+	mouse_filter = Control.MOUSE_FILTER_STOP
+
+## Hide the chat panel, making sure we are not left stuck in write mode.
+func _hide_chat() -> void:
+	_stop_writing()
+	visible = false
+	is_shown = false
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+## Focus the input line: the player can type and the mouse is freed.
+func _start_writing() -> void:
+	can_write = true
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	input_field.grab_focus()
+
+## Leave write mode: release the input line and recapture the mouse for gameplay.
+func _stop_writing() -> void:
+	if input_field.has_focus():
+		input_field.release_focus()
+	can_write = false
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 # Receives a message from the server
 func receive_message_from_server(receveid_message: ChatMessage) -> void:

--- a/ui/direct_chat/direct_chat.gd
+++ b/ui/direct_chat/direct_chat.gd
@@ -37,14 +37,23 @@ var forced_colors := {
 }
 
 @onready var channel_selector: OptionButton = $MarginContainer/VBoxContainer/HBoxContainer/ChannelSelector
+@onready var input_bar: HBoxContainer = $MarginContainer/VBoxContainer/HBoxContainer
 
 func _enter_tree() -> void:
 	if not OS.has_feature("dedicated_server"):
 		connect("visibility_changed", _on_visibility_changed)
 
 func _ready():
-	visible = false
+	# Shown by default (F12 still toggles it). MOUSE_FILTER_IGNORE so the always-visible
+	# panel never steals the mouse/look from gameplay; its children (input field, channel
+	# selector) still receive clicks while writing.
+	visible = true
 	is_shown = visible
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	# The input bar (channel selector + text field) stays hidden until the player
+	# presses Enter to write; the message log is always visible.
+	input_bar.visible = false
 
 	# Populate the channel selector (inactive channels are greyed — see _refresh_channels).
 	_refresh_channels()
@@ -107,14 +116,19 @@ func _on_input_text_text_submitted(message: String) -> void:
 	input_field.text = ""
 	_stop_writing()
 
-## TAB, while typing, cycles the chat channel. It is caught here (in _input, before
-## the GUI focus system) so it does NOT move keyboard focus. TAB is intentionally a
-## fixed key (a text-field convention), not a rebindable InputMap action.
+## While typing, TAB cycles the channel and Escape closes the input. Both are caught
+## here (in _input, before the GUI focus system) — otherwise the focused input field
+## consumes TAB (focus change) and Escape before _unhandled_input sees them. TAB is a
+## fixed text-field key (not a rebindable action).
 func _input(event: InputEvent) -> void:
 	if not _is_local() or not can_write:
 		return
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_TAB:
 		_cycle_channel()
+		get_viewport().set_input_as_handled()
+	elif event.is_action_pressed("pause"):
+		# Escape while typing closes the input (cancels writing) without pausing.
+		_stop_writing()
 		get_viewport().set_input_as_handled()
 
 func _unhandled_input(event):
@@ -133,8 +147,8 @@ func _unhandled_input(event):
 		get_viewport().set_input_as_handled()
 		return
 
+	# Escape while typing is handled in _input (closes the input). Here it pauses.
 	if event.is_action_pressed("pause"):
-		_stop_writing()
 		GameOrchestrator.change_game_state(GameOrchestrator.GameStates.PAUSE_MENU)
 		return
 
@@ -154,7 +168,7 @@ func _unhandled_input(event):
 func _show_chat() -> void:
 	visible = true
 	is_shown = true
-	mouse_filter = Control.MOUSE_FILTER_STOP
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 ## Hide the chat panel, making sure we are not left stuck in write mode.
 func _hide_chat() -> void:
@@ -166,6 +180,7 @@ func _hide_chat() -> void:
 ## Focus the input line: the player can type and the mouse is freed.
 func _start_writing() -> void:
 	can_write = true
+	input_bar.visible = true
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	input_field.grab_focus()
 
@@ -174,6 +189,7 @@ func _stop_writing() -> void:
 	if input_field.has_focus():
 		input_field.release_focus()
 	can_write = false
+	input_bar.visible = false
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 # Receives a message from the server

--- a/ui/direct_chat/direct_chat.tscn
+++ b/ui/direct_chat/direct_chat.tscn
@@ -2,15 +2,20 @@
 
 [ext_resource type="Script" uid="uid://p7wkxaw77bvr" path="res://ui/direct_chat/direct_chat.gd" id="1_2gaj1"]
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_g6bju"]
+
 [node name="DirectChat" type="PanelContainer" unique_id=114847019 node_paths=PackedStringArray("input_field", "output_field")]
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -365.0
-offset_right = 683.0
-grow_vertical = 0
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 20.0
+offset_top = -182.0
+offset_right = 703.0
+offset_bottom = 183.0
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+theme_override_styles/panel = SubResource("StyleBoxEmpty_g6bju")
 script = ExtResource("1_2gaj1")
 input_field = NodePath("MarginContainer/VBoxContainer/HBoxContainer/input_text")
 output_field = NodePath("MarginContainer/VBoxContainer/ScrollContainer/output_text")
@@ -32,6 +37,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 bbcode_enabled = true
 scroll_following = true
+vertical_alignment = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer" unique_id=1578436371]
 custom_minimum_size = Vector2(0, 40)


### PR DESCRIPTION
## Description
Wire a working text chat over the MQTT broker (clients connect directly; the old half-built
server-relay prototype is removed and replaced by a dedicated `ChatNetwork` autoload).

- **UX:** F12 shows/hides; chat shown by default (left, vertically centered); only the message
  log at rest, the input bar appears on **Enter**; **Enter** sends + closes; **Escape** cancels
  typing; **Tab** cycles channels.
- **Channels:** multi-channel scaffold — GENERAL works, GROUP/ALLIANCE/REGION/DM greyed until a
  context-id provider is registered (extension point for future systems).
- **Pseudo:** use the server-provided player name (from Horizon, generated in dev bypass) as the
  single source of truth (chat author, labels…).
- **Auth-ready:** sends the JWT as the MQTT username for go-auth (anonymous broker ignores it).

Tested locally (two clients exchange messages; pseudo shows correctly).

## Changelog

<!-- CHANGELOG_EN -->
Add an in-game text chat: shown by default on the left, F12 to hide/show, Enter to write and send, Escape to cancel, Tab to switch channel.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Ajout d'un chat textuel en jeu : affiché par défaut à gauche, F12 pour masquer/afficher, Entrée pour écrire et envoyer, Échap pour annuler, Tab pour changer de canal.
<!-- /CHANGELOG_FR -->
