### PR TITLE
Honor the WebSocket path in the chat broker_url

### DIFF
--- a/addons/mqtt/mqtt.gd
+++ b/addons/mqtt/mqtt.gd
@@ -278,7 +278,7 @@ func cleanupsockets(retval=false):
 	brokerconnectmode = BCM_NOCONNECTION
 	return retval
 
-func connect_to_broker(brokerprotocol, brokerserver, brokerport): #brokerurl):
+func connect_to_broker(brokerprotocol, brokerserver, brokerport, brokerwspath = "/"): #brokerurl):
 	assert (brokerconnectmode == BCM_NOCONNECTION)
 	#var brokermatch = regexbrokerurl.search(brokerurl)
 	#if brokermatch == null:
@@ -293,7 +293,7 @@ func connect_to_broker(brokerprotocol, brokerserver, brokerport): #brokerurl):
 	#if brokercomponents[3]:
 		#brokerport = int(brokercomponents[3].substr(1)) 
 	#var brokerpath = brokercomponents[4] if brokercomponents[4] else ""
-	var brokerpath = "/"
+	var brokerpath = brokerwspath  # WebSocket path from the caller (e.g. "/mqtt"); "/" by default
 	 
 	common_name = null	
 	if iswebsocket:

--- a/scenes/globals/chat_network.gd
+++ b/scenes/globals/chat_network.gd
@@ -73,13 +73,15 @@ func ensure_connected() -> void:
 	var proto := "ws://"
 	var host := "127.0.0.1"
 	var port := 9001
+	var path := "/"
 	var parsed := _parse_broker_url(url)
 	if not parsed.is_empty():
 		proto = parsed["proto"]
 		host = parsed["host"]
 		port = parsed["port"]
-	print("[chat] connecting to broker %s%s:%d" % [proto, host, port])
-	_client.connect_to_broker(proto, host, port)
+		path = parsed["path"]
+	print("[chat] connecting to broker %s%s:%d%s" % [proto, host, port, path])
+	_client.connect_to_broker(proto, host, port, path)
 
 ## Publish a message on its channel's topic. The author is stamped here from the
 ## local player identity so the UI never has to know it. Ignored if the channel is
@@ -186,6 +188,12 @@ func _parse_broker_url(url: String) -> Dictionary:
 		return {}
 	var proto := url.substr(0, sep + 3)
 	var rest := url.substr(sep + 3)
+	# Split off an optional path (e.g. ".../mqtt") before reading host:port.
+	var path := "/"
+	var slash := rest.find("/")
+	if slash != -1:
+		path = rest.substr(slash)
+		rest = rest.substr(0, slash)
 	var colon := rest.rfind(":")
 	if colon == -1:
 		return {}
@@ -193,4 +201,5 @@ func _parse_broker_url(url: String) -> Dictionary:
 		"proto": proto,
 		"host": rest.substr(0, colon),
 		"port": int(rest.substr(colon + 1)),
+		"path": path,
 	}


### PR DESCRIPTION
## Description

The text-chat `broker_url` could not carry a **path**. When the broker is reverse-proxied behind a sub-path (e.g. `ws://chat-preprod…:7080/mqtt`), the client silently connected to `/` instead:
- `ChatNetwork._parse_broker_url` only returned proto/host/port (the path was dropped);
- the bundled MQTT addon (`addons/mqtt/mqtt.gd`) hardcoded `brokerpath = "/"`.

This parses the path out of `broker_url` and threads it through to the WebSocket connection (`connect_to_broker(..., brokerwspath = "/")`), defaulting to `/` so nothing changes for a root-served broker.

Lets preprod/prod expose the broker on a sub-path through nginx without the client losing it. No config change needed for the local (`ws://…:9001`) setup.

## Changelog

<!-- CHANGELOG_EN -->
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
<!-- /CHANGELOG_FR -->