### PR TITLE
Mining zones (server-side rock fields + per-zone mineral)

### DIFF
--- a/assets/materials/minerals/iron/iron.tres
+++ b/assets/materials/minerals/iron/iron.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="MineralDef" format=3 uid="uid://dy81i0qbytwih"]
+
+[ext_resource type="Texture2D" uid="uid://lha7jekg5khj" path="res://assets_blender/_universe/_shared/materials/metals/metal_iron_041A_4K_Roughness.jpg" id="1_qu6xp"]
+[ext_resource type="Texture2D" uid="uid://tmoad1l7oxy6" path="res://assets/textures/minerals/gold/gold_normal.png" id="2_jddbm"]
+[ext_resource type="Script" uid="uid://dfol8sjf0bo8c" path="res://scenes/props/rock/mineral_def.gd" id="3_fa1if"]
+
+[resource]
+script = ExtResource("3_fa1if")
+id = &"iron"
+use_texture = true
+albedo_tex = ExtResource("1_qu6xp")
+color = Color(1, 1, 1, 1)
+normal_tex = ExtResource("2_jddbm")
+metallic = 0.638
+emission = 0.01

--- a/assets/materials/minerals/iron/iron_material.tres
+++ b/assets/materials/minerals/iron/iron_material.tres
@@ -1,0 +1,11 @@
+[gd_resource type="StandardMaterial3D" format=3 uid="uid://8ukrbr5j4lhl"]
+
+[ext_resource type="Texture2D" uid="uid://lha7jekg5khj" path="res://assets_blender/_universe/_shared/materials/metals/metal_iron_041A_4K_Roughness.jpg" id="1_oa1le"]
+[ext_resource type="Texture2D" uid="uid://tmoad1l7oxy6" path="res://assets/textures/minerals/gold/gold_normal.png" id="2_dv0vy"]
+
+[resource]
+albedo_texture = ExtResource("1_oa1le")
+metallic = 1.0
+roughness = 0.14
+normal_enabled = true
+normal_texture = ExtResource("2_dv0vy")

--- a/assets/materials/minerals/iron/irontest.tscn
+++ b/assets/materials/minerals/iron/irontest.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://bi02k4vqfw00t"]
+
+[ext_resource type="Material" uid="uid://8ukrbr5j4lhl" path="res://assets/materials/minerals/iron/iron_material.tres" id="1_qbkyy"]
+
+[node name="Goldtest" type="Node3D" unique_id=874944914]
+
+[node name="CSGBox3D" type="CSGBox3D" parent="." unique_id=230158004]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.04204695484068088, -0.18389934042945416, 0.2639370162097575)
+material_override = ExtResource("1_qbkyy")

