### PR TITLE
Vehicle cargo bed (drop-to-load, ride, spill) + rear-view camera

### DIFF
--- a/scenes/globals/generic_prop.gd
+++ b/scenes/globals/generic_prop.gd
@@ -22,9 +22,9 @@ var has_parent: bool = false
 var carried: bool = false             # carried by a player (issue #124)
 var server_reparenting: bool = false  # briefly leaving the tree to reparent (carry/drop)
 
-# Client-side smoothing used ONLY while this prop rides a vehicle bed (parent is a Vehicle): the
-# server resends its constant LOCAL bed position every frame, so glide instead of stepping at 30 Hz.
-var _interp := NetInterpolator.new()
+# Last replicated LOCAL pose, re-asserted every render frame while riding a vehicle bed (see _process).
+var _ride_local_pos: Vector3 = Vector3.ZERO
+var _ride_local_rot: Vector3 = Vector3.ZERO
 
 func _enter_tree() -> void:
 	if GameOrchestrator.is_server():
@@ -39,18 +39,14 @@ func _ready() -> void:
 		position = spawn_position
 	# So the carry pickup can resolve this prop by uuid (the client sends what it aims at).
 	add_to_group("carriable")
+	# Created already under a vehicle (cargo loaded before we arrived): ride it (KINEMATIC).
+	PropNet.apply_ride_freeze_mode(self)
 
 func _physics_process(_delta: float) -> void:
 	PropNet.server_tick(self)
 
-## Client: glide a bed-riding crate toward its replicated local position (the truck itself is
-## interpolated in its own _process, so the crate rides the smooth truck AND smooths its own 30 Hz
-## updates). Free crates keep the direct snap in client_channel_data_update — nothing to smooth.
-func _process(delta: float) -> void:
-	if GameOrchestrator.is_server():
-		return
-	if get_parent() is Vehicle:
-		_interp.update_position(self, delta)
+func _process(_delta: float) -> void:
+	PropNet.ride_pin(self)  # hold the constant local bed pose at render rate (no jitter)
 
 func _exit_tree() -> void:
 	# Don't delete on clients when only reparenting (carried/dropped).
@@ -75,8 +71,7 @@ func server_prop_update(data: Dictionary):
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
 	has_parent = true
-	# The local frame just changed: re-snap so the bed smoothing doesn't glide from the old space.
-	_interp.snap_next()
+	PropNet.apply_ride_freeze_mode(self)  # KINEMATIC under a vehicle so it rides the moving truck
 	_apply_carry_collision_exception(parent)
 
 ## Client: if WE (the local player) are the new parent, we're carrying this prop — ignore
@@ -96,24 +91,7 @@ func _apply_carry_collision_exception(parent: Node) -> void:
 
 # receive the update from server, in this example, we manage position and rotation properties
 func client_channel_data_update(data: Dictionary) -> void:
-	# Riding a bed (parent is a Vehicle): smooth the (constant) local position so it doesn't step.
-	var riding: bool = get_parent() is Vehicle
-	if data.has("position"):
-		var local_pos := Vector3(
-			data["position"]["x"],
-			data["position"]["y"],
-			data["position"]["z"]
-		)
-		if riding:
-			_interp.set_position_target(self, local_pos)
-		else:
-			position = local_pos
-	if data.has("rotation"):
-		rotation = Vector3(
-			data["rotation"]["x"],
-			data["rotation"]["y"],
-			data["rotation"]["z"]
-		)
+	PropNet.apply_client_transform(self, data)
 
 # ── Carry contract (issue #124): any generic prop becomes pickable with E ──
 func interact(_interactor: Node = null) -> bool:

--- a/scenes/globals/prop_net.gd
+++ b/scenes/globals/prop_net.gd
@@ -7,6 +7,40 @@ extends RefCounted
 ##
 ## A prop using server_tick MUST expose: `uuid`, `type_name`, `has_parent`,
 ## `server_last_position`, `server_last_rotation` and the `hs_server_prop_update` signal.
+## A prop using the client ride helpers (apply_client_transform / ride_pin) MUST also expose
+## `_ride_local_pos` and `_ride_local_rot`.
+
+## Client: match the freeze mode to the prop's parent. A bed-riding crate must be KINEMATIC so the
+## frozen body follows the moving truck through the scene tree (a STATIC frozen body instead gets its
+## world transform rewritten every physics frame, so it stays put while the truck drives off — the
+## "cargo left behind at speed" bug). Resting in the world stays STATIC.
+static func apply_ride_freeze_mode(prop: RigidBody3D) -> void:
+	if GameOrchestrator.is_server():
+		return  # the server sets KINEMATIC itself on lock; this is the client replica's parenting
+	prop.freeze_mode = (
+		RigidBody3D.FREEZE_MODE_KINEMATIC if prop.get_parent() is Vehicle
+		else RigidBody3D.FREEZE_MODE_STATIC)
+
+## Client: apply a replicated LOCAL pose (position/rotation) and remember it so ride_pin can hold it.
+## Call from a prop's client_channel_data_update (shared by every networked prop).
+static func apply_client_transform(prop: Node3D, data: Dictionary) -> void:
+	if data.has("position"):
+		prop.position = Vector3(data["position"]["x"], data["position"]["y"], data["position"]["z"])
+		prop._ride_local_pos = prop.position
+	if data.has("rotation"):
+		prop.rotation = Vector3(data["rotation"]["x"], data["rotation"]["y"], data["rotation"]["z"])
+		prop._ride_local_rot = prop.rotation
+
+## Client: while riding a bed, re-assert the constant LOCAL pose every render frame. The crate is a
+## physics body, so it otherwise refreshes only at the (slower) physics tick and lags the truck,
+## which is interpolated at render rate -> visible jitter. Call from a prop's _process; the parent
+## (truck) runs first, so a direct set (no lerp) tracks it exactly.
+static func ride_pin(prop: Node3D) -> void:
+	if GameOrchestrator.is_server():
+		return
+	if prop.get_parent() is Vehicle:
+		prop.position = prop._ride_local_pos
+		prop.rotation = prop._ride_local_rot
 
 ## Call from a prop's _physics_process. Replicates position/rotation when they change. While
 ## the prop is CARRIED (parented to a Player), re-sends position + parent_id every frame so

--- a/scenes/globals/settings_manager.gd
+++ b/scenes/globals/settings_manager.gd
@@ -1,5 +1,8 @@
 extends Node
 
