### PR TITLE
Fixed VIP hab LOD

### DIFF
--- a/assets/_universe/structures/buildings/building_apartment_002.glb.import
+++ b/assets/_universe/structures/buildings/building_apartment_002.glb.import
@@ -42,19 +42,19 @@ materials/extract_path=""
 _subresources={
 "nodes": {
 "PATH:hab_LOD0": {
-"mesh_instance/visibility_range_begin": 200.0,
-"mesh_instance/visibility_range_end": 400.0
+"mesh_instance/visibility_range_end": 50.0
 },
 "PATH:hab_LOD1": {
-"mesh_instance/visibility_range_end": 30.0
+"mesh_instance/visibility_range_begin": 50.0,
+"mesh_instance/visibility_range_end": 100.0
 },
 "PATH:hab_LOD2": {
-"mesh_instance/visibility_range_begin": 30.0,
-"mesh_instance/visibility_range_end": 80.0
+"mesh_instance/visibility_range_begin": 100.0,
+"mesh_instance/visibility_range_end": 200.0
 },
 "PATH:hab_LOD3": {
-"mesh_instance/visibility_range_begin": 80.0,
-"mesh_instance/visibility_range_end": 200.0
+"mesh_instance/visibility_range_begin": 200.0,
+"mesh_instance/visibility_range_end": 500.0
 }
 }
 }


### PR DESCRIPTION
## Description

Fixed wrong LOD settings on the VIP hab.

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Fixed wrong LOD settings for the VIP hab that caused a visual glitch. The correct model is now displayed when being close to it.
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Correction du LOD de l'appartement VIP qui causait un soucis visuel. Le bon modèle est désormais affiché quand le joueur est proche de celui-ci.
<!-- /CHANGELOG_FR -->
