### PR TITLE
perf(server): freeze + OCS for settled props far from players

### DIFF
--- a/server/server.gd
+++ b/server/server.gd
@@ -11,6 +11,15 @@ const PIN_PROP_TYPES: Array[String] = ["box50cm", "box4m", "ship"]
 ## Max number of [Pin] log entries before suppressing further output.
 const PIN_DEBUG_MAX: int = 200
 
+## Physics activity freeze (Part A — server FPS): a body that has SETTLED (negligible drift, so it
+## stops jittering) AND is far from every player is frozen, so Jolt stops simulating it. It unfreezes
+## as soon as a player comes within ACTIVE_RADIUS, so it stays pushable/mineable. Only bodies WE froze
+## are unfrozen (design-frozen props — storage boxes, carried, in a bed — are left alone).
+const SETTLE_EPS: float = 0.05       # m of net drift below which a body counts as "not moving"
+const SETTLE_TICKS: int = 15         # consecutive still ticks (~1.5 s at the pin cadence) before freezing
+const ACTIVE_RADIUS: float = 60.0    # m: keep bodies dynamic within this of any player
+const FREEZE_DEBUG: bool = true      # server console: periodic frozen/active counts (dev aid)
+
 var universe_scene: Node = null
 var entities_spawn_node: Node = null
 var datas_to_spawn_count: int = 0
@@ -129,6 +138,7 @@ var _zone_initialized: bool = false
 ## PIN_TICK_INTERVAL frames in _process to refresh which planet chunks
 ## must stay resident because an awake RigidBody3D is sitting on them.
 var _pin_tick_counter: int = 0
+var _freeze_dbg_accum: int = 0  # throttles the FREEZE_DEBUG console line
 ## Number of debug lines printed by the pin sweep so far (capped to keep
 ## logs readable).  Reset/incremented in _pin_node_to_planet_chunk.
 var _pin_debug_logged: int = 0
@@ -188,6 +198,7 @@ func _process(_delta: float) -> void:
 	if _pin_tick_counter >= PIN_TICK_INTERVAL:
 		_pin_tick_counter = 0
 		_refresh_active_body_pins()
+		_cull_settled_bodies()
 
 
 ## Sweep all RigidBody3D-based props, identify the planet chunk under
@@ -254,6 +265,86 @@ func _refresh_active_body_pins() -> void:
 		for k in pins_by_planet[puuid].keys():
 			keys.append(k as String)
 		planet.planet_terrain.set_pinned_chunks(keys)
+
+
+## Physics activity freeze (Part A): freeze props that have SETTLED and are far from every player so
+## Jolt stops simulating them (kills the resting-pile jitter cost); unfreeze them the moment a player
+## comes within ACTIVE_RADIUS so they stay pushable/mineable. Only bodies WE froze are unfrozen —
+## design-frozen props (storage boxes, carried, bed-loaded) and vehicles are left alone.
+func _cull_settled_bodies() -> void:
+	if not GameOrchestrator.is_server():
+		return  # server-only: it owns the authoritative bodies
+	var frozen_count := 0
+	var active_count := 0
+	for ptype in props_list.keys():
+		if ptype == "planets" or not (props_list[ptype] is Dictionary):
+			continue
+		for body_uuid in props_list[ptype].keys():
+			var body = props_list[ptype][body_uuid]
+			if not is_instance_valid(body) or not (body is RigidBody3D) or body is Vehicle:
+				continue
+			var rb: RigidBody3D = body
+			var parent := rb.get_parent()
+			if parent is Player or parent is Vehicle:
+				continue  # carried / loaded in a bed — keep it dynamic
+			if _player_within(rb.global_position, ACTIVE_RADIUS):
+				if rb.freeze and rb.get_meta("_culled_frozen", false):
+					_unfreeze_culled_body(rb)
+				rb.set_meta("_settle_ticks", 0)
+				active_count += 1
+				continue
+			if rb.freeze:
+				if rb.get_meta("_culled_frozen", false):
+					frozen_count += 1
+				continue  # already frozen (by us or by design), far → leave
+			# Settle detection: drift from a reference point. Jitter oscillates within SETTLE_EPS so it
+			# still counts as still; a real move pushes past it and resets the reference.
+			var ref: Vector3 = rb.get_meta("_settle_ref", rb.global_position)
+			var ticks: int = rb.get_meta("_settle_ticks", 0)
+			if rb.global_position.distance_to(ref) < SETTLE_EPS:
+				ticks += 1
+			else:
+				ticks = 0
+				rb.set_meta("_settle_ref", rb.global_position)
+			rb.set_meta("_settle_ticks", ticks)
+			if ticks >= SETTLE_TICKS:
+				_freeze_culled_body(rb)
+				frozen_count += 1
+			else:
+				active_count += 1
+	if FREEZE_DEBUG:
+		_freeze_dbg_accum += 1
+		if _freeze_dbg_accum >= 20:  # ~every 2 s at the pin cadence
+			_freeze_dbg_accum = 0
+			prints("[FREEZE] frozen=%d active=%d physics=%.1fms (idle-loop fps=%.0f, NOT the bottleneck)" % [
+				frozen_count, active_count,
+				Performance.get_monitor(Performance.TIME_PHYSICS_PROCESS) * 1000.0,
+				Performance.get_monitor(Performance.TIME_FPS)])
+
+## True if any connected player is within [param radius] of [param pos].
+func _player_within(pos: Vector3, radius: float) -> bool:
+	var r2 := radius * radius
+	for puuid in players_list.keys():
+		var p = players_list[puuid]
+		if is_instance_valid(p) and p is Node3D and pos.distance_squared_to((p as Node3D).global_position) < r2:
+			return true
+	return false
+
+func _freeze_culled_body(rb: RigidBody3D) -> void:
+	rb.linear_velocity = Vector3.ZERO
+	rb.angular_velocity = Vector3.ZERO
+	rb.freeze = true
+	rb.set_meta("_culled_frozen", true)
+	rb.remove_meta("_settle_ticks")
+
+func _unfreeze_culled_body(rb: RigidBody3D) -> void:
+	rb.freeze = false
+	rb.linear_velocity = Vector3.ZERO
+	rb.angular_velocity = Vector3.ZERO
+	rb.remove_meta("_culled_frozen")
+	# Force a replication resend so it re-registers in Horizon/GORC for nearby clients after idling.
+	if "server_last_position" in rb:
+		rb.server_last_position = Vector3.INF
 
 
 ## Find the closest planet to [param body] and add the chunk key under