+## Emitted when a debug toggle changes, so live systems (e.g. vehicles) react without a restart.
+signal cargo_debug_changed(on: bool)
+
 # user:// is writable in an exported build (res:// is packed read-only), so settings actually
 # persist between sessions there.
 const CONFIG_FILEPATH : String = "user://settings.ini"
@@ -21,6 +24,7 @@ func initialize_settings():
 	config.set_value("video", "v_sync", false)
 	config.set_value("video", "screen_shake", true)
 	config.set_value("video", "dev_mode", false)
+	config.set_value("general", "cargo_debug", false)
 
 func save_settings():
 	config.save(CONFIG_FILEPATH)
@@ -89,6 +93,16 @@ func set_dev_mode(on: bool) -> void:
 
 func is_dev_mode() -> bool:
 	return config.get_value("video", "dev_mode", false)
+
+## Cargo debug: draw a green envelope around items REALLY locked into a vehicle bed (dev aid). Lives
+## under [general]; emits so vehicles toggle their markers live.
+func set_cargo_debug(on: bool) -> void:
+	config.set_value("general", "cargo_debug", on)
+	save_settings()
+	cargo_debug_changed.emit(on)
+
+func is_cargo_debug() -> bool:
+	return config.get_value("general", "cargo_debug", false)
 
 func set_monitor(index: int) -> void:
 	DisplayServer.window_set_current_screen(index)

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -123,7 +123,8 @@ var _owner_carrying: bool = false
 var _los_ray: RayCast3D = null
 
 # Carry prompt, decided by the SERVER (it owns the collisions) and replicated to the owner:
-# "" / "carry" / "drop". The client only displays it — it never computes reachability itself.
+# "" / "carry" / "drop" / "cargo" (cargo = dropping here loads it onto a truck). The client only
+# displays it — it never computes reachability itself.
 var _carry_prompt: String = ""
 var _carry_prompt_timer: float = 0.0  # server-side throttle
 
@@ -447,6 +448,9 @@ func _process(_delta: float) -> void:
 	if not interact_label.visible:
 		if _carry_prompt == "drop":
 			interact_label.text = "[E] Drop"
+			interact_label.show()
+		elif _carry_prompt == "cargo":
+			interact_label.text = "[E] Cargo"  # dropping here loads it onto the truck (sticks)
 			interact_label.show()
 		elif _carry_prompt == "carry":
 			interact_label.text = "[E] Carry"
@@ -1145,6 +1149,15 @@ func _find_vehicle(target_uuid: String) -> Node:
 			return v
 	return null
 
+## Which truck bed should swallow a crate dropped at this world point: any truck whose designer
+## loading zone contains it. Same rule whether we stand in the bed or reach over from outside — the
+## zone (not the player's position) decides whether loading is allowed.
+func _cargo_bed_for_drop(world_point: Vector3) -> Vehicle:
+	for v in get_tree().get_nodes_in_group("vehicle"):
+		if v is Vehicle and v.is_point_in_loading_zone(world_point):
+			return v
+	return null
+
 func _find_mining_rock(rock_uuid: String) -> Node:
 	if rock_uuid == "":
 		return null
@@ -1298,10 +1311,13 @@ func _server_update_carry_prompt(delta: float) -> void:
 		_carry_prompt = state
 		server_send_properties_to_client({"carry_prompt": state})
 
-## What E would do right now (server side): drop if we hold something, else carry if we aim
-## at a grabbable prop that is reachable (not carried by another, clear line of sight).
+## What E would do right now (server side): if we hold something, "cargo" when the drop would load
+## it onto a truck (it sticks), else "drop"; if our hands are empty, "carry" when we aim at a
+## grabbable prop that is reachable (not carried by another, clear line of sight).
 func _compute_carry_prompt() -> String:
 	if hands_item != null:
+		if _cargo_bed_for_drop(hands_item.global_position) != null:
+			return "cargo"  # dropping here loads it into the bed (sticks)
 		return "drop"
 	interact_ray.force_raycast_update()
 	var prop := _aimed_carriable()
@@ -1438,14 +1454,16 @@ func server_action_received(data: Dictionary) -> void:
 					hands_item.set_carried(false)
 				hands_item.remove_collision_exception_with(self)  # it can collide with us again
 				_carry_ignore_vehicles(hands_item, false)  # restore normal collision with vehicles
-				# Drop INTO a bed we are standing in -> load it onto that truck (the bed no longer
-				# polls for cargo; the carrier, who knows it is in the bed, hands it over directly).
-				if is_instance_valid(_in_vehicle_bed) and _in_vehicle_bed is Vehicle \
-						and hands_item is RigidBody3D:
-					_in_vehicle_bed.lock_dropped_cargo(hands_item)
-					hands_item = null
-					server_send_properties_to_client({"carrying": false})
-					return
+				# Drop INTO a bed -> load it onto that truck (the bed no longer polls for cargo). We
+				# load it if we are standing in the bed, OR if we drop it from outside but it lands
+				# inside a nearby truck's cargo bay (e.g. reaching over the side wall).
+				if hands_item is RigidBody3D:
+					var bed := _cargo_bed_for_drop(hands_item.global_position)
+					if bed != null:
+						bed.lock_dropped_cargo(hands_item)
+						hands_item = null
+						server_send_properties_to_client({"carrying": false})
+						return
 				var drop_parent := get_parent()
 				hands_item.server_parent_change(drop_parent)
 				hands_item.freeze = false

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -105,6 +105,9 @@ var _purity := -1.0
 # Mass (kg) of a WHOLE uncut rock — the GameDesigner value set on the RigidBody in the scene,
 # captured at _ready. A cut piece weighs this scaled by its volume ratio (see _refresh_mass).
 var _full_rock_mass: float = 0.0
+# Last replicated LOCAL pose, re-asserted every render frame while riding a vehicle bed (see _process).
+var _ride_local_pos: Vector3 = Vector3.ZERO
+var _ride_local_rot: Vector3 = Vector3.ZERO
 
 @onready var rock_shape = $CollisionShape3D
 
@@ -258,6 +261,8 @@ func _blocs_payload() -> Array:
 
 func _client_ready() -> void:
 	_show_faults()
