### PR TITLE
fix(interaction): server-authoritative, side-aware line of sight for look-at actions

### DIFF
--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -1313,7 +1313,24 @@ func _aimed_door_handle() -> VehicleDoorHandle:
 	if not interact_ray.is_colliding():
 		return null
 	var hit = interact_ray.get_collider()
-	return hit if hit is VehicleDoorHandle else null
+	var handle := hit as VehicleDoorHandle
+	if handle == null:
+		return null
+	# Only the box on our current side counts: outdoor on foot, indoor when seated in this vehicle.
+	# Aiming at the far-side box (the one you can't reach from where you are) is ignored.
+	if not _door_side_matches(handle):
+		return null
+	return handle
+
+## True when the handle box under the crosshair is on the player's side (outdoor on foot, indoor when
+## seated in that vehicle). "" side (no boxes assigned) always matches, so an un-configured handle works.
+func _door_side_matches(handle: VehicleDoorHandle) -> bool:
+	var side := handle.aimed_side(interact_ray.get_collision_point())
+	if side == "":
+		return true
+	var veh = handle.vehicle()
+	var inside: bool = veh != null and "uuid" in veh and _seat_vehicle_uuid == str(veh.uuid)
+	return side == ("indoor" if inside else "outdoor")
 
 ## Tell the server to open/close the door this handle drives (server-authoritative, replicated back).
 func _toggle_door(handle: VehicleDoorHandle) -> void:
@@ -1324,6 +1341,7 @@ func _toggle_door(handle: VehicleDoorHandle) -> void:
 		"action": "vehicle_door",
 		"target_uuid": str(veh.uuid),
 		"door_id": handle.door_id,
+		"side": handle.aimed_side(interact_ray.get_collision_point()),
 	})
 
 ## Prompt for a door handle under the crosshair: close it if open, else open it.
@@ -1342,40 +1360,66 @@ func _seat_door_open(seat) -> bool:
 		return true
 	return veh.is_door_open(str(seat.door_id))
 
-## True if any solid body (wall, building, city — Static OR Rigid) sits between the eye and
-## the prop. Server-authoritative: the carry handler calls this before granting a pickup, so a
-## thin wall can't be exploited to grab through it. Meant to run on the SERVER, which owns the
-## collisions (the client has none → its result would always be "clear"). We ignore ourselves,
-## the prop, and the prop's parent (a vehicle bed / depot / the ground it rests on) — reaching
-## the prop must not be blocked by the very thing holding it; walls are separate bodies.
-func _is_blocked_by_geometry(prop: Node) -> bool:
-	if not (prop is Node3D):
-		return false
-	if "type_name" in prop:
-		# add this because have problems with detection of small props
-		if prop.type_name == "miningrock":
-			return false;
+## Primitive: true if a MASK_OBSTACLE ray from the eye to `target` (a world point) is cut by a solid
+## before reaching it. `exceptions` are solids to ignore besides ourselves. Used for look-at boxes that
+## sit in open air (door handles): the box on the near side is clear, the one behind the body is not.
+func _line_of_sight_blocked(target: Vector3, exceptions: Array) -> bool:
 	_ensure_los_ray()
 	# top_level → target_position is a world-space delta (no parent transform to fight).
 	_los_ray.global_position = interact_ray.global_position
-	_los_ray.target_position = prop.global_position - _los_ray.global_position
+	_los_ray.target_position = target - _los_ray.global_position
 	_los_ray.clear_exceptions()
 	_los_ray.add_exception(self)
-	if prop is CollisionObject3D:
-		_los_ray.add_exception(prop)
-		#var all_nodes = prop.find_children("*", "CollisionObject3D", true, false)
-		#for node in all_nodes:
-			#_los_ray.add_exception(node)
-	var parent = prop.get_parent()
-	if parent is CollisionObject3D:
-		_los_ray.add_exception(parent)
-		#var all_nodes = parent.find_children("*", "CollisionObject3D", true, false)
-		#for node in all_nodes:
-			#_los_ray.add_exception(node)
+	for node in exceptions:
+		if node is CollisionObject3D:
+			_los_ray.add_exception(node)
 	_los_ray.force_raycast_update()
-	if _los_ray.is_colliding():
-		print(_los_ray.get_collider().owner)
 	return _los_ray.is_colliding()