--- a/server/server.gd
+++ b/server/server.gd
@@ -18,7 +18,6 @@ const PIN_DEBUG_MAX: int = 200
 const SETTLE_EPS: float = 0.05       # m of net drift below which a body counts as "not moving"
 const SETTLE_TICKS: int = 15         # consecutive still ticks (~1.5 s at the pin cadence) before freezing
 const ACTIVE_RADIUS: float = 60.0    # m: keep bodies dynamic within this of any player
-const FREEZE_DEBUG: bool = true      # server console: periodic frozen/active counts (dev aid)
 
 var universe_scene: Node = null
 var entities_spawn_node: Node = null
@@ -138,7 +137,6 @@ var _zone_initialized: bool = false
 ## PIN_TICK_INTERVAL frames in _process to refresh which planet chunks
 ## must stay resident because an awake RigidBody3D is sitting on them.
 var _pin_tick_counter: int = 0
-var _freeze_dbg_accum: int = 0  # throttles the FREEZE_DEBUG console line
 ## Number of debug lines printed by the pin sweep so far (capped to keep
 ## logs readable).  Reset/incremented in _pin_node_to_planet_chunk.
 var _pin_debug_logged: int = 0
@@ -274,8 +272,6 @@ func _refresh_active_body_pins() -> void:
 func _cull_settled_bodies() -> void:
 	if not GameOrchestrator.is_server():
 		return  # server-only: it owns the authoritative bodies
-	var frozen_count := 0
-	var active_count := 0
 	for ptype in props_list.keys():
 		if ptype == "planets" or not (props_list[ptype] is Dictionary):
 			continue
@@ -291,11 +287,8 @@ func _cull_settled_bodies() -> void:
 				if rb.freeze and rb.get_meta("_culled_frozen", false):
 					_unfreeze_culled_body(rb)
 				rb.set_meta("_settle_ticks", 0)
-				active_count += 1
 				continue
 			if rb.freeze:
-				if rb.get_meta("_culled_frozen", false):
-					frozen_count += 1
 				continue  # already frozen (by us or by design), far → leave
 			# Settle detection: drift from a reference point. Jitter oscillates within SETTLE_EPS so it
 			# still counts as still; a real move pushes past it and resets the reference.
@@ -309,17 +302,6 @@ func _cull_settled_bodies() -> void:
 			rb.set_meta("_settle_ticks", ticks)
 			if ticks >= SETTLE_TICKS:
 				_freeze_culled_body(rb)