+	# Created already under a vehicle (piece loaded before we arrived): ride it (KINEMATIC).
+	PropNet.apply_ride_freeze_mode(self)
 
 ## Show each not-yet-fractured fault as a red vein (a thin slice through the rock)
 ## at its cut plane, so faults are visible before perforating.
@@ -446,6 +451,7 @@ func _make_inner_material() -> ShaderMaterial:
 func client_parent_change(parent: Node) -> void:
 	reparent(parent)
 	has_parent = true
+	PropNet.apply_ride_freeze_mode(self)  # KINEMATIC under a vehicle so the piece rides the truck
 	_apply_carry_collision_exception(parent)
 
 ## Client: if WE (the local player) are the new parent, we're carrying this piece — ignore
@@ -470,18 +476,7 @@ func client_channel_data_update(data: Dictionary) -> void:
 		ore_seed = str(data["ore_seed"])
 	if data.has("kick"):
 		_spawn_kick = Vector3(data["kick"]["x"], data["kick"]["y"], data["kick"]["z"])
-	if data.has("position"):
-		position = Vector3(
-			data["position"]["x"],
-			data["position"]["y"],
-			data["position"]["z"]
-		)
-	if data.has("rotation"):
-		rotation = Vector3(
-			data["rotation"]["x"],
-			data["rotation"]["y"],
-			data["rotation"]["z"]
-		)
+	PropNet.apply_client_transform(self, data)  # position/rotation (+ remembers the local ride pose)
 	if data.has("blocs"):
 		blocs = data["blocs"]
 		# _rebuild() needs `_base_mesh`, set in _ready(). When this rock is spawned
@@ -634,6 +629,9 @@ func server_perforate(hit_local: Vector3, push_dir_local: Vector3 = Vector3.ZERO
 
 func _physics_process(_delta: float) -> void:
 	PropNet.server_tick(self)
+
+func _process(_delta: float) -> void:
+	PropNet.ride_pin(self)  # hold the constant local bed pose at render rate (no jitter)
 
 func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 	# Create the complementary half as its own networked rock. It inherits ALL our

--- a/scenes/vehicles/rear_camera.gd
+++ b/scenes/vehicles/rear_camera.gd
@@ -17,11 +17,19 @@ extends Camera3D
 
 ## The cab surface that shows the camera feed (its material_override is replaced by the feed).
 @export var screen: MeshInstance3D
-## Render resolution of the feed. Keep it small — this is a second full 3D render every frame.
+## Render resolution of the feed. Keep it small — each refresh is a second full 3D render.
 @export var resolution: Vector2i = Vector2i(320, 200)
 ## Flip the feed left/right. false = a reversing camera (true view); true = a real mirror (side
 ## mirror / rear-view mirror, which reverses left and right).
 @export var mirror: bool = false
+## How many times per second the feed re-renders. Each render is a full extra 3D pass, so a lower
+## rate is much cheaper on weak GPUs. 0 = render every frame.
+@export var refresh_hz: float = 20.0
+## Beyond this distance (m) from the player's view, the feed stops rendering entirely (the screen
+## keeps its last image). The feed is only readable up close anyway, so far trucks cost nothing.
+@export var max_distance: float = 60.0
+
+var _refresh_accum: float = 0.0
 
 @onready var _viewport: SubViewport = $SubViewport
 @onready var _camera: Camera3D = $SubViewport/Camera3D
@@ -32,22 +40,44 @@ func _ready() -> void:
 	current = false  # this camera is only the placement/preview pose, never the player's view
 	_viewport.size = resolution
 	_viewport.world_3d = get_world_3d()  # render the SAME world, not an empty SubViewport world
+	_viewport.render_target_update_mode = SubViewport.UPDATE_DISABLED  # driven per-frame in _process
 	_camera.current = true
 	_camera.fov = fov
 	if screen != null:
 		var mat := StandardMaterial3D.new()
 		mat.albedo_texture = _viewport.get_texture()
 		mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED  # show the feed as-is, unlit
-		mat.cull_mode = BaseMaterial3D.CULL_DISABLED  # visible on both faces (avoid wrong-side blank)
+		mat.cull_mode = BaseMaterial3D.CULL_BACK  # one-sided: show only on the screen's front face
 		if mirror:
 			# Reverse left/right within the quad's 0..1 UVs, like a real mirror.
 			mat.uv1_scale = Vector3(-1.0, 1.0, 1.0)
 			mat.uv1_offset = Vector3(1.0, 0.0, 0.0)
 		screen.material_override = mat
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	if OS.has_feature("dedicated_server"):
 		return
-	# Mirror this (placeable) camera's pose + lens into the SubViewport's renderer.
+	# Too far from the player's view: stop rendering entirely (the screen keeps its last image).
+	if _is_beyond_max_distance():
+		_viewport.render_target_update_mode = SubViewport.UPDATE_DISABLED
+		return
+	# Keep the SubViewport camera glued to this (placeable) camera's pose + lens.
 	_camera.global_transform = global_transform
 	_camera.fov = fov
+	if refresh_hz <= 0.0:
+		_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+		return
+	# Throttle: render one frame every 1/refresh_hz seconds (UPDATE_ONCE auto-disables after).
+	_refresh_accum += delta
+	if _refresh_accum >= 1.0 / refresh_hz:
+		_refresh_accum = 0.0
+		_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+
+## True when the player's active camera is farther than max_distance from this screen.
+func _is_beyond_max_distance() -> bool:
+	if max_distance <= 0.0:
+		return false  # 0 = no distance culling
+	var view := get_viewport().get_camera_3d()
+	if view == null:
+		return false
+	return global_position.distance_to(view.global_position) > max_distance

--- a/scenes/vehicles/rear_camera.tscn
+++ b/scenes/vehicles/rear_camera.tscn
@@ -1,12 +1,12 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene format=3 uid="uid://bjxceboesdb8w"]
 
-[ext_resource type="Script" path="res://scenes/vehicles/rear_camera.gd" id="1_rcam"]
+[ext_resource type="Script" uid="uid://dham1c3n5htnd" path="res://scenes/vehicles/rear_camera.gd" id="1_rcam"]
 
-[node name="RearCamera" type="Camera3D"]
-current = false
+[node name="RearCamera" type="Camera3D" unique_id=1461387812]
 script = ExtResource("1_rcam")
+max_distance = 5.0
 
-[node name="SubViewport" type="SubViewport" parent="."]
+[node name="SubViewport" type="SubViewport" parent="." unique_id=1503875210]
 render_target_update_mode = 4
 
