### PR TITLE
DyingStar editor tool: import/export server props (startup_items.json)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ assets/qgis/checksum.txt
 assets/qgis/creationtime.txt
 assets/qgis/export.tar.gz
 
+addons/dyingstar/network_defs.json

--- a/addons/dyingstar/dyingstar.gd
+++ b/addons/dyingstar/dyingstar.gd
@@ -2,33 +2,512 @@
 extends EditorPlugin
 
 const MainPanel = preload("res://addons/dyingstar/main_panel.tscn")
+const ServerPropsIO = preload("res://addons/dyingstar/server_props_io.gd")
+
+const ITEM_IMPORT := 0
+const ITEM_EXPORT := 1
+const ITEM_CLEAR := 2
+const ITEM_UPDATE_DEFS := 3
+const ITEM_VIEW_DEFS := 4
+
+## GitHub source of the network definitions (<type>_def.json), fetched on startup and on demand.
+const DEFS_API := "https://api.github.com/repos/DyingStar-game/horizonserver/contents/ds_genericprops/props?ref=develop"
+const DEFS_HEADERS := ["User-Agent: dyingstar-godot-plugin", "Accept: application/vnd.github+json"]
+## Fallback type list when the GitHub API listing is rate-limited (403): each file is then fetched
+## by its own api.github.com contents URL. The listing is preferred when available (discovers new types).
+const DEFS_KNOWN := ["box", "building", "city", "mining_depot", "miningrock", "palette_container",
+	"planet", "player", "spawnbuilding", "star", "storagewarehouse", "vehicle"]
 
 var main_panel_instance
+var _menu_button: MenuButton = null
+var _ds_popup: PopupMenu = null  # the menu when hosted in an editor MenuBar
+var _tool_menu_added := false
+var _file_dialog: EditorFileDialog = null
+var _dialog_mode := ""  # "import" or "export"
+var _http: HTTPRequest = null
+var _defs_loading := false
+var _defs_ready := false  # whether Import/Export are allowed (fresh fetch OK, or cache accepted)
+var _defs_abort := false  # set by "Use cache instead" to stop the in-progress download
+
 
 func _enable_plugin() -> void:
-	# Add autoloads here.
 	pass
 
 
 func _disable_plugin() -> void:
-	# Remove autoloads here.
 	pass
 
 
 func _enter_tree() -> void:
-	# Initialization of the plugin goes here.
 	main_panel_instance = MainPanel.instantiate()
 	add_control_to_bottom_panel(main_panel_instance, "DyingStar")
+	_http = HTTPRequest.new()
+	_http.timeout = 20.0  # never hang forever (would lock _defs_loading and the menus)
+	EditorInterface.get_base_control().add_child(_http)
+	_install_menu()
+	# Always refresh the network definitions from GitHub on startup (designers have no local Horizon).
+	_refresh_defs()
 
 
 func _exit_tree() -> void:
-	# Clean-up of the plugin goes here.
 	remove_control_from_bottom_panel(main_panel_instance)
-	
 	if is_instance_valid(main_panel_instance):
 		main_panel_instance.queue_free()
 		main_panel_instance = null
+	_remove_menu()
+	if is_instance_valid(_file_dialog):
+		_file_dialog.queue_free()
+		_file_dialog = null
+	if is_instance_valid(_http):
+		_http.queue_free()
+		_http = null
 
 
 func _get_plugin_name():
 	return "DyingStar"
