### PR TITLE
Show a remote player's flashlight to other players

### DIFF
--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -185,7 +185,9 @@ func _enter_tree() -> void:
 	if remote_player:
 		position = spawn_position
 		$UserInterface.visible = false
-		$CameraPivot.visible = false
+		# Don't hide CameraPivot: its Torch (SpotLight3D) lives under it, and a hidden ancestor would
+		# keep a remote player's flashlight dark even when its replicated state is ON. The camera is
+		# made non-current in _ready, so it never renders for us anyway.
 
 	elif not OS.has_feature("dedicated_server"):
 		NetworkOrchestrator.set_player_global_position.connect(_set_player_global_position)


### PR DESCRIPTION
## Description

Fix: a **remote player's flashlight** never showed to other players.

The remote player's `CameraPivot` was hidden in `_enter_tree`, which also hid its child `Torch`
(`SpotLight3D`) — a node doesn't emit/render if any ancestor is invisible. So the replicated
flashlight state (already whitelisted in `player_def.json` and applied via `client_channel_data_update`)
never lit up on other clients.

Keep `CameraPivot` visible for remotes (the camera is already made non-current in `_ready`, so it
never renders for us) and let the torch follow its replicated on/off state. The torch defaults to
`visible = false`, so a remote starts dark and toggles correctly.

## Changelog

<!-- CHANGELOG_EN -->
You can now see other players turn their flashlight on and off.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
On voit désormais les autres joueurs allumer et éteindre leur lampe torche.
<!-- /CHANGELOG_FR -->