--- a/assets_blender/_universe/_shared/materials/metals/metal_iron_041A_4K_Roughness.jpg.import
+++ b/assets_blender/_universe/_shared/materials/metals/metal_iron_041A_4K_Roughness.jpg.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://lha7jekg5khj"
-path="res://.godot/imported/metal_iron_041A_4K_Roughness.jpg-a5e847d6b4cb0a6b954535eddfbec4eb.ctex"
+path.s3tc="res://.godot/imported/metal_iron_041A_4K_Roughness.jpg-a5e847d6b4cb0a6b954535eddfbec4eb.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets_blender/_universe/_shared/materials/metals/metal_iron_041A_4K_Roughness.jpg"
-dest_files=["res://.godot/imported/metal_iron_041A_4K_Roughness.jpg-a5e847d6b4cb0a6b954535eddfbec4eb.ctex"]
+dest_files=["res://.godot/imported/metal_iron_041A_4K_Roughness.jpg-a5e847d6b4cb0a6b954535eddfbec4eb.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0
@@ -23,7 +24,7 @@ compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -37,4 +38,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/levels/devmode/SimpleBoxTest/SimpleBoxTest.tscn
+++ b/levels/devmode/SimpleBoxTest/SimpleBoxTest.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://cc8s2k0q8cxf" path="res://scenes/props/StorageBoxes/pallet_crate_120x80x100.tscn" id="5_w0ufy"]
 [ext_resource type="PackedScene" uid="uid://ddr43a2c4deep" path="res://scenes/props/StorageBoxes/container_liquid_1200x240x240.tscn" id="6_bdj2j"]
 [ext_resource type="PackedScene" uid="uid://d37hc6ybk8fsj" path="res://scenes/props/testbox/box_50cm.tscn" id="7_w0ufy"]
-[ext_resource type="PackedScene" uid="uid://dtijoobxv67w2" path="res://scenes/props/rock/rock_mining_01.tscn" id="8_bdj2j"]
+[ext_resource type="PackedScene" uid="uid://dtijoobxv67w2" path="res://scenes/props/rock/rock_mining_small.tscn" id="8_bdj2j"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_xqwsu"]
 size = Vector2(100, 100)

--- a/scenes/normal_player/mining_tool.gd
+++ b/scenes/normal_player/mining_tool.gd
@@ -291,11 +291,15 @@ func _is_owner() -> bool:
 
 # ── Internals ────────────────────────────────────────────────────────────────
 
-## True if a mining rock (group "miningrock") is within aim range.
+## True if a mining rock (group "miningrock") is within aim range. Distance is measured to
+## the rock's SURFACE (center distance minus its radius), so big variants — whose center is
+## metres deep — are reachable like the small one (which has a ~0 radius -> unchanged).
 func _is_near_mining_rock() -> bool:
 	for r in get_tree().get_nodes_in_group("miningrock"):
-		if r is Node3D and global_position.distance_to((r as Node3D).global_position) <= aim_rock_distance:
-			return true
+		if r is Node3D:
+			var radius: float = r.aim_radius() if r.has_method("aim_radius") else 0.0
+			if global_position.distance_to((r as Node3D).global_position) - radius <= aim_rock_distance:
+				return true
 	return false
 
 ## True if the camera is currently looking at a mining rock (camera raycast).

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -1022,7 +1022,7 @@ func _on_fov_changed(fov: float) -> void:
 func _on_spawn_selected(data) -> void:
 	match data:
 		"rock":
-			spawn_box("rock/rock_mining_01", "miningrock", 5.5, 1.2)
+			spawn_box("rock/rock_mining_small", "miningrock", 5.5, 1.2)
 		"box":
 			spawn_box("testbox/box_50cm", "box", 1.5, 2.0)
 		"depot":

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -361,6 +361,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		if _spawn_wheel:
 			_spawn_wheel.open([
 				{"text": "Rocher", "data": "rock"},
+				{"text": "Rocher M", "data": "rock_medium"},
+				{"text": "Rocher L", "data": "rock_large"},
 				{"text": "Caisse", "data": "box"},
 				{"text": "Dépôt", "data": "depot"},
 				{"text": "Camion", "data": "truck"},
@@ -1023,6 +1025,10 @@ func _on_spawn_selected(data) -> void:
 	match data:
 		"rock":
 			spawn_box("rock/rock_mining_small", "miningrock", 5.5, 1.2)
+		"rock_medium":
+			spawn_box("rock/rock_mining_medium", "miningrock", 6.0, 4.0)
+		"rock_large":
+			spawn_box("rock/rock_mining_large", "miningrock", 9.0, 6.0)
 		"box":
 			spawn_box("testbox/box_50cm", "box", 1.5, 2.0)
 		"depot":

--- a/scenes/props/MiningZone/Mining_Zone.tscn
+++ b/scenes/props/MiningZone/Mining_Zone.tscn
@@ -1,0 +1,17 @@
+[gd_scene format=3 uid="uid://y76cnowlemud"]
+
+[ext_resource type="Script" path="res://scenes/props/MiningZone/mining_zone.gd" id="1_zone"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_trigger"]
+radius = 1000.0
+
+[node name="MiningZone" type="Node3D"]
+script = ExtResource("1_zone")
+trigger_area = NodePath("TriggerArea")
+
+[node name="TriggerArea" type="Area3D" parent="."]
+collision_layer = 0
+collision_mask = 4294967295
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="TriggerArea"]
+shape = SubResource("SphereShape3D_trigger")

--- a/scenes/props/MiningZone/mining_zone.gd
+++ b/scenes/props/MiningZone/mining_zone.gd
@@ -1,0 +1,266 @@
+@tool
+extends Node3D
+
+# Mining Zone — a designer-placed trigger. When a player enters its detection Area3D AND
+# the zone currently holds no mining rocks, the SERVER seed-generates a field of rocks
+# (positions, sizes, ore richness) over a flat square region. The rocks are ordinary
+# "miningrock" props, so they replicate + persist like any other rock. A fully-depleted
+# zone re-generates on the next entry (renewable, no persisted marker needed).
+#
+# Place an instance of Mining_Zone.tscn in the world (e.g. sandbox_capital.tscn) and tune
+# the @export values per zone (mineral, richness, density, size mix).
+#
+# Generation runs from _physics_process, NOT from the body_entered callback: the ground
+# raycast needs direct_space_state, which is only valid during the physics step (the space
+# is locked while area signals are flushed).
+
+const SCENE_SMALL := "scenes/props/rock/rock_mining_small.tscn"
+const SCENE_MEDIUM := "scenes/props/rock/rock_mining_medium.tscn"
+const SCENE_LARGE := "scenes/props/rock/rock_mining_large.tscn"
+# One rock is spawned every SPAWN_INTERVAL_FRAMES physics frames while draining the queue, to
+# spread the create_object burst so Horizon's message channel never overflows (a flood of
+# create_object messages gets dropped -> the rocks exist server-side but never reach clients).
+const SPAWN_INTERVAL_FRAMES := 6
+# Height (m) above the detected ground a rock is dropped from, so it FALLS and settles
+# cleanly (each frame replicated) instead of spawning half-buried in the surface — a buried
+# spawn makes the server eject+sleep the body, leaving the frozen client mesh ~1 m off.
+const SPAWN_DROP := 2.0
+
+@export_group("Identity")
+## Seed for the deterministic rock UUIDs, so regenerating the SAME zone never duplicates
+## rocks in the DB. Leave EMPTY to derive it from the zone's world position.
+@export var stable_id: String = ""
+
+@export_group("Field")
+## Side length (m) of the square region rocks are scattered over, centered on the zone.
+@export var field_size: float = 500.0
+## How many rocks to generate when the zone is (re)populated.
+@export var rock_count: int = 30
+## Minimum spacing (m) between two rocks, to avoid overlaps.
+@export var min_spacing: float = 8.0
+## Relative share of each size in the mix (small, medium, large). Any positive ratio works.
+@export var weight_small: float = 0.6
+@export var weight_medium: float = 0.3
+@export var weight_large: float = 0.1
+
+@export_group("Ore")
+## Zone ore richness 0..1 (poor..rich). Picks each rock's ore_seed so its derived richness
+## sits near this target — works WITHOUT any extra replication (ore_seed is already synced).
+@export_range(0.0, 1.0) var richness: float = 0.5
+## How tightly rock richness hugs the target (smaller = tighter spread around `richness`).
+@export_range(0.0, 0.5) var richness_spread: float = 0.12
+## Which mineral this zone yields. Replication of this comes in step 3b (Horizon def); for
+## now it is informational and every rock still renders the default mineral.
+@export var mineral_id: String = "gold"
+
+@export_group("Detection")
+## The Area3D (the ~1 km trigger) that detects players. Assign the child Area3D.
+@export var trigger_area: Area3D
+
+@export_group("Editor")
+## EDITOR PREVIEW: toggle ON to populate the field with rock instances right in the editor
+## (flat ground, no networking) so you can see size mix / density / spread. OFF clears it.
+## These preview nodes are transient — they are NOT saved into the scene.
+@export var preview_in_editor: bool = false:
+	set(value):
+		preview_in_editor = value
+		if Engine.is_editor_hint():
+			if value:
+				_build_preview()
+			else:
+				_clear_preview()
+
+var _pending_generate: bool = false
+var _spawn_queue: Array[Dictionary] = []
+var _spawn_tick: int = 0
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)  # the editor runs @tool scripts; no server logic there
+		return
+	if trigger_area == null:
+		trigger_area = get_node_or_null("TriggerArea")
+	if trigger_area == null:
+		push_warning("MiningZone: no trigger_area assigned, zone disabled.")
+		set_physics_process(false)
+		return
+	# Only the server detects players, raycasts and spawns; clients do nothing.
+	var is_srv: bool = GameOrchestrator.is_server()
+	trigger_area.monitoring = is_srv
+	set_physics_process(is_srv)
+	if is_srv:
+		trigger_area.body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node3D) -> void:
+	if body.is_in_group("player"):
+		_pending_generate = true
+
+# Server only (physics process is disabled on clients). On a pending request, (re)generate
+# only if the field is currently empty AND we are not already mid-spawn — so an entry into a
+# populated zone does nothing, and a fully-mined zone repopulates on the next entry. The
+# ground raycasts happen here (direct_space_state is only valid during the physics step).
+# Then drain the spawn queue a few rocks per frame to spread the burst.
+func _physics_process(_delta: float) -> void:
+	if Engine.is_editor_hint():
+		return
+	if _pending_generate:
+		_pending_generate = false
+		if _spawn_queue.is_empty() and not _has_rocks_in_field():
+			_build_spawn_queue()
+	if not _spawn_queue.is_empty():
+		_spawn_tick += 1
+		if _spawn_tick >= SPAWN_INTERVAL_FRAMES:
+			_spawn_tick = 0
+			NetworkOrchestrator.spawn_prop_authoritative(_spawn_queue.pop_back())
+
+## True if any mining rock currently sits inside this zone's square field.
+func _has_rocks_in_field() -> bool:
+	var half: float = field_size * 0.5
+	for r in get_tree().get_nodes_in_group("miningrock"):
+		if r is Node3D:
+			var local: Vector3 = to_local((r as Node3D).global_position)
+			if absf(local.x) <= half and absf(local.z) <= half:
+				return true
+	return false
+
+## Seed the RNG and fill _spawn_queue with ready-to-send rock spawn data. All ground
+## raycasts are done here (called from _physics_process) so the physics space is available.
+func _build_spawn_queue() -> void:
+	var seed_str: String = stable_id if stable_id != "" \
+		else "%.2f,%.2f,%.2f" % [global_position.x, global_position.y, global_position.z]
+	var rng := RandomNumberGenerator.new()
+	rng.seed = hash(seed_str)
+	# Parent the rocks to the same networked frame the zone lives under (the planet/city that
+	# MOVES in world space), exactly like mining_depot — otherwise root-level (parent_id="")
+	# rocks are fixed in world space and instantly drift off the rotating planet, so the client
+	# renders them flying into space (invisible). Positions are thus expressed parent-local.
+	var net_parent: Node = _find_net_parent()
+	var parent_uuid: String = str(net_parent.uuid) if net_parent != null and "uuid" in net_parent else ""
+	var to_parent_local: Transform3D = Transform3D.IDENTITY
+	if net_parent is Node3D:
+		to_parent_local = (net_parent as Node3D).global_transform.affine_inverse()
+	var half: float = field_size * 0.5
+	var placed: Array[Vector2] = []
+	var made: int = 0
+	var attempts: int = 0
+	var max_attempts: int = rock_count * 40
+	while made < rock_count and attempts < max_attempts:
+		attempts += 1
+		var lx: float = rng.randf_range(-half, half)
+		var lz: float = rng.randf_range(-half, half)
+		if _too_close(placed, lx, lz):
+			continue
+		var ground: Variant = _ground_point(to_global(Vector3(lx, 0.0, lz)))
+		if ground == null:
+			continue
+		placed.append(Vector2(lx, lz))
+		# Drop from a bit above the ground (along the zone's up) so it settles cleanly.
+		var spawn_world: Vector3 = (ground as Vector3) + global_transform.basis.y.normalized() * SPAWN_DROP
+		var local_pos: Vector3 = to_parent_local * spawn_world
+		_spawn_queue.append({
+			"type": "miningrock",
+			"uuid": _stable_uuid("%s#%d" % [seed_str, made]),
+			"position": {"x": local_pos.x, "y": local_pos.y, "z": local_pos.z},
+			"rotation": {"x": 0.0, "y": rng.randf_range(0.0, TAU), "z": 0.0},
+			"scenename": _pick_scene(rng),
+			"parent_id": parent_uuid,
+			"ore_seed": _ore_seed_for_richness(seed_str, made),
+		})
+		made += 1
+
+## Nearest ancestor that is a networked object (has a `uuid`) — the frame rocks are parented
+## to so they move with the planet/city instead of staying fixed in world space. Mirrors
+## mining_depot's net-parent walk.
+func _find_net_parent() -> Node:
+	var n: Node = get_parent()
+	while n != null and not ("uuid" in n):
+		n = n.get_parent()
+	return n
+
+func _too_close(placed: Array[Vector2], lx: float, lz: float) -> bool:
+	for p in placed:
+		if p.distance_to(Vector2(lx, lz)) < min_spacing:
+			return true
+	return false
+
+## Raycast down along the zone's up axis to drop the rock onto the terrain / structures.
+## Returns the world hit position, or null if nothing was hit there. MUST be called from
+## the physics step (direct_space_state is null outside it).
+func _ground_point(world_xz: Vector3) -> Variant:
+	var space := get_world_3d().direct_space_state
+	if space == null:
+		return null
+	var up: Vector3 = global_transform.basis.y.normalized()
+	var query := PhysicsRayQueryParameters3D.create(world_xz + up * 300.0, world_xz - up * 300.0)
+	query.collide_with_areas = false
+	var hit: Dictionary = space.intersect_ray(query)
+	if hit.is_empty():
+		return null
+	return hit.position
+
+func _pick_scene(rng: RandomNumberGenerator) -> String:
+	var total: float = weight_small + weight_medium + weight_large
+	if total <= 0.0:
+		return SCENE_SMALL
+	var r: float = rng.randf() * total
+	if r < weight_small:
+		return SCENE_SMALL
+	if r < weight_small + weight_medium:
+		return SCENE_MEDIUM
+	return SCENE_LARGE
+
+## Pick an ore_seed whose DERIVED richness (the same hash the rock uses) lands closest to the
+## zone target. ore_seed is replicated, so this controls ore amount with no extra plumbing.
+func _ore_seed_for_richness(seed_str: String, index: int) -> String:
+	var best_seed: String = "%s|ore%d" % [seed_str, index]
+	var best_err: float = 1.0
+	for k in 48:
+		var candidate: String = "%s|ore%d|%d" % [seed_str, index, k]
+		var rich: float = float(absi(candidate.hash()) % 1000) / 1000.0
+		var err: float = absf(rich - richness)
+		if err < best_err:
+			best_err = err
+			best_seed = candidate
+		if err <= richness_spread:
+			return candidate
+	return best_seed
+
+## Deterministic, valid-format uuid from a seed string (same seed -> same uuid across reboots,
+## so the DB upserts instead of piling duplicates). Mirrors mining_depot._stable_uuid.
+func _stable_uuid(seed_str: String) -> String:
+	var h: String = seed_str.sha256_text()
+	return "%s-%s-%s-%s-%s" % [h.substr(0, 8), h.substr(8, 4), h.substr(12, 4), h.substr(16, 4), h.substr(20, 12)]
+
+# ── Editor preview (transient, not networked, not saved) ───────────────────────
+
+## Populate a transient "PreviewRocks" child with rock instances laid out like _generate
+## would (flat y=0 — no physics raycast in the editor) so the field can be eyeballed.
+func _build_preview() -> void:
+	_clear_preview()
+	var holder := Node3D.new()
+	holder.name = "PreviewRocks"
+	add_child(holder)  # no owner set -> not saved into the scene
+	var rng := RandomNumberGenerator.new()
+	rng.seed = hash(stable_id if stable_id != "" else "preview")
+	var half: float = field_size * 0.5
+	var placed: Array[Vector2] = []
+	var made: int = 0
+	var attempts: int = 0
+	while made < rock_count and attempts < rock_count * 40:
+		attempts += 1
+		var lx: float = rng.randf_range(-half, half)
+		var lz: float = rng.randf_range(-half, half)
+		if _too_close(placed, lx, lz):
+			continue
+		placed.append(Vector2(lx, lz))
+		var scene: PackedScene = load("res://" + _pick_scene(rng))
+		var inst: Node3D = scene.instantiate()
+		holder.add_child(inst)
+		inst.position = Vector3(lx, 0.0, lz)
+		inst.rotation.y = rng.randf_range(0.0, TAU)
+		made += 1
+
+func _clear_preview() -> void:
+	var holder := get_node_or_null("PreviewRocks")
+	if holder != null:
+		holder.free()

--- a/scenes/props/MiningZone/mining_zone.gd
+++ b/scenes/props/MiningZone/mining_zone.gd
@@ -49,8 +49,8 @@ const SPAWN_DROP := 2.0
 @export_range(0.0, 1.0) var richness: float = 0.5
 ## How tightly rock richness hugs the target (smaller = tighter spread around `richness`).
 @export_range(0.0, 0.5) var richness_spread: float = 0.12
-## Which mineral this zone yields. Replication of this comes in step 3b (Horizon def); for
-## now it is informational and every rock still renders the default mineral.
+## Which mineral this zone yields (must match a key in rock_mining.gd MINERALS: gold, iron,
+## cryptonite, ...). Replicated per rock via the ore channel and applied on every client.
 @export var mineral_id: String = "gold"
 
 @export_group("Detection")
@@ -78,10 +78,14 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		set_physics_process(false)  # the editor runs @tool scripts; no server logic there
 		return
+	# Always use our OWN TriggerArea child unless trigger_area is explicitly set to one of our
+	# descendants. Prevents accidentally wiring a sibling area (e.g. the ambience Area3D), which
+	# both mis-triggers the zone AND disables that area's monitoring on clients.
+	var own_trigger: Area3D = get_node_or_null("TriggerArea") as Area3D
+	if trigger_area == null or (own_trigger != null and not is_ancestor_of(trigger_area)):
+		trigger_area = own_trigger
 	if trigger_area == null:
-		trigger_area = get_node_or_null("TriggerArea")
-	if trigger_area == null:
-		push_warning("MiningZone: no trigger_area assigned, zone disabled.")
+		push_warning("MiningZone: no TriggerArea found, zone disabled.")
 		set_physics_process(false)
 		return
 	# Only the server detects players, raycasts and spawns; clients do nothing.
@@ -165,6 +169,7 @@ func _build_spawn_queue() -> void:
 			"scenename": _pick_scene(rng),
 			"parent_id": parent_uuid,
 			"ore_seed": _ore_seed_for_richness(seed_str, made),
+			"mineral_id": mineral_id,
 		})
 		made += 1
 