+
+
+func _get_plugin_icon():
+	return null
+
+
+# ── "DyingStar" top menu (sits just before Help/Aide in the editor menu bar) ──
+
+func _install_menu() -> void:
+	var base := EditorInterface.get_base_control()
+	# Strategy A — the editor uses a MenuBar (Godot 4.3+): add our PopupMenu as a top menu.
+	var menubar := _find_by_class(base, "MenuBar")
+	if menubar != null:
+		_ds_popup = PopupMenu.new()
+		_ds_popup.name = "DyingStar"
+		_fill_popup(_ds_popup)
+		menubar.add_child(_ds_popup)
+		var idx := _menubar_index(menubar, ["Help", "Aide"])
+		if idx >= 0:
+			menubar.move_child(_ds_popup, idx)  # sit right before Help/Aide
+		print("DyingStar: menu added to the editor MenuBar.")
+		return
+	# Strategy B — a row of MenuButton/Button: sit right before the Help/Aide entry.
+	var help := _find_menu_label(base, ["Help", "Aide"])
+	if help != null and help.get_parent() != null:
+		_menu_button = MenuButton.new()
+		_menu_button.text = "DyingStar"
+		_menu_button.flat = true
+		_fill_popup(_menu_button.get_popup())
+		help.get_parent().add_child(_menu_button)
+		help.get_parent().move_child(_menu_button, help.get_index())
+		print("DyingStar: menu added before '%s' in the editor menu row." % help.text)
+		return
+	# Strategy C — fallback to Project > Tools.
+	push_warning("DyingStar: editor menu bar not found, using Project > Tools fallback.")
+	add_tool_menu_item("DyingStar — Import server props…", _on_import)
+	add_tool_menu_item("DyingStar — Export server props…", _on_export)
+	add_tool_menu_item("DyingStar — Clear server props", _on_clear)
+	add_tool_menu_item("DyingStar — Update network definitions", _on_update_defs)
+	add_tool_menu_item("DyingStar — View network definitions…", _on_view_defs)
+	_tool_menu_added = true
+
+
+func _fill_popup(pm: PopupMenu) -> void:
+	pm.add_item("Import server props from JSON…", ITEM_IMPORT)
+	pm.add_item("Export server props to JSON…", ITEM_EXPORT)
+	pm.add_separator()
+	pm.add_item("Clear server props (build clean)", ITEM_CLEAR)
+	pm.add_separator()
+	pm.add_item("Update network definitions (GitHub)", ITEM_UPDATE_DEFS)
+	pm.add_item("View network definitions…", ITEM_VIEW_DEFS)
+	pm.id_pressed.connect(_on_menu_id)
+	_refresh_menu_state()
+
+
+func _remove_menu() -> void:
+	if is_instance_valid(_ds_popup):
+		_ds_popup.queue_free()
+		_ds_popup = null
+	if is_instance_valid(_menu_button):
+		_menu_button.queue_free()
+		_menu_button = null
+	if _tool_menu_added:
+		remove_tool_menu_item("DyingStar — Import server props…")
+		remove_tool_menu_item("DyingStar — Export server props…")
+		remove_tool_menu_item("DyingStar — Clear server props")
+		remove_tool_menu_item("DyingStar — Update network definitions")
+		remove_tool_menu_item("DyingStar — View network definitions…")
+		_tool_menu_added = false
+
+
+## Depth-first search for the first node of a given class (e.g. "MenuBar").
+func _find_by_class(node: Node, klass: String) -> Node:
+	if node.is_class(klass):
+		return node
+	for c in node.get_children():
+		var r := _find_by_class(c, klass)
+		if r != null:
+			return r
+	return null
+
+
+## Index of the MenuBar menu whose title matches one of `labels` (-1 if none).
+func _menubar_index(menubar, labels: Array) -> int:
+	for i in menubar.get_menu_count():
+		if String(menubar.get_menu_title(i)).strip_edges() in labels:
+			return i
+	return -1
+
+
+## First Button/MenuButton whose (trimmed) text matches one of `labels` — an editor menu entry.
+func _find_menu_label(node: Node, labels: Array) -> Control:
+	if node is Button and String((node as Button).text).strip_edges() in labels:
+		return node
+	for c in node.get_children():
+		var r := _find_menu_label(c, labels)
+		if r != null:
+			return r
+	return null
+
+
+func _on_menu_id(id: int) -> void:
+	match id:
+		ITEM_IMPORT:
+			_on_import()
+		ITEM_EXPORT:
+			_on_export()
+		ITEM_CLEAR:
+			_on_clear()
+		ITEM_UPDATE_DEFS:
+			_on_update_defs()
+		ITEM_VIEW_DEFS:
+			_on_view_defs()
+
+
+# ── Actions ──────────────────────────────────────────────────────────────────
+
+func _on_import() -> void:
+	_open_dialog("import")
+
+
+func _on_export() -> void:
+	_open_dialog("export")
+
+
+func _open_dialog(mode: String) -> void:
+	_dialog_mode = mode
+	if _file_dialog == null:
+		_file_dialog = EditorFileDialog.new()
+		_file_dialog.access = EditorFileDialog.ACCESS_FILESYSTEM  # browse outside res:// (e.g. horizonserver)
+		_file_dialog.add_filter("*.json", "JSON files")
+		_file_dialog.file_selected.connect(_on_file_selected)
+		EditorInterface.get_base_control().add_child(_file_dialog)
+	_file_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE if mode == "import" else EditorFileDialog.FILE_MODE_SAVE_FILE
+	_file_dialog.title = "Import server props JSON" if mode == "import" else "Export server props JSON"
+	if mode == "export":
+		_file_dialog.current_file = "startup_items.json"
+	_file_dialog.popup_centered_ratio(0.6)
+
+
+func _on_file_selected(path: String) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var res: Dictionary
+	if _dialog_mode == "import":
+		res = ServerPropsIO.import_from_json(scene_root, path)
+		# Select the import root so the designer can frame it with F (objects sit at planetary coords).
+		if res.get("ok", false) and res.get("root_node") != null:
+			var sel := EditorInterface.get_selection()
+			sel.clear()
+			sel.add_node(res["root_node"])
+	else:
+		res = ServerPropsIO.export_to_json(scene_root, path)
+	_report(_dialog_mode, res)
+
+
+func _on_clear() -> void:
+	_report("clear", ServerPropsIO.clear(EditorInterface.get_edited_scene_root()))
+
+
+## Print + a small dialog with the result of an import/export/clear.
+func _report(action: String, res: Dictionary) -> void:
+	var msg := ""
+	if res.get("ok", false):
+		msg = "DyingStar %s: OK — %d objects." % [action, int(res.get("count", 0))]
+		if res.has("by_type"):
+			msg += "\nBy type: %s" % str(res["by_type"])
+		if int(res.get("skipped", 0)) > 0:
+			msg += "\n%d skipped (see Output)." % int(res["skipped"])
+		# Remind where the server actually spawns this scene (the editor keeps the root at 0,0,0).
+		var sp = res.get("server_position")
+		if sp != null:
+			msg += "\nServer spawn (JSON): (%.1f, %.1f, %.1f)" % [
+				float(sp.get("x", 0.0)), float(sp.get("y", 0.0)), float(sp.get("z", 0.0))]
+			if str(res.get("server_parent_id", "")) != "":
+				msg += " under %s" % str(res["server_parent_id"])
+			msg += " — edited at (0,0,0)."
+	else:
+		msg = "DyingStar %s FAILED: %s" % [action, str(res.get("error", "unknown"))]
+	print(msg)
+	# Persistent feedback in the DyingStar bottom panel.
+	if is_instance_valid(main_panel_instance) and main_panel_instance.has_method("show_status"):
+		main_panel_instance.show_status(msg)
+	var dlg := AcceptDialog.new()
+	dlg.title = "DyingStar"
+	dlg.dialog_text = msg
+	EditorInterface.get_base_control().add_child(dlg)
+	dlg.popup_centered()
+	dlg.confirmed.connect(dlg.queue_free)
+	dlg.canceled.connect(dlg.queue_free)
+
+
+# ── Network definitions (fetched from GitHub) ──────────────────────────────────
+
+func _on_update_defs() -> void:
+	_refresh_defs()
+
+
+## Fetch the <type>_def.json files from GitHub, cache them, and refresh the menu state. Used both on
+## startup and by the "Update network definitions" menu item (always hits GitHub).
+func _refresh_defs() -> void:
+	if _defs_loading or not is_instance_valid(_http):
+		return
+	_defs_loading = true
+	_defs_abort = false
+	_refresh_menu_state()
+	# Blocking modal with a progress bar: the designer sees the download and can't touch anything else.
+	var dlg := AcceptDialog.new()
+	dlg.title = "DyingStar — Network definitions"
+	dlg.exclusive = true
+	var vbox := VBoxContainer.new()
+	vbox.custom_minimum_size = Vector2(440, 0)
+	var lbl := Label.new()
+	lbl.text = "Connecting to GitHub…"
+	var bar := ProgressBar.new()
+	vbox.add_child(lbl)
+	vbox.add_child(bar)
+	dlg.add_child(vbox)
+	EditorInterface.get_base_control().add_child(dlg)
+	dlg.get_ok_button().disabled = true  # cannot dismiss while downloading
+	# "Use cache instead": skip the download and use the cached defs (disabled when there is no cache).
+	var cache_btn := dlg.add_button("Use cache instead", false, "use_cache")
+	cache_btn.disabled = not ServerPropsIO.has_network_defs()
+	dlg.custom_action.connect(_on_progress_action.bind(dlg))
+	dlg.popup_centered(Vector2i(520, 160))
+	var count := await _fetch_defs(lbl, bar)
+	if _defs_abort:
+		return  # the "Use cache instead" button already handled everything
+	_defs_loading = false
+	if count > 0:
+		_defs_ready = true
+		_finish_dialog(dlg, lbl, bar,
+			"OK — updated %d type definitions from GitHub.\nImport / Export are now enabled." % count)
+	elif ServerPropsIO.has_network_defs():
+		dlg.queue_free()  # close the progress modal; let the designer choose whether to use the cache
+		_propose_cached()
+	else:
+		_defs_ready = false
+		_finish_dialog(dlg, lbl, bar,
+			"FAILED — could not fetch the definitions and no cache is available.\nImport / Export disabled.")
+	_refresh_menu_state()
+
+
+## "Use cache instead" pressed in the progress modal: stop the download and use the cached defs.
+func _on_progress_action(action: StringName, dlg: AcceptDialog) -> void:
+	if String(action) != "use_cache":
+		return
+	_defs_abort = true
+	_defs_loading = false
+	_defs_ready = true
+	_refresh_menu_state()
+	_status("DyingStar: using the cached network definitions (download skipped).")
+	if is_instance_valid(dlg):
+		dlg.queue_free()
+
+
+## Turn the progress modal into its final state (result text + closable OK) and report it.
+func _finish_dialog(dlg: AcceptDialog, lbl: Label, bar: ProgressBar, msg: String) -> void:
+	lbl.text = msg
+	bar.value = bar.max_value
+	dlg.get_ok_button().disabled = false
+	dlg.confirmed.connect(dlg.queue_free)
+	dlg.canceled.connect(dlg.queue_free)
+	_status(msg)
+
+
+## GitHub unreachable but a cache exists: ask the designer whether to use the cached definitions.
+func _propose_cached() -> void:
+	var n := ServerPropsIO.load_network_defs().size()
+	var cd := ConfirmationDialog.new()
+	cd.title = "DyingStar — Network definitions"
+	cd.dialog_text = "Could not reach GitHub.\nUse the previously cached definitions (%d types)?" % n
+	cd.get_ok_button().text = "Use cached"
+	cd.get_cancel_button().text = "Disable"
+	EditorInterface.get_base_control().add_child(cd)
+	cd.confirmed.connect(_on_use_cached.bind(cd))
+	cd.canceled.connect(_on_decline_cached.bind(cd))
+	cd.popup_centered()
+
+
+func _on_use_cached(cd: ConfirmationDialog) -> void:
+	_defs_ready = true
+	_refresh_menu_state()
+	_status("DyingStar: using the cached network definitions (Import / Export enabled).")
+	cd.queue_free()
+
+
+func _on_decline_cached(cd: ConfirmationDialog) -> void:
+	_defs_ready = false
+	_refresh_menu_state()
+	_status("DyingStar: cached definitions declined — Import / Export disabled.")
+	cd.queue_free()
+
+
+func _status(msg: String) -> void:
+	print(msg)
+	if is_instance_valid(main_panel_instance) and main_panel_instance.has_method("show_status"):
+		main_panel_instance.show_status(msg)
+
+
+## Show the cached network definitions ({type: [properties]}) in a searchable tree.
+func _on_view_defs() -> void:
+	var defs := ServerPropsIO.load_network_defs()
+	var dlg := AcceptDialog.new()
+	dlg.title = "DyingStar — Network definitions (%d types)" % defs.size()
+	var vbox := VBoxContainer.new()
+	vbox.custom_minimum_size = Vector2(420, 460)
+	var search := LineEdit.new()
+	search.placeholder_text = "Filter by type or property…"
+	search.clear_button_enabled = true
+	var tree := Tree.new()
+	tree.hide_root = true
+	tree.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	vbox.add_child(search)
+	vbox.add_child(tree)
+	dlg.add_child(vbox)
+	EditorInterface.get_base_control().add_child(dlg)
+	_populate_defs_tree(tree, defs, "")
+	search.text_changed.connect(_on_defs_filter.bind(tree, defs))
+	dlg.confirmed.connect(dlg.queue_free)
+	dlg.canceled.connect(dlg.queue_free)
+	dlg.popup_centered(Vector2i(460, 520))
+
+
+func _on_defs_filter(text: String, tree: Tree, defs: Dictionary) -> void:
+	_populate_defs_tree(tree, defs, text)
+
+
+## (Re)build the tree: one item per type matching the filter, with its properties as children. A
+## type matches if its name contains the filter (then all its properties show), or if any property
+## does (then only the matching ones show).
+func _populate_defs_tree(tree: Tree, defs: Dictionary, filter: String) -> void:
+	tree.clear()
+	var root := tree.create_item()
+	var f := filter.strip_edges().to_lower()
+	var types := defs.keys()
+	types.sort()
+	for type_name in types:
+		var props: Array = defs[type_name]
+		var type_match := f == "" or str(type_name).to_lower().contains(f)
+		var shown: Array = []
+		for p in props:
+			if type_match or str(p).to_lower().contains(f):
+				shown.append(p)
+		if not type_match and shown.is_empty():
+			continue
+		var ti := tree.create_item(root)
+		ti.set_text(0, "%s  (%d)" % [str(type_name), props.size()])
+		for p in shown:
+			tree.create_item(ti).set_text(0, str(p))
+	if root.get_child_count() == 0:
+		var msg := "No definitions — run 'Update network definitions' first." if defs.is_empty() else "No match."
+		tree.create_item(root).set_text(0, msg)
+
+
+## Download the props directory listing then each <type>_def.json, parse the union of channel
+## properties per type, and write the cache. Returns the type count (0 = failure; cache untouched).
+func _fetch_defs(lbl: Label, bar: ProgressBar) -> int:
+	# List via the GitHub API (1 call) to discover every <type>_def.json; fall back to the built-in
+	# list if it fails. File CONTENT is fetched from the SAME api.github.com host (base64): raw
+	# .githubusercontent.com times out via Godot's HTTPRequest on some networks (even when curl works).
+	lbl.text = "Listing definitions on GitHub…"
+	var files: Array = []  # [{name, url}]  url = api.github.com contents URL
+	var r := await _http_req(DEFS_API, DEFS_HEADERS)
+	if _http_ok(r):
+		var listing = JSON.parse_string((r[3] as PackedByteArray).get_string_from_utf8())
+		if typeof(listing) == TYPE_ARRAY:
+			for item in listing:
+				var n := str(item.get("name", ""))
+				if n.ends_with("_def.json"):
+					files.append({"name": n, "url": str(item.get("url", ""))})
+	if files.is_empty():
+		push_warning("DyingStar defs: API listing unavailable %s — using the built-in list." % _http_status(r))
+		for t in DEFS_KNOWN:
+			files.append({"name": "%s_def.json" % t, "url": DEFS_API.replace("?ref=", "/%s_def.json?ref=" % t)})
+	bar.max_value = max(1, files.size())
+	bar.value = 0
+	var defs := {}
+	var i := 0
+	for fobj in files:
+		if _defs_abort:  # "Use cache instead" was pressed
+			return 0
+		i += 1
+		var fname := str(fobj["name"])
+		var url := str(fobj["url"])
+		lbl.text = "Downloading %s  (%d/%d)" % [fname, i, files.size()]
+		bar.value = i
+		if url == "":
+			continue
+		var rf := await _http_req(url, DEFS_HEADERS)
+		if not _http_ok(rf):
+			push_warning("DyingStar defs: %s failed %s" % [fname, _http_status(rf)])
+			continue
+		var meta = JSON.parse_string((rf[3] as PackedByteArray).get_string_from_utf8())
+		if typeof(meta) != TYPE_DICTIONARY:
+			continue
+		var b64 := str(meta.get("content", "")).replace("\n", "").replace("\r", "")
+		var dj = JSON.parse_string(Marshalls.base64_to_utf8(b64))
+		if typeof(dj) != TYPE_DICTIONARY:
+			continue
+		var props: Array = []
+		for ch in dj.get("channels", []):
+			for p in ch.get("properties", []):
+				var ps := str(p).strip_edges()
+				if ps != "" and not props.has(ps):
+					props.append(ps)
+		defs[fname.trim_suffix("_def.json")] = props
+	if defs.is_empty():
+		push_error("DyingStar defs: nothing parsed; keeping the previous cache")
+		return 0
+	var f := FileAccess.open(ServerPropsIO.DEFS_CACHE, FileAccess.WRITE)
+	if f == null:
+		push_error("DyingStar defs: cannot write cache %s" % ServerPropsIO.DEFS_CACHE)
+		return 0
+	f.store_string(JSON.stringify(defs, "    "))
+	f.close()
+	return defs.size()
+
+
+## Reuse the SHARED HTTPRequest (created in _enter_tree, which the editor polls correctly; a fresh
+## HTTPRequest created inside a coroutine is not polled and times out). [result, code, headers, body] or [].
+func _http_req(url: String, headers) -> Array:
+	if _http.request(url, headers) != OK:
+		return []
+	return await _http.request_completed
+
+
+func _http_ok(r: Array) -> bool:
+	return r.size() >= 4 and int(r[0]) == HTTPRequest.RESULT_SUCCESS and int(r[1]) == 200
+
+
+func _http_status(r: Array) -> String:
+	if r.size() < 2:
+		return "(no response — connection error)"
+	return "(result %d, HTTP %d)" % [int(r[0]), int(r[1])]
+
+
+## Grey out Import/Export while the network definitions are missing or being fetched.
+func _refresh_menu_state() -> void:
+	var ready := _defs_ready and not _defs_loading
+	for pm in [_ds_popup, (_menu_button.get_popup() if is_instance_valid(_menu_button) else null)]:
+		if pm == null:
+			continue
+		for id in [ITEM_IMPORT, ITEM_EXPORT]:
+			var idx: int = pm.get_item_index(id)
+			if idx >= 0:
+				pm.set_item_disabled(idx, not ready)