-				frozen_count += 1
-			else:
-				active_count += 1
-	if FREEZE_DEBUG:
-		_freeze_dbg_accum += 1
-		if _freeze_dbg_accum >= 20:  # ~every 2 s at the pin cadence
-			_freeze_dbg_accum = 0
-			prints("[FREEZE] frozen=%d active=%d physics=%.1fms (idle-loop fps=%.0f, NOT the bottleneck)" % [
-				frozen_count, active_count,
-				Performance.get_monitor(Performance.TIME_PHYSICS_PROCESS) * 1000.0,
-				Performance.get_monitor(Performance.TIME_FPS)])
 
 ## True if any connected player is within [param radius] of [param pos].
 func _player_within(pos: Vector3, radius: float) -> bool:

--- a/server/server.gd
+++ b/server/server.gd
@@ -334,10 +334,16 @@ func _freeze_culled_body(rb: RigidBody3D) -> void:
 	rb.linear_velocity = Vector3.ZERO
 	rb.angular_velocity = Vector3.ZERO
 	rb.freeze = true
+	# OCS: drop the body out of Jolt's broadphase entirely. freeze=true alone keeps it registered
+	# (residual per-step cost), so we also disable its own collision shapes and stop its script tick.
+	rb.set_physics_process(false)
+	_set_body_shapes_disabled(rb, true)
 	rb.set_meta("_culled_frozen", true)
 	rb.remove_meta("_settle_ticks")
 
 func _unfreeze_culled_body(rb: RigidBody3D) -> void:
+	_set_body_shapes_disabled(rb, false)
+	rb.set_physics_process(true)
 	rb.freeze = false
 	rb.linear_velocity = Vector3.ZERO
 	rb.angular_velocity = Vector3.ZERO
@@ -345,6 +351,15 @@ func _unfreeze_culled_body(rb: RigidBody3D) -> void:
 	# Force a replication resend so it re-registers in Horizon/GORC for nearby clients after idling.
 	if "server_last_position" in rb:
 		rb.server_last_position = Vector3.INF
+
+## Enable/disable the body's OWN collision shapes (direct CollisionShape3D/Polygon children) so it
+## leaves/re-enters Jolt's broadphase. Child Area3D shapes (interaction zones) are left untouched.
+func _set_body_shapes_disabled(rb: RigidBody3D, disabled: bool) -> void:
+	for c in rb.get_children():
+		if c is CollisionShape3D:
+			(c as CollisionShape3D).disabled = disabled
+		elif c is CollisionPolygon3D:
+			(c as CollisionPolygon3D).disabled = disabled
 
 
 ## Find the closest planet to [param body] and add the chunk key under


### PR DESCRIPTION
## Description

The Godot game server dropped to ~2 FPS on scenes with thousands of props
because Jolt simulates every RigidBody every step, and resting piles never
sleep (they micro-jitter against each other). This adds physics activity
culling on the server, in two layers:

1. **Freeze settled props far from players.** `_cull_settled_bodies()` (called
   from `_process` at the existing pin cadence, with no planet guard so it also
   covers flat sandbox scenes) detects when a body has *settled* — net position
   drift below `SETTLE_EPS` over `SETTLE_TICKS` consecutive ticks, which is
   robust to resting jitter (raw velocity stays above Jolt's sleep threshold).
   A settled body farther than `ACTIVE_RADIUS` from every player is frozen; it
   unfreezes the moment a player comes within range, so it stays pushable and
   mineable. Carried props, bed-loaded props and vehicles are never frozen.

2. **OCS — drop frozen bodies out of the broadphase.** `freeze = true` alone
   keeps a body registered in Jolt (~32 ms/step residual with ~260 frozen
   props). When culling, we also disable the body's own collision shapes and
   stop its `physics_process`, removing it from the broadphase entirely; child
   Area3D interaction zones are left untouched. On unfreeze, shapes and tick are
   restored and the body's position is invalidated to force a GORC resend.

Server-authoritative and server-only: `freeze` is not replicated, so this is
invisible to clients except through the resend on unfreeze.

Measured on an overloaded sandbox (~260 props): physics step time
**50–66 ms -> ~5 ms** when far from every player; ~14–20 ms near a pile (normal,
bodies are dynamic again).

Known minor follow-up: a one-frame ~100 ms hitch when a large pile unfreezes at
once — to be smoothed later by spreading unfreezes over several ticks.

## Changelog

<!-- CHANGELOG_EN -->
- Server performance: distant, settled props are now frozen and removed from the
  physics broadphase, and reactivated when a player approaches.
<!-- CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- Performance serveur : les props éloignés et stabilisés sont gelés et retirés du
  broadphase physique, puis réactivés à l'approche d'un joueur.
<!-- CHANGELOG_FR -->