-[node name="Camera3D" type="Camera3D" parent="SubViewport"]
+[node name="Camera3D" type="Camera3D" parent="SubViewport" unique_id=1480709256]

--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" uid="uid://smslf5v47u3e" path="res://scenes/vehicles/vehicle_seat.gd" id="3_seat"]
 [ext_resource type="PackedScene" uid="uid://cwhwra3b8ixvn" path="res://scenes/interactables/gui_3d.tscn" id="4_nd433"]
 [ext_resource type="PackedScene" uid="uid://eymb64nygadx" path="res://scenes/vehicles/trucks/truck_ui.tscn" id="5_d2vf6"]
-[ext_resource type="PackedScene" path="res://scenes/vehicles/rear_camera.tscn" id="6_nd433"]
+[ext_resource type="PackedScene" uid="uid://bjxceboesdb8w" path="res://scenes/vehicles/rear_camera.tscn" id="6_nd433"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_seat"]
 size = Vector3(0.8699799106043429, 1.889733397892087, 1.1162902846483576)
@@ -91,20 +91,26 @@ shadow_mesh = SubResource("ArrayMesh_lj7vy")
 
 [sub_resource type="QuadMesh" id="QuadMesh_nd433"]
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_nd433"]
+size = Vector3(3.3263575824812506, 2.283011432481544, 3.583552714480902)
+
 [node name="Truck" type="VehicleBody3D" unique_id=1579985098]
 mass = 1000.0
 script = ExtResource("1_vehicle")
 engine_power = 850.0
 max_speed_kmh = 55.0
+bed_wall_height = 0.6
 wheel_visual_drop = 0.26
 motor_max_rpm = 3000.0
 debug_color_driven_wheels = false
-cargo_bay_size = Vector3(1.8, 0.1, 2.9)
+cargo_bay_size = Vector3(1.8, 0.6, 2.9)
 cargo_bay_offset = Vector3(0, 0.4, 0.75)
+debug_show_cargo_bay = false
 
 [node name="SeatDriver" type="Area3D" parent="." unique_id=924961125 node_paths=PackedStringArray("sit_point")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 1, -1.625)
-collision_layer = 0
+collision_layer = 16
+collision_mask = 0
 monitoring = false
 script = ExtResource("3_seat")
 role = 0
@@ -119,7 +125,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7052961417606898, 0.5053189
 
 [node name="SeatPassenger" type="Area3D" parent="." unique_id=418211017 node_paths=PackedStringArray("sit_point")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.5, 1, -1.625)
-collision_layer = 0
+collision_layer = 16
+collision_mask = 0
 monitoring = false
 script = ExtResource("3_seat")
 sit_point = NodePath("SitPoint")
@@ -175,21 +182,21 @@ mesh = SubResource("ArrayMesh_j0cs4")
 [node name="Retro" type="Node3D" parent="." unique_id=241733783]
 
 [node name="RetroL" type="MeshInstance3D" parent="Retro" unique_id=655497253]
-transform = Transform3D(-0.3170223113008912, -0.21367460653674272, 1.50927418158291e-17, -1.762937452191217e-33, 1.5427620320199728e-17, 0.29065724085451006, -0.507341751251217, 0.13351871290609493, -9.430991796991935e-18, -1.1450000000040743, 1.8429999999934807, -2.1999999999970896)
+transform = Transform3D(-0.3170223113008912, -0.21367460653674272, 1.50927418158291e-17, -1.762937452191217e-33, 1.5427620320199728e-17, 0.29065724085451006, -0.507341751251217, 0.13351871290609493, -9.430991796991935e-18, -1.1450000000040743, 1.7211906460434776, -2.1999999999970896)
 material_override = ExtResource("3_lpt68")
 mesh = SubResource("ArrayMesh_tuoiw")
 
 [node name="RetroL_Screen" type="MeshInstance3D" parent="Retro/RetroL" unique_id=715380985]
-transform = Transform3D(0.00640108200256853, 1.5336793744598216e-18, -0.17883126698222424, 0.9127150305674672, 3.2804069000799227e-16, 0.00707061228188268, -1.4534978370346534e-16, 1.5482153435332782, -3.7529676327875183e-19, -0.1089776533347564, -0.00023051120554873, 0)
+transform = Transform3D(0.006401082002568476, 1.533679374459828e-18, -0.17883126698222424, 0.9127150305674671, 3.2804069000799237e-16, 0.007070612281882688, -1.4534978370346534e-16, 1.5482153435332784, -3.7529676327874875e-19, -0.1089776533347564, -0.00023051120554962168, 0)
 mesh = SubResource("QuadMesh_nd433")
 
 [node name="RetroD" type="MeshInstance3D" parent="Retro" unique_id=949377116]
-transform = Transform3D(0.31702231130089137, -0.2136746065367428, 1.5092741815829098e-17, 0, 1.5427620320199744e-17, 0.2906572408545101, -0.5073417512512173, -0.13351871290609502, 9.430991796991935e-18, 1.1116747671982483, 1.8429999999934807, -2.1385892980616505)
+transform = Transform3D(0.31702231130089137, -0.2136746065367428, 1.5092741815829098e-17, 0, 1.5427620320199744e-17, 0.2906572408545101, -0.5073417512512173, -0.13351871290609502, 9.430991796991935e-18, 1.1116747671982483, 1.7211906460434776, -2.1385892980616505)
 material_override = ExtResource("3_lpt68")
 mesh = SubResource("ArrayMesh_tuoiw")
 
 [node name="RetroD_Screen" type="MeshInstance3D" parent="Retro/RetroD" unique_id=934713954]
-transform = Transform3D(0.00640108200256853, 1.5336793744597969e-18, -0.17883126698222426, 0.9127150305674676, 3.280406900079923e-16, 0.00707061228188268, -1.4534978370346534e-16, 1.548215343533278, -3.7529676327875183e-19, -0.10897765333475684, -0.00023051120554828, 0)
+transform = Transform3D(0.00640108200256853, 1.5336793744597967e-18, -0.17883126698222426, 0.9127150305674676, 3.280406900079923e-16, 0.00707061228188268, -1.4534978370346534e-16, 1.548215343533278, -3.7529676327875183e-19, -0.10897765333475684, -0.00023051120554828, 0)
 mesh = SubResource("QuadMesh_nd433")
 
 [node name="Recul" type="Node3D" parent="." unique_id=683381723]
@@ -200,7 +207,7 @@ material_override = ExtResource("3_lpt68")
 mesh = SubResource("ArrayMesh_tuoiw")
 
 [node name="Recul_Screen" type="MeshInstance3D" parent="Recul" unique_id=946437510]
-transform = Transform3D(0.4448829333770059, 0, 0, 0, 0.24538884339518696, 0, 0, 0, 1, -0.00883323543254654, 1.7960000000020957, -1.7033350191500347)
+transform = Transform3D(-0.4448829333770059, 0, -1.2246064e-16, 0, 0.24538884339518696, 0, 5.448064669206188e-17, 0, -1, -0.00883323543254654, 1.7960000000020957, -1.7033350191500347)
 mesh = SubResource("QuadMesh_nd433")
 
 [node name="Light" type="Node3D" parent="." unique_id=2071163623]
@@ -232,13 +239,18 @@ light_color = Color(1, 0.039215688, 0.0627451, 1)
 spot_range = 10.0
 spot_angle = 37.0
 
+[node name="SpotLight3DL2" type="SpotLight3D" parent="Light" unique_id=331479837 groups=["vehicle_light"]]
+transform = Transform3D(1, 0, 0, 0, -0.6741734925434366, 0.7385730173461422, 0, -0.7385730173461422, -0.6741734925434367, -0.016123824681809396, 1.4597819505451362, -0.7685460891703952)
+spot_range = 4.0
+spot_angle = 33.29
+
 [node name="RearCamera_Rear" parent="." unique_id=984847245 node_paths=PackedStringArray("screen") instance=ExtResource("6_nd433")]
 transform = Transform3D(-1, -2.4651903e-32, 1.2246064e-16, 6.123031769111884e-17, 0.8660254037844387, 0.5, -1.0605402120460136e-16, 0.5, -0.8660254037844387, -0.00059340561188747, 2.216733946285466, -0.831925203098164)
 screen = NodePath("../Recul/Recul_Screen")
 mirror = true
 
 [node name="RearCamera_RetroL" parent="." unique_id=1162117254 node_paths=PackedStringArray("screen") instance=ExtResource("6_nd433")]
-transform = Transform3D(-1, -3.698526287045973e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.0605402120460141e-16, 0.49999999999999994, -0.8660254037844387, -1.6000000000058208, 1.8000000000029104, -1.8999999999941792)
+transform = Transform3D(-1, -3.698526287045973e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.060540212046014e-16, 0.49999999999999994, -0.8660254037844387, -1.6000000000058208, 1.8000000000029104, -1.8999999999941792)
 screen = NodePath("../Retro/RetroL/RetroL_Screen")
 resolution = Vector2i(200, 320)
 
@@ -246,3 +258,8 @@ resolution = Vector2i(200, 320)
 transform = Transform3D(-1, -2.4651903e-32, 1.2246064e-16, 6.123031769111884e-17, 0.8660254037844387, 0.5, -1.0605402120460136e-16, 0.5, -0.8660254037844387, 1.630042590852213, 1.8000000000029104, -1.8999999999941792)
 screen = NodePath("../Retro/RetroD/RetroD_Screen")
 resolution = Vector2i(200, 320)
+
+[node name="Cargo_loading_zone" type="CollisionShape3D" parent="." unique_id=551701719]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.009779394, 0.996233457483554, 1.0425897240638733)
+shape = SubResource("BoxShape3D_nd433")
+debug_color = Color(0.22392991, 0.61549836, 0.4901445, 0.41960785)

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -31,6 +31,8 @@ enum ViewMode {CHASE, CAB}
 
 # Meta marker put on every node we generate, so a rebuild can clear the old ones.
 const GENERATED := "vehicle_generated"