+
+## Server-authoritative "can I actually SEE it?" gate, shared by EVERY look-at interaction (carry AND
+## door handles): nothing solid may stand in front of the target. MUST run on the server — the client
+## has no collisions, so its answer would always be "clear" and be trivially cheatable.
+func _can_see(target: Node) -> bool:
+	if not (target is Node3D):
+		return false
+	# Door handle: pick the box for the side the player is on — seated in this vehicle → indoor box,
+	# on foot → outdoor box — then require a clear sightline to it. The vehicle's own collision is a
+	# coarse CONVEX hull that encloses the boxes, so we exclude it (it can't self-block); FOREIGN walls
+	# still block. Choosing the box by seated-state is what stops opening a door you can't see.
+	if target.has_method("side_shape"):
+		var veh: Node = target.vehicle() if target.has_method("vehicle") else null
+		var inside: bool = veh != null and veh.has_method("is_occupied_by") and veh.is_occupied_by(self)
+		var box: Node3D = target.side_shape(inside)
+		if box == null:
+			return true  # handle without assigned boxes: don't lock the door
+		return not _line_of_sight_blocked(box.global_position, [veh])
+	# Otherwise the target IS the solid we look at (a carriable): a solids ray must reach IT first — a
+	# wall, a bed side or the bodywork in front is hit instead, so the target is not visible.
+	return _first_solid_hit_is(target)
+
+## True if a MASK_OBSTACLE ray from the eye toward `target` hits `target` ITSELF first (nothing solid
+## in front of it). We only ignore ourselves; whatever the target rests in/on is NOT excluded, so you
+## can't grab an object through the side of the bed it sits in — you must actually see it.
+func _first_solid_hit_is(target: Node3D) -> bool:
+	_ensure_los_ray()
+	_los_ray.global_position = interact_ray.global_position
+	var to_target: Vector3 = target.global_position - _los_ray.global_position
+	# Aim a touch past the centre so a thin/small target is still crossed by the ray.
+	_los_ray.target_position = to_target * 1.05
+	_los_ray.clear_exceptions()
+	_los_ray.add_exception(self)
+	_los_ray.force_raycast_update()
+	if not _los_ray.is_colliding():
+		return false
+	var c: Object = _los_ray.get_collider()
+	return c == target or (c is Node and (target.is_ancestor_of(c) or (c as Node).is_ancestor_of(target)))
+
+## True if a solid wall stands between the eye and the carriable `prop`. Thin wrapper over `_can_see`
+## for the carry call sites; tiny ore pieces detect unreliably, so we don't gate them on sight.
+func _is_blocked_by_geometry(prop: Node) -> bool:
+	if prop is Node3D and "type_name" in prop and prop.type_name == "miningrock":
+		return false
+	return not _can_see(prop)
 
 ## Lazily create the body-only line-of-sight ray (a node, so force_raycast_update works in
 ## _process / input / server alike — direct_space_state is only valid during physics).
@@ -1578,9 +1622,18 @@ func server_action_received(data: Dictionary) -> void:
 				veh_l.toggle_headlights()
 		"vehicle_door":
 			# A door handle is operated on foot by anyone nearby - NOT gated on the driver.
+			# Server-authoritative so a client can't forge opening a door it can't use: (1) the box it
+			# aimed at must match the player's side (outdoor on foot, indoor when seated in this vehicle),
+			# and (2) that box must have a clear sightline (see _can_see). Both run on the server.
 			var veh_d := _find_vehicle(str(data.get("target_uuid", "")))
 			if veh_d != null and veh_d.has_method("server_toggle_door"):
-				veh_d.server_toggle_door(str(data.get("door_id", "")))
+				var handle_d: Node3D = veh_d.get_door_handle(str(data.get("door_id", ""))) \
+						if veh_d.has_method("get_door_handle") else null
+				var inside_d: bool = veh_d.has_method("is_occupied_by") and veh_d.is_occupied_by(self)
+				var claimed_side: String = str(data.get("side", ""))
+				var side_ok: bool = claimed_side == "" or claimed_side == ("indoor" if inside_d else "outdoor")
+				if side_ok and (handle_d == null or _can_see(handle_d)):
+					veh_d.server_toggle_door(str(data.get("door_id", "")))
 		"action":
 			print("action key pressed by player")
 			if hands_item != null:

--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -15,7 +15,7 @@ size = Vector3(0.7717459236309878, 1.889733397892087, 1.1162902846483576)
 size = Vector3(1.6587069341703682, 0.851504158613352, 1.9680689896658805)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_8eohf"]
-size = Vector3(0.3371703098891885, 0.1044873444532186, 0.17418536227137338)
+size = Vector3(0.03758665739610478, 0.1044873444532186, 0.14503269956207987)
 
 [node name="Truck" type="VehicleBody3D" unique_id=1579985098]
 collision_layer = 4
@@ -24,6 +24,7 @@ mass = 1000.0
 script = ExtResource("1_vehicle")
 engine_power = 850.0
 max_speed_kmh = 55.0
+steer_speed = 0.8
 bed_wall_height = 0.6
 wheel_radius = 0.05
 wheel_visual_drop = 0.02
@@ -38,19 +39,19 @@ debug_show_cargo_bay = false
 [node name="Model" parent="." unique_id=327486982 groups=["vehicle_model"] instance=ExtResource("7_d2vf6")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.07848798309627769, 1.0561842884377195)
 
-[node name="Col_cabin" parent="Model" index="12" unique_id=1460336411]
+[node name="Col_cabin" parent="Model" index="12" unique_id=1893118231]
 visible = false
 
-[node name="Col_bed" parent="Model" index="13" unique_id=1241534496]
+[node name="Col_bed" parent="Model" index="13" unique_id=2036259373]
 visible = false
 
-[node name="Col_bed_left" parent="Model" index="14" unique_id=1536814149]
+[node name="Col_bed_left" parent="Model" index="14" unique_id=667201349]
 visible = false
 
-[node name="Col_bed_right" parent="Model" index="15" unique_id=544865821]
+[node name="Col_bed_right" parent="Model" index="15" unique_id=847818137]
 visible = false
 
-[node name="Col_bed_rear" parent="Model" index="16" unique_id=2062772161]
+[node name="Col_bed_rear" parent="Model" index="16" unique_id=393553607]
 visible = false
 
 [node name="SeatDriver" type="Area3D" parent="." unique_id=924961125 node_paths=PackedStringArray("sit_point")]
@@ -140,7 +141,7 @@ screen = NodePath("../Model/Screen_Rear")
 mirror = true
 
 [node name="RearCamera_RetroL" parent="." unique_id=1162117254 node_paths=PackedStringArray("screen") instance=ExtResource("6_nd433")]
-transform = Transform3D(-1, -3.698526287045972e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.0605402120460141e-16, 0.49999999999999994, -0.8660254037844387, -1.00805571025538, 1.673670425970804, -0.777821705103517)
+transform = Transform3D(-1, -3.698526287045972e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.060540212046014e-16, 0.49999999999999994, -0.8660254037844387, -1.00805571025538, 1.673670425970804, -0.777821705103517)
 screen = NodePath("../Model/ScreenL_Retro")
 resolution = Vector2i(320, 320)
 mirror = true
@@ -155,30 +156,46 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00417295131010436, 0.490065
 shape = SubResource("BoxShape3D_nd433")
 debug_color = Color(0.22392991, 0.61549836, 0.4901445, 0.41960785)
 
-[node name="Handle_FL" type="Area3D" parent="." unique_id=372280064]
+[node name="Handle_FL" type="Area3D" parent="." unique_id=372280064 node_paths=PackedStringArray("outdoor_shape", "indoor_shape")]
+collision_layer = 32
 collision_mask = 0
 monitoring = false
 script = ExtResource("7_tuoiw")
 door_id = "Front_l_door"
 open_angle_deg = 60.0
 reverse = true
+outdoor_shape = NodePath("CollisionShape3D_out")
+indoor_shape = NodePath("CollisionShape3D_in")
 metadata/_custom_type_script = "uid://kbp6qag1idal"
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Handle_FL" unique_id=266252602]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.8128694950007134, 0.9530118970551352, -0.5995300287153289)
+[node name="CollisionShape3D_out" type="CollisionShape3D" parent="Handle_FL" unique_id=266252602]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.8771307377480202, 0.9530118970551352, -0.5995300287153289)
 shape = SubResource("BoxShape3D_8eohf")
 debug_color = Color(0.9607843, 0, 0.5254902, 0.41960785)
 
