### PR TITLE
Fix mining depot double-spawn (deterministic uuid)

### DIFF
--- a/scenes/structures/mining_depot.gd
+++ b/scenes/structures/mining_depot.gd
@@ -76,8 +76,12 @@ func _ready() -> void:
 			# restarts (the database upserts by uuid -> no duplicate pile-up, and no delete is
 			# needed). Seed from the explicit stable_id, else from the fixed placement position
 			# so no manual setup is required.
+			# Seed from the STABLE local placement (parent frame) + parent uuid, NOT global_position:
+			# the parent is a moving world frame, so global_position differs every restart -> a new
+			# uuid each time -> the DB (upsert by uuid) never dedups -> depots pile up. place_pos is
+			# fixed in the parent's frame, so the same depot keeps the same uuid across restarts.
 			var uuid_seed: String = stable_id if stable_id != "" \
-				else "%.3f,%.3f,%.3f" % [global_position.x, global_position.y, global_position.z]
+				else "%s|%.3f,%.3f,%.3f" % [parent_uuid, place_pos.x, place_pos.y, place_pos.z]
 			var depot_uuid: String = _stable_uuid(uuid_seed)
 			# Designer-placed depot = world infrastructure: protect it from the admin cleanup
 			# tool (only player-spawned depots should be deletable).


### PR DESCRIPTION
## Description

A designer-placed mining depot was **persisted multiple times**: every server restart added a new `mining_depot` row at the same spot (same parent, same local position) with a different uuid, piling up in the database.

**Cause.** The depot builds a stable uuid so the DB can upsert it (one depot, one row across restarts). But the uuid was seeded from `global_position`. The depot's parent is a **moving world frame** (the planet/city moves), so `global_position` is different on every boot → a new seed → a new uuid → the upsert-by-uuid never matched → duplicates accumulated. The placement itself was already correct (stored in the parent's local frame); only the uuid seed used the wrong, drifting value.

**Fix.** Seed the uuid from the **stable local placement** (the depot's position in the parent's frame, which is fixed) **+ the parent uuid**, instead of `global_position`. The same depot now keeps the same uuid across restarts → the DB upserts it → no duplicate pile-up.

Verified: after the fix, restarting the server keeps exactly one `mining_depot` row, and its uuid matches the deterministic seed.

## Changelog

<!-- CHANGELOG_EN -->
Fix designer-placed mining depots being duplicated in the database on every server restart.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Corrige la duplication des dépôts de minage en base à chaque redémarrage du serveur.
<!-- /CHANGELOG_FR -->