--- a/scenes/props/MiningZone/mining_zone.gd.uid
+++ b/scenes/props/MiningZone/mining_zone.gd.uid
@@ -1,0 +1,1 @@
+uid://c18w1cdmeckpe

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -97,6 +97,14 @@ var _mesh_instance: MeshInstance3D = null
 # Geometric center of the base mesh (its origin is not necessarily its middle), used
 # so a fault at position 0.5 sits in the true middle along its normal.
 var _mesh_center: Vector3 = Vector3.ZERO
+# Half-size of the CSG subtraction box used to cut a fault, in rock-local units. Must reach
+# past the rock surface from the center plane, so it scales with the rock (floored at 10 to
+# keep the small variant's proven behavior). Computed once from the base mesh AABB.
+var _cut_box_half: float = 10.0
+# Uniform scale baked into the mesh (1 for small, >1 for medium/large). The fault-hit
+# tolerances (FAULT_HIT_THRESHOLD / INTERSECTION_MARGIN) are in rock-local units, so they
+# must be multiplied by this to stay proportional — otherwise a big rock is uncuttable.
+var _fault_scale: float = 1.0
 # Velocity to apply once when this piece spawns, to push it off the half it split from.
 var _spawn_kick: Vector3 = Vector3.ZERO
 # Cached per-piece ore fraction (sampled over the piece's volume). -1 = not computed yet;