--- a/addons/dyingstar/main_panel.gd
+++ b/addons/dyingstar/main_panel.gd
@@ -6,6 +6,12 @@ extends Control
 func _ready() -> void:
 	_on_reload_command_pressed()
 
+## Show the result of an import/export/clear (incl. the server spawn position) in the panel.
+func show_status(text: String) -> void:
+	var lbl := get_node_or_null("MarginContainer/VBoxContainer/ServerPropsStatus")
+	if lbl:
+		lbl.text = text
+
 func _on_reload_command_pressed() -> void:
 	# read the devmodefolder
 	var children = devmodelist.get_children()
@@ -28,7 +34,7 @@ func _on_reload_command_pressed() -> void:
 			file_name = dir.get_next()
 	else:
 		print("An error occurred when trying to access the path.")
-	
+
 	self.set_focus_mode(Control.FOCUS_ALL)
 	self.grab_focus()
 	self.set_focus_mode(Control.FOCUS_NONE)
@@ -38,13 +44,13 @@ func _on_button_pressed(file_name: String):
 	var editor = EditorInterface.get_editor_settings()
 	var actual_instance_config: Array = editor.get_project_metadata("debug_options", "run_instances_config")
 	var actual_launch_mode: String = actual_instance_config.back().arguments
-	
+
 	if actual_launch_mode.contains("--devmode="):
 		self.set_focus_mode(Control.FOCUS_ALL)
 		self.grab_focus()
 		self.set_focus_mode(Control.FOCUS_NONE)
 		return