+# Thickness of the generated bed floor / walls (m). Shared by the collider and the cargo-rest math.
+const BED_WALL_THICKNESS := 0.08
 # Bench: the real mining rock scene, reused to test loading the bed.
 const ROCK_SCENE := preload("res://scenes/props/rock/rock_mining_01.tscn")
 const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
@@ -206,6 +208,11 @@ const LIGHT_GROUP := "vehicle_light"
 	set(v):
 		cargo_bay_offset = v
 		_rebuild_deferred()
+## Designer-placed box (a CollisionShape3D with a BoxShape3D) marking WHERE a dropped item is allowed
+## to load/stick. Drop a crate inside it (from in the bed or reaching over) and it loads. Leave unset
+## to fall back to the cargo_bay box. Its physics collision is turned off at runtime — it is only a
+## zone marker. (The truck wires its "Cargo_loading_zone" node here.)
+@export var cargo_loading_zone: CollisionShape3D
 ## A body is locked into the bed once it slows below this speed (m/s).
 @export var cargo_settle_speed: float = 0.6
 ## Tilt (degrees from upright) past which the bed unlocks and spills its load — a rollover drops
@@ -236,9 +243,13 @@ var _cab_cam: Camera3D = null
 var _view: ViewMode = ViewMode.CHASE
 var _empty_mass: float = 0.0
 var _occupant_mass: float = 0.0  # kg of seated players (driver + passengers), added to the mass
-var _locked_cargo: Dictionary = {}
+var _locked_cargo: Dictionary = {}  # RigidBody3D cargo -> its mass (kg), summed into the load
+var _locked_cargo_local: Dictionary = {}  # RigidBody3D cargo -> its rest LOCAL transform in the bed
 var _bed_players: Dictionary = {}  # set of on-foot players standing in the bed (player -> true)
 var _cargo_area: Area3D = null
+var _cargo_debug: bool = false  # Settings > General: draw a green envelope on really-locked cargo
+var _cargo_debug_accum: float = 0.0  # throttle the debug refresh (dev aid, off by default)
+var _cargo_debug_markers: Dictionary = {}  # RigidBody3D cargo -> its MeshInstance3D envelope
 var _net_last_position: Vector3 = Vector3.ZERO
 var _net_last_rotation: Vector3 = Vector3.ZERO
 var _net_throttle: float = 0.0  # pilot input relayed by the server (networked)