@@ -116,9 +124,20 @@ func _ready() -> void:
 	add_to_group("carriable")  # so the carry pickup can resolve it by uuid (#124)
 	_full_rock_mass = mass  # GameDesigner value from the scene = the whole-rock mass (before scaling)
 	var item_rock_mesh = get_child(0) as CSGMesh3D
+	# Bake any uniform scale set on the mesh node into a scale-1 mesh, so every cut /
+	# collision / ore computation below works in true-size local space. The small variant
+	# is scale 1 (no-op); medium/large scale their mesh node (x4 / x10) for their size.
+	if item_rock_mesh != null and not item_rock_mesh.scale.is_equal_approx(Vector3.ONE):
+		var s: Vector3 = item_rock_mesh.scale
+		_fault_scale = maxf(s.x, maxf(s.y, s.z))
+		item_rock_mesh.mesh = _scaled_mesh(item_rock_mesh.mesh, s)
+		item_rock_mesh.scale = Vector3.ONE
 	_base_mesh = item_rock_mesh.mesh   # keep a ref to rebuild cuts later
 	if _base_mesh != null:
 		_mesh_center = _base_mesh.get_aabb().get_center()   # true middle of the rock
+		# Box big enough to cover the rock from its center plane (diagonal), floored at the
+		# small variant's original 10 so its cuts are bit-for-bit unchanged.
+		_cut_box_half = maxf(10.0, _base_mesh.get_aabb().size.length())
 	combiner = CSGCombiner3D.new()
 	add_child(combiner)
 