-	
+
 	editor.set_project_metadata("debug_options", "run_instance_count", 2.0)
 	editor.set_project_metadata("debug_options", "multiple_instances_enabled", true)
 	editor.set_project_metadata("debug_options", "run_instances_config", [
@@ -67,19 +73,19 @@ func _on_button_pressed(file_name: String):
 func _on_horizon_clients_pressed(extra_arg_0: int) -> void:
 	var editor = EditorInterface.get_editor_settings()
 	var actual_instance_config: Array = editor.get_project_metadata("debug_options", "run_instances_config")
-	var actual_launch_mode: String = actual_instance_config.back().arguments	
+	var actual_launch_mode: String = actual_instance_config.back().arguments
 	var actual_instance_count: int = editor.get_project_metadata("debug_options", "run_instance_count")
 	var needed_instance_count: int = 1 + extra_arg_0
-	
+
 	if actual_instance_count == needed_instance_count and not actual_launch_mode.contains("--devmode="):
 		self.set_focus_mode(Control.FOCUS_ALL)
 		self.grab_focus()
 		self.set_focus_mode(Control.FOCUS_NONE)
 		return
-	
+
 	editor.set_project_metadata("debug_options", "run_instance_count", needed_instance_count)
 	editor.set_project_metadata("debug_options", "multiple_instances_enabled", true)
-	
+
 	var instances = []
 	print("\t")
 	for instance in range(extra_arg_0):

--- a/addons/dyingstar/main_panel.tscn
+++ b/addons/dyingstar/main_panel.tscn
@@ -90,6 +90,15 @@ layout_mode = 2
 size_flags_vertical = 0
 text = "3 clients"
 
+[node name="ServerPropsStatus" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=771530112]
+layout_mode = 2
+size_flags_vertical = 0
+bbcode_enabled = true
+text = ""
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+
 [connection signal="tree_entered" from="." to="." method="_on_tree_entered"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/reload command" to="." method="_on_reload_command_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer2/Horizon 1 client" to="." method="_on_horizon_clients_pressed" binds= [1]]

--- a/addons/dyingstar/server_props_io.gd
+++ b/addons/dyingstar/server_props_io.gd
@@ -1,0 +1,331 @@
+@tool
+class_name ServerPropsIO
+extends RefCounted
+
+## Import / export / clear the SERVER (network) props of the edited scene.
+##
+## Model: the EDITED SCENE'S ROOT is itself the top server prop (it carries a `uuid`). On import we
+## record the matching JSON object's identity for that root (never recreate it), and put every other
+## object under a single marker node named `dyingstarNetwork` so the level designer sees what gets
+## serialized. Export emits the root then walks the marker's subtree; clear deletes the marker.
+##
+## IMPORTANT — no node metadata: the editor hides a node's non-exported script vars (type_name, uuid),
+## and adding metadata to a runtime-instanced node crashes the .tscn save. So we keep each prop's
+## identity (type, uuid, original object_data) in a SESSION TABLE here, keyed by instance id, instead
+## of on the nodes. The nodes stay metadata-free, so they save exactly like hand-placed instances.
+
+const UUID_UTIL = preload("res://addons/uuid/uuid.gd")
+## Marker node grouping every imported/networked prop. Created on import; NOT written to the JSON.
+const NETWORK_NODE_NAME := "dyingstarNetwork"
+## Cache of the per-type network property allowlists, fetched from horizonserver's <type>_def.json
+## files by the editor plugin. {type: [property names]}. Empty until "Update network definitions".
+const DEFS_CACHE := "res://addons/dyingstar/network_defs.json"
+
+## Session identity table: node instance id -> {type, uuid, data}. Populated on import, read on
+## export, emptied on clear. Kept OFF the nodes so saving the scene never serializes it (no crash).
+static var _identity: Dictionary = {}
+
+# ── Export ──────────────────────────────────────────────────────────────────
+
+static func export_to_json(scene_root: Node, path: String) -> Dictionary:
+	if scene_root == null or _node_uuid(scene_root) == "":
+		return {"ok": false, "error":
+			"The scene root has no uuid. Open the scene of a server prop (its root must carry a uuid) before exporting."}
+	var defs := load_network_defs()
+	if defs.is_empty():
+		return {"ok": false, "error": "Network definitions not loaded — run 'Update network definitions' first."}
+	# The scene root is the top prop: emit it (server position kept from its recorded data), then
+	# collect the props under the dyingstarNetwork marker — that subtree is what gets serialized.
+	var objects: Array = []
+	var root_pid := str(_stored_data(scene_root).get("parent_id", ""))
+	objects.append(_build_object(scene_root, root_pid, true))
+	var marker := _find_marker(scene_root)
+	if marker != null:
+		_collect(marker, _root_uuid_of(scene_root), objects)
+	# Keep only the network properties each type declares in its horizonserver <type>_def.json.
+	_filter_by_defs(objects, defs)
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	if f == null:
+		return {"ok": false, "error": "Cannot write to %s" % path}
+	f.store_string(JSON.stringify(objects, "    "))
+	f.close()
+	return {"ok": true, "count": objects.size()}
+
+static func _collect(node: Node, parent_id: String, objects: Array) -> void:
+	for child in node.get_children():
+		if _is_prop(child):
+			var cid := _prop_uuid(child)
+			# A prop that has prop children must own a uuid so they can reference it as parent.
+			if cid == "" and _has_prop_descendant(child):
+				cid = UUID_UTIL.v4()
+				var e: Dictionary = _identity.get(child.get_instance_id(), {})
+				e["uuid"] = cid
+				_identity[child.get_instance_id()] = e
+			objects.append(_build_object(child, parent_id))
+			_collect(child, (cid if cid != "" else parent_id), objects)
+		else:
+			# A plain grouping node (incl. the dyingstarNetwork marker): keep walking, parent unchanged.
+			_collect(child, parent_id, objects)
+
+static func _build_object(node: Node, parent_id: String, is_anchor := false) -> Dictionary:
+	var data: Dictionary = {}
+	# 1) Fidelity: replay fields imported but not editable in Godot (e.g. spawn_point).
+	var stored := _stored_data(node)
+	for k in stored:
+		data[k] = stored[k]
+	# 2) Common, always-current fields.
+	if node.name != "" and not String(node.name).is_valid_int():
+		data["name"] = String(node.name)
+	if not data.has("parent_id"):
+		data["parent_id"] = parent_id
+	# Keep the scenename from the recorded data when the node has no scene_file_path (scene root).
+	var scenename := String(node.scene_file_path).trim_prefix("res://")
+	if scenename != "":
+		data["scenename"] = scenename
+	# The anchor (scene root) is edited at 0,0,0; its real server position lives in the recorded data
+	# (replayed above), so keep it. Children use their live transform. Fall back to the transform.
+	if not is_anchor or not data.has("position"):
+		data["position"] = _v3(node.position)
+	if not is_anchor or not data.has("rotation"):
+		data["rotation"] = _v3(node.rotation)
+	# 3) Type-specific fields (opt-in), override the stale recorded values with current ones.
+	if node.has_method("server_export_data"):
+		for k in (node.server_export_data() as Dictionary):
+			data[k] = node.server_export_data()[k]
+	var uuid_val := _prop_uuid(node)
+	return {
+		"object_type": _prop_type(node),
+		"object_uuid": (uuid_val if uuid_val != "" else null),
+		"object_data": data,
+	}
+
+# ── Import ──────────────────────────────────────────────────────────────────
+
+static func import_from_json(scene_root: Node, path: String) -> Dictionary:
+	if scene_root == null:
+		return {"ok": false, "error": "Open a scene first."}
+	if not has_network_defs():
+		return {"ok": false, "error": "Network definitions not loaded — run 'Update network definitions' first."}
+	# The scene's ROOT node is the anchor: it must already BE a server prop (carry a uuid). We record
+	# the matching JSON object's identity for it (never recreate it) and put the rest under the
+	# dyingstarNetwork marker. No uuid on the root -> refuse: this scene is not a server prop.
+	var root_uuid := _node_uuid(scene_root)
+	if root_uuid == "":
+		return {"ok": false, "error":
+			"The scene root has no uuid. Open the scene of a server prop (its root must carry a uuid) before importing."}
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return {"ok": false, "error": "Cannot read %s" % path}
+	var parsed = JSON.parse_string(f.get_as_text())
+	f.close()
+	if typeof(parsed) != TYPE_ARRAY:
+		return {"ok": false, "error": "JSON root must be an array of objects."}
+
+	# Every imported prop lives under one marker node, so the designer sees what gets serialized.
+	var marker := _get_or_create_marker(scene_root)
+	# The root's children resolve to the marker; the root's uuid maps there for parent lookups.
+	var by_uuid: Dictionary = {root_uuid: marker}
+	var created: Array = []  # [{node, parent_id}]
+	var counts: Dictionary = {}  # object_type -> instantiated count (diagnostic)
+	var skipped := 0
+	var matched_root := false
+	var root_data: Dictionary = {}  # the JSON object_data of the scene root (for the server-position note)
+	for entry in parsed:
+		var u: String = str(entry["object_uuid"]) if entry.get("object_uuid") != null else ""
+		var t := str(entry.get("object_type", ""))
+		if u != "" and u == root_uuid:
+			_apply_identity(scene_root, entry)  # root already exists: record its identity, do not recreate
+			matched_root = true
+			root_data = entry.get("object_data", {})
+			continue
+		var node := _instantiate(entry)
+		if node == null:
+			skipped += 1
+			push_warning("ServerProps import: could not instantiate a '%s' (scene missing?)" % t)
+			continue
+		counts[t] = int(counts.get(t, 0)) + 1
+		created.append({"node": node, "parent_id": str(entry.get("object_data", {}).get("parent_id", ""))})
+		if u != "":
+			by_uuid[u] = node
+
+	# Parent each node under its parent prop (by uuid); default under the marker for top-level
+	# objects or parents that live elsewhere (e.g. another planet not in this JSON).
+	for item in created:
+		var node: Node = item["node"]
+		var parent: Node = by_uuid.get(item["parent_id"], marker)
+		# force_readable_name = true so duplicate scenes get "Name2"… not "@RigidBody3D@123".
+		parent.add_child(node, true)
+		# Own them so they show in the Scene dock and can be edited — and carry NO metadata (identity
+		# is in the session table), so saving the scene never crashes on them.
+		node.owner = scene_root
+	return {"ok": true, "count": created.size(), "root_node": marker,
+		"by_type": counts, "skipped": skipped, "matched_root": matched_root,
+		"root_uuid": root_uuid,
+		"server_position": root_data.get("position", null),
+		"server_parent_id": str(root_data.get("parent_id", ""))}
+
+## Record an EXISTING node's identity (the scene root) without recreating it.
+static func _apply_identity(node: Node, entry: Dictionary) -> void:
+	var od: Dictionary = entry.get("object_data", {})
+	if node.get("uuid") != null and entry.get("object_uuid") != null:
+		node.uuid = str(entry["object_uuid"])
+	# Not applying position/rotation to the scene root: a Godot scene is edited at the origin; the
+	# JSON position is only the SERVER spawn distance, kept in the session table and re-emitted.
+	if node.has_method("server_import_data"):
+		node.server_import_data(od)
+	_record(node, entry)
+
+static func _instantiate(entry: Dictionary) -> Node:
+	var od: Dictionary = entry.get("object_data", {})
+	var scenename: String = str(od.get("scenename", ""))
+	if scenename == "":
+		return null
+	var packed := load("res://" + scenename) as PackedScene
+	if packed == null:
+		push_warning("ServerProps import: scene not found: %s" % scenename)
+		return null
+	var node := packed.instantiate()
+	if od.has("name"):
+		node.name = str(od["name"])
+	if node.get("uuid") != null and entry.get("object_uuid") != null:
+		node.uuid = str(entry["object_uuid"])
+	if node is Node3D:
+		if od.has("position"):
+			node.position = _to_v3(od["position"])
+		if od.has("rotation"):
+			node.rotation = _to_v3(od["rotation"])
+	if node.has_method("server_import_data"):
+		node.server_import_data(od)
+	_record(node, entry)
+	return node
+
+## Store a node's identity (type, uuid, original object_data) in the session table — see _identity.
+static func _record(node: Node, entry: Dictionary) -> void:
+	_identity[node.get_instance_id()] = {
+		"type": str(entry.get("object_type", "")),
+		"uuid": str(entry["object_uuid"]) if entry.get("object_uuid") != null else "",
+		"data": entry.get("object_data", {}),
+	}
+
+# ── Clear ───────────────────────────────────────────────────────────────────
+
+static func clear(scene_root: Node) -> Dictionary:
+	if scene_root == null:
+		return {"ok": false, "error": "Open a scene first."}
+	var markers: Array = []
+	_find_markers(scene_root, markers)
+	var n := 0
+	for m in markers:
+		n += m.get_child_count()
+		m.get_parent().remove_child(m)
+		m.queue_free()
+	_identity.clear()
+	if markers.is_empty():
+		return {"ok": false, "error": "No '%s' node found in the scene." % NETWORK_NODE_NAME}
+	return {"ok": true, "count": n}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+## The dyingstarNetwork grouping node (or a legacy ServerPropsRoot) that holds the imported props.
+static func _is_marker(node: Node) -> bool:
+	return node.name == NETWORK_NODE_NAME or node is ServerPropsRoot
+
+static func _find_marker(scene_root: Node) -> Node:
+	var found: Array = []
+	_find_markers(scene_root, found)
+	return found[0] if not found.is_empty() else null
+
+static func _find_markers(node: Node, out: Array) -> void:
+	if node == null:
+		return
+	for c in node.get_children():
+		if _is_marker(c):
+			out.append(c)
+		else:
+			_find_markers(c, out)
+
+static func _get_or_create_marker(scene_root: Node) -> Node:
+	var existing := _find_marker(scene_root)
+	if existing != null:
+		return existing
+	var marker := ServerPropsRoot.new()
+	marker.name = NETWORK_NODE_NAME
+	scene_root.add_child(marker)
+	marker.owner = scene_root
+	return marker
+
+## A prop is a node we recorded on import, or one whose `type_name` is readable (e.g. @export/@tool).
+static func _is_prop(node: Node) -> bool:
+	return _identity.has(node.get_instance_id()) or node.get("type_name") != null
+
+static func _has_prop_descendant(node: Node) -> bool:
+	for c in node.get_children():
+		if _is_prop(c) or _has_prop_descendant(c):
+			return true
+	return false
+
+## object_type, from the recorded identity (preferred) or a readable `type_name`.
+static func _prop_type(node: Node) -> String:
+	var e: Dictionary = _identity.get(node.get_instance_id(), {})
+	if e.has("type"):
+		return str(e["type"])
+	return str(node.get("type_name")) if node.get("type_name") != null else ""
+
+## object_uuid, from the recorded identity (preferred) or a readable `uuid`.
+static func _prop_uuid(node: Node) -> String:
+	var e: Dictionary = _identity.get(node.get_instance_id(), {})
+	if e.has("uuid") and str(e["uuid"]) != "":
+		return str(e["uuid"])
+	return _node_uuid(node)
+
+## The original object_data recorded for a node (for fidelity), or {} if none.
+static func _stored_data(node: Node) -> Dictionary:
+	var e: Dictionary = _identity.get(node.get_instance_id(), {})
+	var d = e.get("data", {})
+	return d if typeof(d) == TYPE_DICTIONARY else {}
+
+## A node's readable `uuid` as a String, or "" (works for @export uuid like the scene root's).
+static func _node_uuid(node: Node) -> String:
+	var v = node.get("uuid")
+	return str(v) if v != null else ""
+
+## The scene root's uuid: its recorded uuid (after an import) or its readable @export uuid.
+static func _root_uuid_of(node: Node) -> String:
+	return _prop_uuid(node)
+
+static func _v3(v: Vector3) -> Dictionary:
+	return {"x": snappedf(v.x, 0.001), "y": snappedf(v.y, 0.001), "z": snappedf(v.z, 0.0001)}
+
+static func _to_v3(d) -> Vector3:
+	return Vector3(float(d.get("x", 0.0)), float(d.get("y", 0.0)), float(d.get("z", 0.0)))
+
+# ── Network definitions (from horizonserver <type>_def.json, cached by the editor plugin) ─────
+
+## {type: [property names]}. Empty until the plugin runs "Update network definitions".
+static func load_network_defs() -> Dictionary:
+	if not FileAccess.file_exists(DEFS_CACHE):
+		return {}
+	var f := FileAccess.open(DEFS_CACHE, FileAccess.READ)
+	if f == null:
+		return {}
+	var parsed = JSON.parse_string(f.get_as_text())
+	f.close()
+	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+
+static func has_network_defs() -> bool:
+	return not load_network_defs().is_empty()
+
+## Strip each object's object_data down to the properties its type's definition allows. Unknown
+## types are left untouched (better to over-export than to silently drop something).
+static func _filter_by_defs(objects: Array, defs: Dictionary) -> void:
+	for obj in objects:
+		var t := str(obj.get("object_type", ""))
+		if not defs.has(t):
+			continue
+		var allowed: Array = defs[t]
+		var od: Dictionary = obj.get("object_data", {})
+		var filtered: Dictionary = {}
+		for k in od:
+			if allowed.has(k):
+				filtered[k] = od[k]
+		obj["object_data"] = filtered

--- a/addons/dyingstar/server_props_io.gd.uid
+++ b/addons/dyingstar/server_props_io.gd.uid
@@ -1,0 +1,1 @@
+uid://cxmrfvhoji51s

--- a/addons/dyingstar/server_props_root.gd
+++ b/addons/dyingstar/server_props_root.gd
@@ -1,0 +1,19 @@
+@tool
+class_name ServerPropsRoot
+extends Node3D
+
+## Marks a subtree as SERVER (network) props. Everything placed UNDER this node is exported to the
+## startup items JSON and stripped before a build, so the network layout is not dataminable. Drop
+## several of these in a scene to keep the tree tidy — each is an independent export root.
+##
+## `parent_id` is the GORC parent that this root's DIRECT children attach to in the JSON (e.g.
+## "_planet_SandBox", or the uuid of an object spawned elsewhere). Nested props derive their own
+## parent_id automatically from their Godot parent's uuid — designers only place nodes under here.
+
+@export var parent_id: String = "_planet_SandBox"
+
+## Surface the node's purpose in the scene tree (yellow triangle), so a level designer knows this
+## subtree is the one serialized to the server props JSON.
+func _get_configuration_warnings() -> PackedStringArray:
+	return PackedStringArray([
+		"Everything under this node is exported to the server props JSON (and is not shipped in builds)."])

--- a/addons/dyingstar/server_props_root.gd.uid
+++ b/addons/dyingstar/server_props_root.gd.uid
@@ -1,0 +1,1 @@
+uid://btll1iyh6lphs


### PR DESCRIPTION
## Description

Adds an editor plugin (the **DyingStar** menu) to round-trip a scene's **server / network props** with horizonserver's `startup_items.json`, so level designers can place and arrange networked objects visually instead of editing the JSON by hand.

**Workflow** — open the scene of a server prop (its root carries a `uuid`), then:
- **Import server props from JSON…** — instantiates every object under a `dyingstarNetwork` marker node (so it's obvious what gets serialized). The edited scene ROOT is the top prop: the matching JSON object's properties are applied to it (it is *not* recreated). The root stays at the origin — the JSON position is only the server spawn distance and is preserved on export.
- **Export server props to JSON…** — writes the root + the marker subtree back to a JSON, keeping **only the properties each type declares** in its `<type>_def.json`.
- **Clear server props** — removes the `dyingstarNetwork` subtree.
- **Update network definitions (GitHub)** — fetches the `<type>_def.json` allowlists from horizonserver on GitHub (also done on startup), shown in a progress modal with a **Use cache instead** button. Import/Export are disabled until definitions are available; a cached copy can be reused when GitHub is unreachable / rate-limited.

**Notes**
- Prop identity (type/uuid/object_data) is kept in an in-editor session table, **not** in node metadata, so saving the scene never crashes and never bakes server props into the `.tscn`.
- The fetched definitions are cached at `addons/dyingstar/network_defs.json` (gitignored).
- Builds on the existing `addons/dyingstar/` plugin shell (adds `server_props_io.gd`, `server_props_root.gd`, the import/export menu, and a status line in the panel).

## Changelog

<!-- CHANGELOG_EN -->
Editor-only: add a DyingStar tool to import/export a scene's server props to horizonserver's startup_items.json.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Éditeur uniquement : ajout d'un outil DyingStar pour importer/exporter les props serveur d'une scène vers le startup_items.json d'horizonserver.
<!-- /CHANGELOG_FR -->