@@ -266,6 +277,10 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	add_to_group("vehicle")  # so a pilot can find and enter us
+	_setup_loading_zone()  # designer "can load here" box: turn off its physics, keep it as a marker
+	if not OS.has_feature("dedicated_server"):
+		_cargo_debug = SettingsManager.is_cargo_debug()  # dev aid: green envelope on locked cargo
+		SettingsManager.cargo_debug_changed.connect(_on_cargo_debug_changed)
 	_sync_powertrain()
 	set_headlights(_headlights_on)  # start in a known state (off) on the server and every client
 	if _is_networked():
@@ -345,7 +360,7 @@ func _build_collision() -> void:
 	# (collision-less) visual. These add to the VehicleBody3D compound collider.
 	var bed_len: float = body_length - cab_length
 	var bed_z: float = (body_length - bed_len) * 0.5
-	var wall: float = 0.08
+	var wall: float = BED_WALL_THICKNESS
 	_add_collision_box(Vector3(body_width, wall, bed_len), Vector3(0.0, top + wall * 0.5, bed_z))
 	_add_collision_box(Vector3(wall, bed_wall_height, bed_len),
 		Vector3(body_width * 0.5 - wall * 0.5, top + bed_wall_height * 0.5, bed_z))
@@ -495,6 +510,27 @@ func lock_dropped_cargo(body: Node) -> void:
 	if body is RigidBody3D and body.mass > 0.0:
 		_lock_cargo(body)
 
+## Resolve the designer loading zone (explicit @export, else a child named "Cargo_loading_zone") and
+## turn OFF its physics collision: a CollisionShape3D under this VehicleBody3D would otherwise be a
+## real (huge) collider. We only read its box to test where loading is allowed.
+func _setup_loading_zone() -> void:
+	if cargo_loading_zone == null:
+		cargo_loading_zone = get_node_or_null("Cargo_loading_zone") as CollisionShape3D
+	if cargo_loading_zone != null:
+		cargo_loading_zone.disabled = true
+
+## True when a world point is inside the loading zone (where a dropped item is allowed to stick).
+## Uses the designer's Cargo_loading_zone box if set, else falls back to the cargo_bay box (blockout).
+func is_point_in_loading_zone(world_point: Vector3) -> bool:
+	if cargo_loading_zone != null and cargo_loading_zone.shape is BoxShape3D:
+		var local := cargo_loading_zone.global_transform.affine_inverse() * world_point
+		var half: Vector3 = (cargo_loading_zone.shape as BoxShape3D).size * 0.5
+		return absf(local.x) <= half.x and absf(local.y) <= half.y and absf(local.z) <= half.z
+	var bay := to_local(world_point) - cargo_bay_offset
+	return absf(bay.x) <= cargo_bay_size.x * 0.5 \
+		and absf(bay.y) <= cargo_bay_size.y * 0.5 \
+		and absf(bay.z) <= cargo_bay_size.z * 0.5
+
 ## A player walked into the bed on foot: count them in the load (and let them ride). Seated players
 ## are handled by _occupant_mass, so they are skipped in get_bed_mass — no double-count.
 func add_bed_player(player: Node) -> void:
@@ -539,15 +575,139 @@ func _lock_cargo(body: RigidBody3D) -> void:
 	# stop the truck body and the crate from fighting each other where they overlap in the bed.
 	add_collision_exception_with(body)
 	# Reparent into the bed WITHOUT the prop's _exit_tree firing a delete (server_parent_change
-	# sets server_reparenting), then replicate the reparent so clients ride it in the bed. A raw
-	# reparent() made the prop vanish in-game (its _exit_tree deleted it from Horizon).
+	# sets server_reparenting). A raw reparent() made the prop vanish in-game (its _exit_tree
+	# deleted it from Horizon).
 	if body.has_method("server_parent_change"):
 		body.server_parent_change(self)
-		if body.has_method("send_properties_to_client"):
-			body.send_properties_to_client(str(uuid))
 	else:
 		body.reparent(self)
+	# Rest it on the bed floor: it was frozen at hand height, so without this it would hang in the
+	# air. Keep its X/Z, lower it until its underside sits on the floor, THEN replicate that pose.
+	_settle_on_bed_floor(body)
+	_locked_cargo_local[body] = body.transform  # rest pose, re-asserted each frame so it rides rigidly
+	if body.has_method("send_properties_to_client"):
+		body.send_properties_to_client(str(uuid))
 	_refresh_mass()