@@ -134,6 +153,23 @@ func _ready() -> void:
 	else:
 		_client_ready()
 
+## Return a copy of `src` with every vertex multiplied by `s` (uniform scale), so a
+## mesh authored small can be baked to its true size at scale 1. Normals/UVs are kept as
+## is (a uniform positive scale preserves normal direction). Used for medium/large variants.
+func _scaled_mesh(src: Mesh, s: Vector3) -> ArrayMesh:
+	var out := ArrayMesh.new()
+	for surf in src.get_surface_count():
+		var arrays: Array = src.surface_get_arrays(surf)
+		var verts: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]
+		for i in verts.size():
+			verts[i] *= s
+		arrays[Mesh.ARRAY_VERTEX] = verts
+		out.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+		var mat: Material = src.surface_get_material(surf)
+		if mat != null:
+			out.surface_set_material(surf, mat)
+	return out
+
 ## Rebuild the cut geometry from the current fault state (server + client). No cut
 ## yet -> keep the initial full-rock combiner and just (re)show the veins.
 func _refresh_cuts() -> void:
@@ -147,17 +183,17 @@ func _refresh_cuts() -> void:
 ## Build the CSG box that subtracts one fault's half from the rock (rock-local).
 func _make_cut_box(bloc: Dictionary) -> CSGBox3D:
 	var box := CSGBox3D.new()
-	box.size = Vector3(20.0, 20.0, 20.0)
+	box.size = Vector3(2.0 * _cut_box_half, 2.0 * _cut_box_half, 2.0 * _cut_box_half)
 	# rotate before translating so the cut plane matches on both halves
 	box.rotation = Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))
-	box.translate_object_local(Vector3(10.5, 0, 0))        # box on the far right of the rock
+	box.translate_object_local(Vector3(_cut_box_half + 0.5, 0, 0))  # box on the far right of the rock
 	box.translate_object_local(Vector3(-bloc.position, 0.0, 0.0))
 	# Shift the cut plane onto the mesh center (along the fault normal) so position 0.5
 	# is the true middle even when the mesh origin is off-center.
 	var n: Vector3 = Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z))) * Vector3(1.0, 0.0, 0.0)
 	box.translate_object_local(Vector3(n.dot(_mesh_center), 0.0, 0.0))
 	if int(bloc.keep_side) == 2:
-		box.translate_object_local(Vector3(-20.0, 0, 0))   # cut the other half instead
+		box.translate_object_local(Vector3(-2.0 * _cut_box_half, 0, 0))   # cut the other half instead
 	box.operation = CSGShape3D.OPERATION_SUBTRACTION
 	return box
 
@@ -286,6 +322,15 @@ func ore_richness() -> float:
 	if s == "":
 		return 0.5
 	return float(absi(s.hash()) % 1000) / 1000.0