-[node name="Handle_FR" type="Area3D" parent="." unique_id=1072075434]
+[node name="CollisionShape3D_in" type="CollisionShape3D" parent="Handle_FL" unique_id=1932272077]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.80846598368544, 0.9530118970551352, -0.9405029228353458)
+shape = SubResource("BoxShape3D_8eohf")
+debug_color = Color(0.9607843, 0, 0.5254902, 0.41960785)
+
+[node name="Handle_FR" type="Area3D" parent="." unique_id=1072075434 node_paths=PackedStringArray("outdoor_shape", "indoor_shape")]
+collision_layer = 32
 collision_mask = 0
 monitoring = false
 script = ExtResource("7_tuoiw")
 door_id = "Front_r_door"
 open_angle_deg = 60.0
+outdoor_shape = NodePath("CollisionShape3D_out")
+indoor_shape = NodePath("CollisionShape3D2_in")
 metadata/_custom_type_script = "uid://kbp6qag1idal"
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Handle_FR" unique_id=1401805639]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7833139009418937, 0.9530118970551352, -0.5995300287153289)
+[node name="CollisionShape3D_out" type="CollisionShape3D" parent="Handle_FR" unique_id=1401805639]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.8736682503675075, 0.9530118970551352, -0.5995300287153289)
+shape = SubResource("BoxShape3D_8eohf")
+debug_color = Color(0.9607843, 0, 0.5254902, 0.41960785)
+
+[node name="CollisionShape3D2_in" type="CollisionShape3D" parent="Handle_FR" unique_id=1969757675]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.8121952957268729, 0.9530118970551352, -0.9362578415127812)
 shape = SubResource("BoxShape3D_8eohf")
 debug_color = Color(0.9607843, 0, 0.5254902, 0.41960785)
 

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -1238,6 +1238,26 @@ func server_toggle_door(door_id: String) -> void:
 	_door_state[door_id] = not is_door_open(door_id)
 	_apply_door(door_id, _door_state[door_id])
 
+## The VehicleDoorHandle node driving `door_id` on THIS vehicle (or null). Used server-side to
+## line-of-sight-check a door toggle against the handle's real position (it rides its door at runtime).
+func get_door_handle(door_id: String) -> Node3D:
+	for h in get_tree().get_nodes_in_group("vehicle_door_handle"):
+		if h is Node3D and "door_id" in h and str(h.door_id) == door_id and h.has_method("vehicle") \
+				and h.vehicle() == self:
+			return h
+	return null
+
+## True if `player` currently occupies a seat of THIS vehicle (driver or passenger). Server-authoritative
+## (reads seat occupancy, set by server_enter/server_exit) — used to tell whether a player operating a
+## door handle is inside (seated) or outside (on foot).
+func is_occupied_by(player: Node) -> bool:
+	if _pilot == player:
+		return true
+	for c in get_children():
+		if c is VehicleSeat and (c as VehicleSeat).occupant == player:
+			return true
+	return false
+
 ## A seat may be boarded/left only through an open door: true when the seat is gated by a door that is
 ## currently shut. A seat with no door_id is never blocked. Used by server_enter/server_exit (the
 ## client gates this too, but the server is the source of truth — never trust the client).

--- a/scenes/vehicles/vehicle_door_handle.gd
+++ b/scenes/vehicles/vehicle_door_handle.gd
@@ -18,13 +18,19 @@ extends Area3D
 @export var open_angle_deg: float = 75.0
 ## Reverse the opening: the door swings the other way (fallback), or its clip plays backwards (anim).
 @export var reverse: bool = false
+## The collision box (a child CollisionShape3D) looked at from OUTSIDE, on foot — placed proud of the
+## exterior door surface. Assigned in the inspector; used for the server line-of-sight check. Optional:
+## unassigned = no sightline gate (the door just opens when looked at).
+@export var outdoor_shape: CollisionShape3D
+## The collision box looked at from INSIDE, while seated — placed on the interior side of the door.
+@export var indoor_shape: CollisionShape3D
 
 func _ready() -> void:
 	add_to_group("vehicle_door_handle")