+
+## Place a just-locked body INTO the cargo bay: shift its X/Z so its WHOLE footprint fits inside the
+## cargo_bay (an item dropped from far / over the rim ends up entirely in the bay, not poking out),
+## then rest its lowest collision point on the bed floor. Uses the real collision AABB, so it works
+## for any pivot (a cut ore piece keeps the original rock's off-centre pivot) and any size.
+func _settle_on_bed_floor(body: Node3D) -> void:
+	var col := body as CollisionObject3D
+	if col == null:
+		return
+	var bounds := _collision_aabb(body, global_transform.affine_inverse() * col.global_transform)
+	if bounds.size == Vector3.ZERO:
+		return  # no collision shape found: leave it where it is
+	var mn := bounds.position
+	var mx := bounds.end
+	var local := to_local(body.global_position)
+	# Fit the whole item inside the cargo bay footprint (centred if it is wider than the bay).
+	local.x += _fit_shift(mn.x, mx.x, cargo_bay_offset.x - cargo_bay_size.x * 0.5, cargo_bay_offset.x + cargo_bay_size.x * 0.5)
+	local.z += _fit_shift(mn.z, mx.z, cargo_bay_offset.z - cargo_bay_size.z * 0.5, cargo_bay_offset.z + cargo_bay_size.z * 0.5)
+	local.y += _bed_floor_local_y() - mn.y  # rest the underside on the floor
+	body.global_position = to_global(local)
+
+## Translation along one axis so the span [item_min, item_max] fits inside [bay_min, bay_max]
+## (centred when the item is wider than the bay).
+static func _fit_shift(item_min: float, item_max: float, bay_min: float, bay_max: float) -> float:
+	if item_max - item_min >= bay_max - bay_min:
+		return (bay_min + bay_max) * 0.5 - (item_min + item_max) * 0.5
+	if item_min < bay_min:
+		return bay_min - item_min
+	if item_max > bay_max:
+		return bay_max - item_max
+	return 0.0
+
+## Local Y of the bed floor's top surface (where cargo rests), matching the generated floor box.
+func _bed_floor_local_y() -> float:
+	return body_height * 0.5 + BED_WALL_THICKNESS
+
+## AABB of a body's OWN collision shapes (covers CollisionShape3D / CollisionPolygon3D alike, and
+## ignores child Area3D shapes — those belong to a separate CollisionObject3D, e.g. the rock mining
+## sphere), expressed in `frame_from_body`: pass IDENTITY for body-local, or this vehicle's
+## (global⁻¹ × body.global) for vehicle-local. Zero-size when the body has no collision.
+func _collision_aabb(body: Node3D, frame_from_body: Transform3D) -> AABB:
+	var col := body as CollisionObject3D
+	if col == null:
+		return AABB()
+	var bounds := AABB()
+	var started := false
+	for owner_id in col.get_shape_owners():
+		var owner_xform: Transform3D = col.shape_owner_get_transform(owner_id)  # relative to body
+		for i in col.shape_owner_get_shape_count(owner_id):
+			var shape: Shape3D = col.shape_owner_get_shape(owner_id, i)
+			if shape == null:
+				continue
+			var debug_mesh := shape.get_debug_mesh()
+			if debug_mesh == null:
+				continue
+			var aabb := debug_mesh.get_aabb()
+			for c in 8:
+				var corner := aabb.position + Vector3(
+					aabb.size.x if (c & 1) else 0.0,
+					aabb.size.y if (c & 2) else 0.0,
+					aabb.size.z if (c & 4) else 0.0)
+				var point: Vector3 = frame_from_body * (owner_xform * corner)
+				if not started:
+					bounds = AABB(point, Vector3.ZERO)
+					started = true
+				else:
+					bounds = bounds.expand(point)
+	return bounds
+
+# ------------------------------------------------------------------------------
+# Cargo debug envelope (Settings > General > Cargo debug). Dev aid only, off by default.
+# ------------------------------------------------------------------------------
+## React live to the Settings toggle: draw or clear the green envelopes without a restart.
+func _on_cargo_debug_changed(on: bool) -> void:
+	_cargo_debug = on
+	if on:
+		_refresh_cargo_debug()
+	else:
+		for body in _cargo_debug_markers.keys():
+			if is_instance_valid(_cargo_debug_markers[body]):
+				_cargo_debug_markers[body].queue_free()
+		_cargo_debug_markers.clear()
+
+## Keep one green envelope per REALLY-locked cargo. A locked crate is reparented under the vehicle
+## (server and client), so the body's direct RigidBody3D children ARE the stuck cargo — an item just
+## resting loose in the bed stays a child of the world, so it gets no envelope (that is the point).
+func _refresh_cargo_debug() -> void:
+	var stuck := {}
+	for child in get_children():
+		if child is RigidBody3D:
+			stuck[child] = true
+			if not _cargo_debug_markers.has(child):
+				_cargo_debug_markers[child] = _make_cargo_marker(child)
+	for body in _cargo_debug_markers.keys():
+		if not stuck.has(body) or not is_instance_valid(body):
+			if is_instance_valid(_cargo_debug_markers[body]):
+				_cargo_debug_markers[body].queue_free()
+			_cargo_debug_markers.erase(body)
+
+## Build a translucent green box matching the body's collision bounds, parented to it so it rides.
+func _make_cargo_marker(body: Node3D) -> MeshInstance3D:
+	var bounds := _body_local_aabb(body)
+	var marker := MeshInstance3D.new()
+	marker.set_meta(GENERATED, true)
+	var box := BoxMesh.new()
+	box.size = bounds.size + Vector3.ONE * 0.05  # a hair bigger so it reads as a wrap, not z-fight
+	marker.mesh = box
+	marker.position = bounds.get_center()
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = Color(0.0, 1.0, 0.0, 0.25)
+	mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	mat.cull_mode = BaseMaterial3D.CULL_DISABLED
+	marker.material_override = mat
+	body.add_child(marker)
+	return marker
+
+## A body's collision AABB in its OWN local frame (for the debug envelope mesh).
+func _body_local_aabb(body: Node3D) -> AABB:
+	return _collision_aabb(body, Transform3D.IDENTITY)
 
 ## Release a crate from the bed back into the world / a player's hands (carry retrieval): stop
 ## ignoring it and drop it from the load. The caller (the carry pickup) then takes ownership.
@@ -556,7 +716,18 @@ func release_cargo(body: Node) -> void:
 		return
 	remove_collision_exception_with(body)
 	_locked_cargo.erase(body)
+	_locked_cargo_local.erase(body)
 	_refresh_mass()
+
+## Server: hold every locked crate at its rest LOCAL pose each physics frame, so it rides the truck
+## rigidly (a KINEMATIC child can drift relative to a moving parent body). Keeps the replicated local
+## position constant -> clients stay perfectly stuck. Skips a crate that vanished (freed elsewhere).
+func _pin_locked_cargo() -> void:
+	for body in _locked_cargo_local.keys():
+		if is_instance_valid(body):
+			(body as Node3D).transform = _locked_cargo_local[body]
+		else:
+			_locked_cargo_local.erase(body)
 
 ## Spill the whole load when the vehicle tips past cargo_unlock_tilt_deg (GDD: the bed lock
 ## releases on a rollover). Each piece becomes a free dynamic prop again, back in the world.
@@ -662,7 +833,7 @@ func _build_body_visual() -> void:
 	# Open bed behind the cab: a floor + four low side walls (loadable by hand, GDD 6.1).
 	var bed_len: float = body_length - cab_length
 	var bed_z: float = (body_length - bed_len) * 0.5
-	var wall: float = 0.08
+	var wall: float = BED_WALL_THICKNESS
 	_add_box(body, Vector3(body_width, wall, bed_len), Vector3(0.0, top + wall * 0.5, bed_z), paint)  # floor
 	_add_box(body, Vector3(wall, bed_wall_height, bed_len),
 		Vector3(body_width * 0.5 - wall * 0.5, top + bed_wall_height * 0.5, bed_z), paint)  # right wall
@@ -761,6 +932,11 @@ func _process(delta: float) -> void:
 	# rides the smoothly-interpolated body (no per-frame world jitter). Server stays authoritative.
 	_interp.update(self, delta)
 	_update_wheels_visual(delta)
+	if _cargo_debug:
+		_cargo_debug_accum += delta
+		if _cargo_debug_accum >= 0.5:  # cheap periodic refresh; this only runs when the toggle is ON
+			_cargo_debug_accum = 0.0
+			_refresh_cargo_debug()
 
 func _physics_process(delta: float) -> void:
 	if Engine.is_editor_hint():