+
+## Approximate outer radius of the rock (world units, mesh baked to true size at node
+## scale 1). Tools measure distance to the SURFACE (center - radius) instead of the center,
+## which is mandatory for the big variants whose center sits several metres inside the rock.
+func aim_radius() -> float:
+	if _base_mesh == null:
+		return 0.0
+	var ab: AABB = _base_mesh.get_aabb()
+	return maxf(ab.size.x, maxf(ab.size.y, ab.size.z)) * 0.5
 
 ## Approximate volume of this piece (AABB of its mesh x a fill factor). Used by the mining
 ## depot to refine in volume (kg is meaningless in space — gravity varies).
@@ -572,7 +617,7 @@ func is_on_fault(hit_local: Vector3) -> bool:
 		var r := Basis.from_euler(Vector3(0.0, deg_to_rad(bloc.rotation_y), deg_to_rad(bloc.rotation_z)))
 		var n: Vector3 = r * Vector3(1.0, 0.0, 0.0)
 		var d: float = absf(n.dot(hit_local) - ((0.5 - bloc.position) + n.dot(_mesh_center)))
-		if d <= FAULT_HIT_THRESHOLD:
+		if d <= FAULT_HIT_THRESHOLD * _fault_scale:
 			return true
 	return false
 
@@ -600,13 +645,13 @@ func server_perforate(hit_local: Vector3, push_dir_local: Vector3 = Vector3.ZERO
 			best_i = i
 	if best_i < 0:
 		return
-	if best_d > FAULT_HIT_THRESHOLD:
+	if best_d > FAULT_HIT_THRESHOLD * _fault_scale:
 		return   # the aim point isn't on any fault -> nothing happens
 	# Intersection priority: when the aim point sits on the crossing of several faults
 	# (their distances are nearly tied), cut the one with the LOWEST number.
 	var best_number: int = int(blocs[best_i].get("number", 9999))
 	for i in dists:
-		if dists[i] <= best_d + INTERSECTION_MARGIN:
+		if dists[i] <= best_d + INTERSECTION_MARGIN * _fault_scale:
 			var num: int = int(blocs[i].get("number", 9999))
 			if num < best_number:
 				best_number = num

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -633,6 +633,13 @@ func _physics_process(_delta: float) -> void:
 func _process(_delta: float) -> void:
 	PropNet.ride_pin(self)  # hold the constant local bed pose at render rate (no jitter)
 
+# The replicated scene path (registry key, no res:// prefix) of THIS rock variant, so a
+# broken-off half spawns the SAME scene (small/medium/large) instead of a hardcoded one.
+func _scene_name() -> String:
+	if scene_file_path != "":
+		return scene_file_path.trim_prefix("res://")
+	return "scenes/props/rock/rock_mining_small.tscn"
+
 func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 	# Create the complementary half as its own networked rock. It inherits ALL our
 	# faults (so it shows the remaining veins and can be split again), but the fault we
@@ -661,7 +668,7 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 		"rotation": {"x": rotation[0], "y": rotation[1], "z": rotation[2]},
 		"blocs": side2_blocs,
 		"kick": {"x": kick.x, "y": kick.y, "z": kick.z},
-		"scenename": "scenes/props/rock/rock_mining_01.tscn",
+		"scenename": _scene_name(),
 		# Same parent as ourselves (a known GORC id, or "" for root) so Horizon can
 		# resolve it instead of queuing the side2 forever.
 		"parent_id": created_parent_id,

--- a/scenes/props/rock/rock_mining.gd
+++ b/scenes/props/rock/rock_mining.gd
@@ -38,11 +38,19 @@ const ORE_T_EXTERIOR := 0.7  # high threshold -> very few spots
 const ORE_SCALE_EXTERIOR := 14.0  # high scale -> tiny spots
 # Fraction of a piece's bounding box that is actually solid (rough volume estimate).
 const VOLUME_FILL := 0.5
+# Registry id -> MineralDef, so a replicated mineral_id (string) resolves to its resource on
+# every client/server. Keep in sync with assets/materials/minerals/.
+const GOLD_MINERAL := preload("res://assets/materials/minerals/gold/gold.tres")
+const MINERALS := {
+	"gold": GOLD_MINERAL,
+	"iron": preload("res://assets/materials/minerals/iron/iron.tres"),
+	"cryptonite": preload("res://assets/materials/minerals/cryptonite/cryptonite.tres"),
+}
 
 @export var uuid: String = ""
 ## Which mineral this rock shows (gold, cryptonite, ...). Default = gold for now; per-rock
 ## attribution + replication come later. The ore FIELD (amount/dispersion) stays below.
-@export var mineral: MineralDef = preload("res://assets/materials/minerals/gold/gold.tres")
+@export var mineral: MineralDef = GOLD_MINERAL
 
 @export_group("Fault look")
 ## Neutral fault grooves — they deliberately do NOT reveal the mineral. Width of the crack,
@@ -464,6 +472,32 @@ func _make_rock_material(ore_threshold_v: float, ore_scale_v: float, with_groove
 	mat.set_shader_parameter("plane_offsets", offsets)
 	return mat
 
+## Resolve a replicated mineral_id to its MineralDef and (re)apply the look. Safe to call
+## before _ready (the look is then built with it); after _ready on a client, it rebuilds the
+## displayed material so the rock switches mineral live.
+func _set_mineral(id: String) -> void:
+	if not MINERALS.has(id):
+		return
+	var m: MineralDef = MINERALS[id]
+	if m == mineral:
+		return
+	mineral = m
+	if not OS.has_feature("dedicated_server"):
+		_reskin_current_mineral()
+
+## Re-apply the mineral look to whatever geometry exists (the uncut combiner mesh, or the cut
+## MeshInstance's two surfaces) WITHOUT rebuilding geometry. Rebuilding here would race the
+## blocs-driven _rebuild() on the same frame and duplicate the mesh. No-op before the mesh
+## exists — _client_ready then builds the look with the mineral already set.
+func _reskin_current_mineral() -> void:
+	if combiner != null and is_instance_valid(combiner) and combiner.get_child_count() > 0:
+		var mesh_node = combiner.get_child(0)
+		if mesh_node is CSGMesh3D:
+			(mesh_node as CSGMesh3D).material = _make_exterior_material()
+	if _mesh_instance != null and is_instance_valid(_mesh_instance):
+		_mesh_instance.set_surface_override_material(0, _make_exterior_material())
+		_mesh_instance.set_surface_override_material(1, _make_inner_material())
+
 ## Push the mineral's LOOK onto the shader (texture or flat colour + metalness). Falls back to
 ## the legacy hardcoded preset when no mineral is assigned, so a rock still renders.
 func _apply_mineral(mat: ShaderMaterial) -> void:
@@ -519,9 +553,14 @@ func client_channel_data_update(data: Dictionary) -> void:
 		created_parent_id = str(data["parent_id"])
 	if data.has("ore_seed"):
 		ore_seed = str(data["ore_seed"])
+	if data.has("mineral_id"):
+		_set_mineral(str(data["mineral_id"]))
 	if data.has("kick"):
 		_spawn_kick = Vector3(data["kick"]["x"], data["kick"]["y"], data["kick"]["z"])
 	PropNet.apply_client_transform(self, data)  # position/rotation (+ remembers the local ride pose)
+	# Always re-derive the cut geometry from the replicated blocs (idempotent): a "skip if
+	# unchanged" guard desyncs the mesh from blocs when a rebuild is interrupted mid-flap
+	# (GORC churn), leaving the rock visually whole forever.
 	if data.has("blocs"):
 		blocs = data["blocs"]
 		# _rebuild() needs `_base_mesh`, set in _ready(). When this rock is spawned
@@ -719,6 +758,8 @@ func _server_create_side2_rock(cut_index: int, kick: Vector3) -> void:
 		"parent_id": created_parent_id,
 		# Inherit our ore distribution seed so the piece's exterior stays continuous.
 		"ore_seed": ore_seed if ore_seed != "" else uuid,
+		# Inherit our mineral so the broken-off half shows the same ore (not the default gold).
+		"mineral_id": str(mineral.id) if mineral != null else "",
 	}
 	# Register the side2 in Horizon (other players) AND create it locally on this game
 	# server (so it can be simulated and re-cut). Horizon's GORC is players-only and does

--- a/scenes/props/rock/rock_mining_large.tscn
+++ b/scenes/props/rock/rock_mining_large.tscn
@@ -1,0 +1,30 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" uid="uid://cynqji0v1gvlk" path="res://scenes/props/rock/rock_mining.gd" id="1_script"]
+[ext_resource type="ArrayMesh" uid="uid://qs2ropifk3ww" path="res://assets/_universe/environment/terrain/rocks/rock_large.res" id="2_mesh"]
+[ext_resource type="Material" uid="uid://bp1l8v64nroad" path="res://scenes/props/rock/rock_material.tres" id="3_mat"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_area"]
+radius = 5.5
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_body"]
+
+[node name="RockMiningLarge" type="RigidBody3D"]
+mass = 5000.0
+continuous_cd = true
+script = ExtResource("1_script")
+
+[node name="CSGMesh3D" type="CSGMesh3D" parent="."]
+transform = Transform3D(2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0)
+material_override = ExtResource("3_mat")
+mesh = ExtResource("2_mesh")
+material = ExtResource("3_mat")
+
+[node name="Area3D" type="Area3D" parent="."]
+monitoring = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("SphereShape3D_area")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("SphereShape3D_body")

--- a/scenes/props/rock/rock_mining_medium.tscn
+++ b/scenes/props/rock/rock_mining_medium.tscn
@@ -1,0 +1,30 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" uid="uid://cynqji0v1gvlk" path="res://scenes/props/rock/rock_mining.gd" id="1_script"]
+[ext_resource type="ArrayMesh" uid="uid://cxl8l75u4r1bg" path="res://assets/_universe/environment/terrain/rocks/rock_medium.res" id="2_mesh"]
+[ext_resource type="Material" uid="uid://bp1l8v64nroad" path="res://scenes/props/rock/rock_material.tres" id="3_mat"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_area"]
+radius = 3.5
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_body"]
+
+[node name="RockMiningMedium" type="RigidBody3D"]
+mass = 2000.0
+continuous_cd = true
+script = ExtResource("1_script")
+
+[node name="CSGMesh3D" type="CSGMesh3D" parent="."]
+transform = Transform3D(1.2, 0, 0, 0, 1.2, 0, 0, 0, 1.2, 0, 0, 0)
+material_override = ExtResource("3_mat")
+mesh = ExtResource("2_mesh")
+material = ExtResource("3_mat")
+
+[node name="Area3D" type="Area3D" parent="."]
+monitoring = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("SphereShape3D_area")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("SphereShape3D_body")

--- a/scenes/props/rock/rock_mining_small.tscn
+++ b/scenes/props/rock/rock_mining_small.tscn
@@ -8,7 +8,7 @@
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_ducf2"]
 
-[node name="RockMining01" type="RigidBody3D" unique_id=525353877]
+[node name="RockMiningSmall" type="RigidBody3D" unique_id=525353877]
 mass = 800.0
 continuous_cd = true
 script = ExtResource("1_6o14g")

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -34,7 +34,7 @@ const GENERATED := "vehicle_generated"
 # Thickness of the generated bed floor / walls (m). Shared by the collider and the cargo-rest math.
 const BED_WALL_THICKNESS := 0.08
 # Bench: the real mining rock scene, reused to test loading the bed.
-const ROCK_SCENE := preload("res://scenes/props/rock/rock_mining_01.tscn")
+const ROCK_SCENE := preload("res://scenes/props/rock/rock_mining_small.tscn")
 const UUID_UTIL := preload("res://addons/uuid/uuid.gd")
 ## Group a dev adds to any Light3D in their vehicle scene to make it a head light (drop-in, no code).
 const LIGHT_GROUP := "vehicle_light"

--- a/server/client.gd
+++ b/server/client.gd
@@ -49,8 +49,8 @@ var props_scene: Dictionary = {
 	'scenes/props/StorageBoxes/pallet_liquid_120x80x100.tscn':
 		preload('res://scenes/props/StorageBoxes/pallet_liquid_120x80x100.tscn'),
 	# 'scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn': preload('res://scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn'),
-	'scenes/props/rock/rock_mining_01.tscn':
-		preload('res://scenes/props/rock/rock_mining_01.tscn'),
+	'scenes/props/rock/rock_mining_small.tscn':
+		preload('res://scenes/props/rock/rock_mining_small.tscn'),
 	'scenes/props/testbox/box_50cm.tscn':
 		preload('res://scenes/props/testbox/box_50cm.tscn'),
 	'scenes/props/testbox/box_4m.tscn':

--- a/server/client.gd
+++ b/server/client.gd
@@ -51,6 +51,10 @@ var props_scene: Dictionary = {
 	# 'scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn': preload('res://scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn'),
 	'scenes/props/rock/rock_mining_small.tscn':
 		preload('res://scenes/props/rock/rock_mining_small.tscn'),
+	'scenes/props/rock/rock_mining_medium.tscn':
+		preload('res://scenes/props/rock/rock_mining_medium.tscn'),
+	'scenes/props/rock/rock_mining_large.tscn':
+		preload('res://scenes/props/rock/rock_mining_large.tscn'),
 	'scenes/props/testbox/box_50cm.tscn':
 		preload('res://scenes/props/testbox/box_50cm.tscn'),
 	'scenes/props/testbox/box_4m.tscn':

--- a/server/server.gd
+++ b/server/server.gd
@@ -92,6 +92,10 @@ var props_scene: Dictionary = {
 	# 'scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn': preload('res://scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn'),
 	'scenes/props/rock/rock_mining_small.tscn':
 		preload('res://scenes/props/rock/rock_mining_small.tscn'),
+	'scenes/props/rock/rock_mining_medium.tscn':
+		preload('res://scenes/props/rock/rock_mining_medium.tscn'),
+	'scenes/props/rock/rock_mining_large.tscn':
+		preload('res://scenes/props/rock/rock_mining_large.tscn'),
 	'scenes/props/testbox/box_50cm.tscn':
 		preload('res://scenes/props/testbox/box_50cm.tscn'),
 	'scenes/props/testbox/box_4m.tscn':

--- a/server/server.gd
+++ b/server/server.gd
@@ -90,8 +90,8 @@ var props_scene: Dictionary = {
 	'scenes/props/StorageBoxes/pallet_liquid_120x80x100.tscn':
 		preload('res://scenes/props/StorageBoxes/pallet_liquid_120x80x100.tscn'),
 	# 'scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn': preload('res://scenes/props/StorageBoxes/pallet_plate_120x80x100.tscn'),
-	'scenes/props/rock/rock_mining_01.tscn':
-		preload('res://scenes/props/rock/rock_mining_01.tscn'),
+	'scenes/props/rock/rock_mining_small.tscn':
+		preload('res://scenes/props/rock/rock_mining_small.tscn'),
 	'scenes/props/testbox/box_50cm.tscn':
 		preload('res://scenes/props/testbox/box_50cm.tscn'),
 	'scenes/props/testbox/box_4m.tscn':


### PR DESCRIPTION
## Description
Adds **Mining Zones**: a designer-placed `Mining_Zone.tscn` (Node3D + ~1 km trigger Area3D) that, when a player enters and the field is empty, **server-side seed-generates** a square field of mining rocks (deterministic positions ground-raycast-placed, size mix, per-zone ore richness via the replicated `ore_seed`). Rocks are parented to the zone's networked ancestor (moving planet/city frame) with parent-local positions.

Also:
- Renamed `rock_mining_01.tscn` → `rock_mining_small.tscn`, scene name now derived dynamically (`scene_file_path`).
- New **medium / large** mineable variants (reuse `rock_mining.gd`, runtime scale-bake so cut/collision/ore work at true size; cut box + fault-hit tolerance scale with the rock; `aim_radius()` so the tool measures distance to the surface).
- **Per-zone mineral** (gold / iron / cryptonite): replicated `mineral_id`, registry → MineralDef, re-skin on receive (exterior + cut faces), inherited by broken-off halves. Adds the **iron** MineralDef.

Needs the companion horizonserver PR (adds `mineral_id` to `miningrock_def.json` + widens replication distance 30 → 150 m).

## Changelog

<!-- CHANGELOG_EN -->
- feat: mining zones generate rock fields server-side on player entry (seeded, renewable)
- feat: small / medium / large mineable rock variants
- feat: per-zone mineral replicated via `mineral_id` (gold / iron / cryptonite)
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- Fonctionnalité : les zones minières génèrent des champs rocheux côté serveur à l’entrée du joueur (ensemencés et renouvelables).
- Fonctionnalité : variantes de roches exploitables de petite, moyenne et grande taille.
- Fonctionnalité : chaque zone contient un minéral répliqué via `mineral_id` (or, fer, cryptonite).
<!-- /CHANGELOG_FR -->