-	add_to_group("interactable")  # generic: look-at + E targets via the InteractRay (scans `zone`)
-	# PASSIVE detection zone on the `zone` layer so the player's look-at ray (collide_with_areas)
+	add_to_group("interactable")  # generic: look-at + E targets via the InteractRay (scans `interactable`)
+	# PASSIVE look-at target on the `interactable` layer so the player's look-at ray (collide_with_areas)
 	# detects it. monitorable-only: it never runs its own overlap pass. The carry placement/LOS ray
-	# scans solids only (not `zone`), so a handle never blocks carry aim.
+	# scans solids only (not `interactable`), so a handle never blocks carry aim.
 	monitoring = false
 	monitorable = true
 	collision_layer = 1 << (Globals.LAYER_INTERACTABLE - 1)  # interactable (InteractRay), NOT zone (seats)
@@ -36,3 +42,21 @@ func vehicle() -> Node:
 	while n != null and not (n is Vehicle):
 		n = n.get_parent()
 	return n
+
+## The collision box to sightline-check for a player on the given side: seated (inside) → the indoor
+## box, on foot (outside) → the outdoor box. Falls back to whichever is assigned, so a half-configured
+## handle still works; null only when neither is set (then the caller skips the sightline gate).
+func side_shape(inside: bool) -> CollisionShape3D:
+	if inside:
+		return indoor_shape if indoor_shape != null else outdoor_shape
+	return outdoor_shape if outdoor_shape != null else indoor_shape
+
+## Which side's box the player is looking at, from the ray's hit point: the nearer of the two assigned
+## boxes → "outdoor" / "indoor" (or "" if none assigned). Lets the interaction require the box that
+## matches where the player is, so aiming at the box on the far side (that you can't reach) doesn't count.
+func aimed_side(hit_point: Vector3) -> String:
+	var d_out: float = hit_point.distance_to(outdoor_shape.global_position) if outdoor_shape != null else INF
+	var d_in: float = hit_point.distance_to(indoor_shape.global_position) if indoor_shape != null else INF
+	if d_out == INF and d_in == INF:
+		return ""
+	return "indoor" if d_in < d_out else "outdoor"


### PR DESCRIPTION
## Description

You could operate a target you **cannot actually see**: the interaction ray ignores solids (so it can reach a handle/prop that sits flush with a body), and vehicle door handles had **no** line-of-sight check at all. This adds a shared, **server-authoritative** "can I see it?" gate so a client can't forge an action to use something through a wall or from the wrong side.

- **`_can_see(target)`** — single entry for every look-at interaction:
  - **Carriables**: a `MASK_OBSTACLE` ray must hit the target **itself first** — a wall, a bed side or the bodywork in front is hit instead. Carry no longer excludes the container, so you can't grab a prop through the side of a bed you can't see into. (`miningrock` kept as an exception — tiny pieces detect unreliably.)
  - **Door handles**: a `VehicleDoorHandle` now exposes **`outdoor_shape`** / **`indoor_shape`** (two collision boxes). The box you **aim at** must match your side — **outdoor on foot, indoor when seated** in that vehicle — **and** have a clear sightline. Side is authoritative (`Vehicle.is_occupied_by`); the vehicle's own convex hull is excluded from the sightline (it can't self-block), while foreign walls still block.
- `Vehicle.get_door_handle()` / `is_occupied_by()` resolve the handle and the player's side server-side; the client sends the aimed side and gates the prompt so you can't even target the far box.
- Fixes stale `zone` comments on `VehicleDoorHandle` (it lives on the **interactable** layer).

**For vehicle authors**: give each door handle two child `CollisionShape3D` (one on the exterior door surface, one inside) and assign them to `Outdoor Shape` / `Indoor Shape`. Unassigned = no sightline gate (the door just opens when looked at).

## Changelog

<!-- CHANGELOG_EN -->
You can no longer interact with something you can't actually see: picking up an object now requires a clear line of sight to it, and a vehicle door only opens from the handle on your side (outside on foot, inside when seated) when it isn't blocked.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Vous ne pouvez plus interagir avec quelque chose que vous ne pouvez pas voir : ramasser un objet nécessite désormais une ligne de vue dégagée, et une portière de véhicule ne s'ouvre par la poignée de votre côté (à l'extérieur à pied, à l'intérieur en position assise) que si elle n'est pas obstruée.
<!-- /CHANGELOG_FR -->