@@ -772,6 +948,7 @@ func _physics_process(delta: float) -> void:
 			return
 		_release_vanished_occupants()  # free seats + bed slots whose player disconnected (node freed)
 		_check_rollover_unlock()  # spill the load if the truck is tipped over
+		_pin_locked_cargo()  # hold the load rigidly in the bed (constant local pose) as the truck moves
 		if is_instance_valid(_pilot):
 			_apply_drive(delta)
 		elif _handbrake:
@@ -781,6 +958,7 @@ func _physics_process(delta: float) -> void:
 		return
 	# Bench / standalone: drive locally.
 	_check_rollover_unlock()
+	_pin_locked_cargo()
 	if _pilot != null:
 		_apply_drive(delta)
 	elif _handbrake:

--- a/server/client.gd
+++ b/server/client.gd
@@ -574,6 +574,9 @@ func create_generic_object(event: Dictionary) -> void:
 		if object_data.has("parent_id"):
 			if object_data["parent_id"] != "":
 				var parent = _search_parent_node(object_data["parent_id"])
+				# Only reparent when the new parent is KNOWN. If it isn't resolved yet, leave the prop
+				# where it is — do NOT detach a bed-riding crate just because its truck wasn't found
+				# for one frame (GORC zone churn at speed), or it stops following the truck.
 				if parent != null and prop_instance.get_parent() != parent:
 					prop_instance.client_parent_change(parent)
 			elif prop_instance.get_parent() != universe_scene:

--- a/ui/settings_page/general_page/general_settings_page.gd
+++ b/ui/settings_page/general_page/general_settings_page.gd
@@ -1,0 +1,16 @@
+extends Control
+
+## Wires the general options to SettingsManager (apply + persist). For now: the cargo-debug toggle
+## (green envelope around items really locked into a vehicle bed), mirroring the graphics page style.
+
+@onready var _cargo_debug: Button = $ScrollContainer/MarginContainer/VBoxContainer/CargoDebug/Button
+
+func _ready() -> void:
+	_cargo_debug.toggle_mode = true
+	_cargo_debug.button_pressed = SettingsManager.is_cargo_debug()
+	_cargo_debug.text = "On" if _cargo_debug.button_pressed else "Off"
+	_cargo_debug.toggled.connect(_on_cargo_debug_toggled)
+
+func _on_cargo_debug_toggled(on: bool) -> void:
+	_cargo_debug.text = "On" if on else "Off"
+	SettingsManager.set_cargo_debug(on)

--- a/ui/settings_page/general_page/general_settings_page.gd.uid
+++ b/ui/settings_page/general_page/general_settings_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bf143sn8as1lk

--- a/ui/settings_page/general_page/general_settings_page.tscn
+++ b/ui/settings_page/general_page/general_settings_page.tscn
@@ -1,14 +1,22 @@
-[gd_scene format=3 uid="uid://dxxwu5jg8wjap"]
+[gd_scene load_steps=4 format=3 uid="uid://dxxwu5jg8wjap"]
 
-[node name="GeneralSettingsPage" type="Control" unique_id=191342304]
+[ext_resource type="Script" path="res://ui/settings_page/general_page/general_settings_page.gd" id="1_gen"]
+[ext_resource type="FontFile" uid="uid://c4j53obrj81gg" path="res://ui/Poppins-Regular.ttf" id="2_pcucv"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_gen"]
+font = ExtResource("2_pcucv")
+font_size = 28
+
+[node name="GeneralSettingsPage" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_gen")
 
-[node name="ColorRect" type="ColorRect" parent="." unique_id=116013742]
+[node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -16,3 +24,41 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.18, 0.18, 0.18, 0.5647059)
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+horizontal_scroll_mode = 0
+
+[node name="MarginContainer" type="MarginContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="CargoDebug" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/CargoDebug"]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Cargo debug (green envelope on locked items)"
+label_settings = SubResource("LabelSettings_gen")
+
+[node name="Button" type="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/CargoDebug"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+theme_override_fonts/font = ExtResource("2_pcucv")
+toggle_mode = true
+text = "Off"


### PR DESCRIPTION
## Description

Improvements to the truck/vehicle: a usable cargo bed, and a cheaper rear-view camera.

**Cargo bed (generic to any `Vehicle`)**
- **Load by dropping**: drop a carriable inside a truck's designer-placed `Cargo_loading_zone` — standing in the bed *or* reaching over from outside — and it loads. The `[E]` prompt reads **Cargo** when a drop would load (sticks), **Drop** otherwise.
- **Clean placement**: a loaded item is tucked **entirely** inside the `cargo_bay` and rested on the bed floor, using its real collision AABB — works for any size and any off-centre pivot (e.g. a cut ore piece).
- **Rigid, jitter-free riding**: server-authoritative. The crate is held at a constant local pose on the server (re-asserted each physics frame) and KINEMATIC-pinned on clients, so it follows the truck with no lag, no jitter, and no "left behind at speed".
- **Rollover spills** the load (GDD). **Retrieve** with `E`.
- **Load** = locked crates + on-foot bed walkers + what they carry; a mining rock's mass scales with its cut volume.
- Designer workflow: the zones are scene nodes (`cargo_bay` export + a `Cargo_loading_zone` box) — no per-vehicle code.

**Rear-view camera / mirrors**
- Feed shown one-sided (`CULL_BACK`), **distance-culled** past `max_distance`, and **refresh-throttled** — much cheaper on weak GPUs while staying live for everyone. A mirror flips left/right via UVs.

**Dev aid**
- Settings → General → **Cargo debug**: a green envelope around items really locked in a bed.

Shared client replication logic (freeze mode, transform apply, ride pin) is centralised in `PropNet` (DRY).

## Changelog

<!-- CHANGELOG_EN -->
Improve cargo: drop an item in a truck's bed (or over the side) to load it, drive it around, and tip the truck to spill it. Changed render of  rear-view mirrors / reversing camera screens.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Modification du fret : déposez un objet dans la benne d'un camion (ou par-dessus le bord) pour le charger, roulez avec, et renversez le camion pour le décharger. Modif des rétroviseurs / caméra de recul au niveau des perf client.
<!-- /CHANGELOG_FR -->
