### PR TITLE
Update physics to 60 FPS.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -247,7 +247,15 @@ locale/translations=PackedStringArray("res://tools/localization/localisation.en.
 [physics]
 
 3d/run_on_separate_thread=true
-common/physics_ticks_per_second=30
+; Jolt's narrowphase runs in FLOAT32 relative to each body's origin (its
+; double-precision mode only covers body POSITIONS). It therefore REQUIRES
+; that no physics body has shapes further than ~1 km from its own origin:
+; a planet-wide body with chunk shapes offset 6,356 km produced cm-scale
+; contact noise (players/vehicles perpetually "dancing", vehicles never
+; sleeping). Planet terrain now uses one small StaticBody3D per chunk
+; (PlanetTerrain._make_chunk_collision_body) which makes Jolt stable at this
+; project's astronomic coordinates — A/B repro 2026-07-07. Keep that rule
+; for any future large object (chunk it or center its origin).
 3d/physics_engine="Jolt Physics"
 jolt_physics_3d/limits/max_body_pairs=131072
 3d/default_gravity=0.0

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -116,6 +116,10 @@ var screen_position: Vector3 = Vector3.ZERO
 
 var _display_debug: bool = false
 
+## Consecutive server ticks this player has been settled (no input, on floor,
+## no velocity) — used to throttle idle physics to every 10th tick.
+var _idle_settled_ticks: int = 0
+
 # Last camera pitch ("head" player property) sent to the server, throttled.
 var _last_head_sent: float = INF
 # Seconds the player has had NO gravity area. A reparent (e.g. leaving a spawn apartment) drops all
@@ -655,6 +659,7 @@ func _leave_vehicle() -> void:
 func net_set_local_target(local_pos: Vector3) -> void:
 	_interp.set_position_target(self, local_pos)
 
+
 func net_set_target(local_pos: Vector3, global_rot: Vector3) -> void:
 	var target_basis := Basis.from_euler(global_rot)
 	var parent := get_parent()
@@ -707,6 +712,24 @@ func _physics_process(delta: float) -> void:
 			if piloting:
 				input_direction = Vector2.ZERO  # seated in a vehicle: no walking
 
+		# Server-side "sleep" for settled players — the CharacterBody analogue
+		# of RigidBody sleeping. An idle player standing on the floor does not
+		# need 60 physics ticks/s: once quasi-still for 0.5 s, run the full
+		# move_and_slide only every 10th tick (6 Hz keeps the floor contact
+		# honest — if the chunk under the player unloads, the fall starts
+		# within 10 ticks). Any client packet, input, or residual velocity
+		# resets the counter instantly. With N players/vehicles idle around a
+		# base this removes ~90% of their per-tick physics cost and, combined
+		# with the position dedup in _on_player_move, all their network
+		# traffic.
+		if not new_input_from_server and input_direction == Vector2.ZERO \
+				and is_on_floor() and velocity.length_squared() < 0.0001:
+			_idle_settled_ticks += 1
+			if _idle_settled_ticks > 30 and (_idle_settled_ticks % 10) != 0:
+				return
+		else:
+			_idle_settled_ticks = 0
+
 		var sprint = null
 		# print("gravity parents:", gravity_parents.size())
 		var parent_gravity_area: Area3D = gravity_parents.back() if not gravity_parents.is_empty() else null
@@ -756,8 +779,16 @@ func _physics_process(delta: float) -> void:
 		if is_on_floor() and is_jumping:
 			velocity += up_direction * jump_height * gravity
 			is_jumping = false
-		# Add the gravity.
-		elif not is_on_floor():
+		# Add the gravity — ALWAYS, including while standing on the floor. The
+		# floor contact absorbs it (move_and_slide cancels the into-floor
+		# component) and keeps the capsule firmly pressed onto the terrain
+		# trimesh so is_on_floor() stays true. Gating this on
+		# "not is_on_floor()" made the contact flicker when idle: the idle
+		# branch zeroes velocity → a zero-motion slide loses the floor → next
+		# tick one dose of gravity sinks the body ~9 mm → depenetration pushes
+		# it back → permanent ~1 cm "dancing", broadcast to every client at
+		# full tick rate (the position changes > the 1 mm dedup snap).
+		else:
 			velocity -= up_direction * gravity * 2.0 * delta
 			is_jumping = false
 
@@ -778,6 +809,7 @@ func _physics_process(delta: float) -> void:
 		if parent_gravity_area and parent_gravity_area.gravity_point \
 				and parent_gravity_area.name == "PlanetGravity":
 			_catch_if_below_surface(parent_gravity_area)
+
 
 		update_last_basis()
 

--- a/scenes/planet/planet_body.gd
+++ b/scenes/planet/planet_body.gd
@@ -42,7 +42,6 @@ var _gravity_area: Area3D
 @onready var planet_terrain: PlanetTerrain = $PlanetTerrain if has_node("PlanetTerrain") else null
 @onready var far_lod_sphere: MeshInstance3D = $FarLODSphere if has_node("FarLODSphere") else null
 
-
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		print("[Planet] _ready: name=%s  spawn_position=%s" % [name, spawn_position])

--- a/scenes/planet/planet_terrain.gd
+++ b/scenes/planet/planet_terrain.gd
@@ -38,6 +38,10 @@ const MAX_ASSEMBLE_PER_FRAME := 8
 const MAX_SERVER_CHUNK_TASKS := 4
 ## Ring-buffer size for camera history (look-ahead prefetch).
 const CAM_HISTORY_SIZE := 10
+## Tolerance (m) for validating cached chunk geometry against the live surface
+## (see _cached_geom_valid). Generous: cracks are ~200 m deep, the failure mode
+## is 3000-6000 m off.
+const _CACHE_GEOM_TOLERANCE_M := 1500.0
 
 ## ── Editor preview settings ───────────────────────────────────────
 ## Quadtree depth for editor preview chunks. Higher = smaller chunks,
@@ -145,7 +149,7 @@ var _update_timer: float = 0.0
 var _initialized: bool = false
 
 ## Server fixed-collision mode: all export-nside chunks loaded at startup.
-## Maps chunk_key → CollisionShape3D for rebuild support.
+## Maps chunk_key → per-chunk StaticBody3D (see _make_chunk_collision_body).
 var _server_collision_chunks: Dictionary = {}
 ## True once _server_load_prebaked_collision() has finished.
 var _server_collision_loaded: bool = false
@@ -284,7 +288,12 @@ func initialize(data: PlanetData, server_mode: bool) -> void:
 		_generate_editor_preview()
 		return
 
-	# Server collision body with a base sphere for rough physics
+	# Server FALLBACK collision body (BaseSphere + SafetyNet only).
+	# Terrain chunks each get their OWN small StaticBody3D at the chunk origin
+	# (see _make_chunk_collision_body) — required for Jolt float32 narrowphase.
+	# The two planet-wide fallback shapes stay here: they sit 100-200 m BELOW
+	# the playable surface and only catch bodies that already fell through
+	# everything, so contact noise on them is harmless.
 	if is_server:
 		planet_data.set_server_mode(true)
 		_collision_body = StaticBody3D.new()
@@ -485,8 +494,8 @@ func _load_chunk(key: String) -> void:
 ## discarded when the task completes.
 func _unload_chunk(key: String) -> void:
 	if _server_collision_chunks.has(key):
-		var col: CollisionShape3D = _server_collision_chunks[key]
-		col.queue_free()
+		var body: Node = _server_collision_chunks[key]
+		body.queue_free()
 		_server_collision_chunks.erase(key)
 	if _server_feature_nodes.has(key):
 		for n in _server_feature_nodes[key]:
@@ -531,6 +540,12 @@ func _server_start_chunk_load(key: String, ipix: int, col_res: int) -> void:
 	var key_nside := _parse_nside_from_key(key)
 	if key_nside <= 0:
 		key_nside = planet_data.export_nside
+
+	# Discard a cached shape that was baked from fallback heights (see
+	# _cached_geom_valid) — regenerating is far cheaper than a player
+	# bouncing forever between a wrong collision floor and the real surface.
+	if cached_shape != null and not _cached_shape_valid(cached_shape, key_nside, ipix, key):
+		cached_shape = null
 
 	if planet_data.chunk_heightmaps_dir != "":
 		if cached_shape != null:
@@ -672,22 +687,48 @@ func _chunk_collision_origin(nside: int, ipix: int) -> Vector3:
 		HEALPix.pix2vec_nest(nside, ipix) * planet_data.radius)
 
 
-## Attach [param shape] to the collision body and spawn chunk features.
-## Must be called on the main thread only.  No-op if already assembled.
+## Create a dedicated StaticBody3D for one chunk, positioned AT the chunk
+## origin, with the shape at ZERO local offset.
+##
+## One small body per chunk instead of offset shapes on a single planet-wide
+## body is REQUIRED for Jolt: Jolt's narrowphase runs in float32 relative to a
+## body's origin (its double-precision mode only covers body POSITIONS).
+## Shapes offset 6,356 km inside one planet-sized body put the contact math at
+## float32 ULP ≈ 0.5 m — standing players/vehicles perpetually "danced" on
+## centimetre-scale contact noise and vehicles never slept.  With the body
+## origin at the chunk centre the narrowphase only ever sees ±~400 m values
+## (ULP ≈ 60 µm).  A/B proof: scratchpad per_chunk_body_test.gd (2026-07-07).
+## Also helps GodotPhysics' broadphase (many small AABBs vs one planet-sized).
+func _make_chunk_collision_body(key: String, nside: int, ipix: int,
+		shape: ConcavePolygonShape3D) -> StaticBody3D:
+	shape.backface_collision = true  # solid from both sides (cached shapes too)
+	var body := StaticBody3D.new()
+	body.name = key + "_body"
+	# Same identity as the legacy shared PlanetCollision body.
+	body.collision_layer = Globals.LAYER_WORLD
+	body.set_collision_layer_value(Globals.LAYER_WORLD, true)
+	body.collision_mask = Globals.MASK_SOLID
+	var col := CollisionShape3D.new()
+	col.shape = shape
+	col.name = key + "_col"
+	body.add_child(col)
+	body.position = _chunk_collision_origin(nside, ipix)
+	return body
+
+
+## Attach [param shape] to its own chunk collision body and spawn chunk
+## features.  Must be called on the main thread only.  No-op if already
+## assembled.
 func _server_assemble_chunk(key: String, nside: int, ipix: int,
 		shape: ConcavePolygonShape3D) -> void:
 	if _server_collision_chunks.has(key):
 		return  # Race guard: assembled by another path.
-	var col_origin := _chunk_collision_origin(nside, ipix)
-	shape.backface_collision = true  # solid from both sides (cached shapes too)
-	var col := CollisionShape3D.new()
-	col.shape = shape
-	col.name = key + "_col"
-	col.position = col_origin  # faces are chunk-local; place them in world
-	_collision_body.add_child(col)
-	_server_collision_chunks[key] = col
+	var body := _make_chunk_collision_body(key, nside, ipix, shape)
+	add_child(body)
+	_server_collision_chunks[key] = body
 	var faces: PackedVector3Array = shape.get_faces()
 	if faces.size() > 0:
+		var col_origin := _chunk_collision_origin(nside, ipix)
 		var dmin: float = INF
 		var dmax: float = -INF
 		for v in faces:
@@ -698,9 +739,9 @@ func _server_assemble_chunk(key: String, nside: int, ipix: int,
 		var tri_count: int = faces.size() / 3
 		print("[PlanetTerrain] loaded chunk ", key, " tris=", tri_count,
 			" alt_min=", dmin - planet_data.radius, " alt_max=", dmax - planet_data.radius,
-			" body_global=", _collision_body.global_position,
-			" body_layer=", _collision_body.collision_layer,
-			" body_mask=", _collision_body.collision_mask)
+			" body_global=", body.global_position,
+			" body_layer=", body.collision_layer,
+			" body_mask=", body.collision_mask)
 	# Chunk features (caves/fumaroles/etc.) are keyed at export granularity;
 	# only spawn them for coarse export-nside chunks so fine collision
 	# sub-chunks pinned under bodies don't duplicate them.
@@ -830,22 +871,19 @@ func rebuild_chunks(chunk_keys: Array, biome_update: Dictionary) -> void:
 			var rf: Array = result[4] if result.size() > 4 else []
 			planet_data.store_chunk_image(key, img, craters, pz, lf, rf)
 
-		# Remove old collision shape.
+		# Remove old chunk collision body.
 		if _server_collision_chunks.has(key):
-			var old_col: CollisionShape3D = _server_collision_chunks[key]
-			old_col.queue_free()
+			var old_body: Node = _server_collision_chunks[key]
+			old_body.queue_free()
 			_server_collision_chunks.erase(key)
 
-		# Regenerate collision shape.
+		# Regenerate collision shape on its own chunk body.
 		var shape := PlanetChunk.generate_collision_shape_healpix(
 			planet_data, nside, ipix, col_res)
 		if shape:
-			var col := CollisionShape3D.new()
-			col.shape = shape
-			col.name = key + "_col"
-			col.position = _chunk_collision_origin(nside, ipix)
-			_collision_body.add_child(col)
-			_server_collision_chunks[key] = col
+			var body := _make_chunk_collision_body(key, nside, ipix, shape)
+			add_child(body)
+			_server_collision_chunks[key] = body
 			# Update disk cache.
 			if _chunk_cache:
 				_chunk_cache.save_collision(key, 0, shape)
@@ -1701,7 +1739,7 @@ func _try_create_or_defer(info: Dictionary) -> void:
 		# Client: respect the mesh disk cache, otherwise mesh asynchronously.
 		if _chunk_cache and _chunk_cache.has_mesh(info.key, info.lod):
 			var cached_mesh := _chunk_cache.load_mesh(info.key, info.lod)
-			if cached_mesh:
+			if cached_mesh and _cached_mesh_valid(cached_mesh, info):
 				info["_from_disk_cache"] = true
 				_assemble_queue.append({"info": info, "mesh": cached_mesh})
 				return
@@ -1725,7 +1763,7 @@ func _try_create_or_defer(info: Dictionary) -> void:
 	# ── Client: check disk cache first ──────────────────────────────
 	if _chunk_cache and _chunk_cache.has_mesh(info.key, info.lod):
 		var cached_mesh := _chunk_cache.load_mesh(info.key, info.lod)
-		if cached_mesh:
+		if cached_mesh and _cached_mesh_valid(cached_mesh, info):
 			info["_from_disk_cache"] = true
 			# Still trigger recipe generation for vegetation height sampling
 			if not planet_data.is_chunk_cached(export_key):
@@ -1744,6 +1782,48 @@ func _try_create_or_defer(info: Dictionary) -> void:
 		_recipe_waiters[export_key] = {}
 	_recipe_waiters[export_key][info.key] = info
 	_submit_recipe_if_needed(export_key, export_ipix, cam_dist_sq)
+
+
+## Sanity-check cached chunk geometry against the live analytic surface.
+## A chunk baked while the per-chunk .r32 elevation tiles were unreadable was
+## built from the flat equirect fallback — its surface sits kilometres away
+## from the real one (the tarsis_4 "3-6 km" bug). The cache version hash can't
+## capture that failure, so validate at LOAD time: reconstruct one vertex's
+## planet-local radial distance and compare it to the crack-aware surface in
+## that direction. Tolerance is generous (cracks are ~200 m deep; the failure
+## mode is 3000-6000 m), so legitimate geometry never trips it.
+## [param first_vertex] is a vertex in chunk-local space, [param origin] the
+## chunk origin in planet-local space (mesh: info.center / collision:
+## _chunk_collision_origin).
+func _cached_geom_valid(first_vertex: Vector3, origin: Vector3, key: String) -> bool:
+	var p := origin + first_vertex
+	var r := p.length()
+	if r <= 0.0:
+		return false
+	var surf: float = planet_data.crack_aware_surface_dist(p / r)
+	if absf(r - surf) <= _CACHE_GEOM_TOLERANCE_M:
+		return true
+	print("[PlanetTerrain] cache STALE for '%s': cached radial=%.0fm vs live surface=%.0fm — discarding, will regenerate" % [
+		key, r, surf])
+	return false
+
+
+## Mesh variant of _cached_geom_valid: pulls the first vertex out of the mesh.
+func _cached_mesh_valid(mesh: ArrayMesh, info: Dictionary) -> bool:
+	if mesh.get_surface_count() == 0:
+		return false
+	var verts: PackedVector3Array = mesh.surface_get_arrays(0)[Mesh.ARRAY_VERTEX]
+	if verts.is_empty():
+		return false
+	return _cached_geom_valid(Vector3(verts[0]), info.center, info.key)
+
+
+## Collision variant of _cached_geom_valid: pulls the first face vertex.
+func _cached_shape_valid(shape: ConcavePolygonShape3D, nside: int, ipix: int, key: String) -> bool:
+	var faces := shape.get_faces()
+	if faces.is_empty():
+		return false
+	return _cached_geom_valid(Vector3(faces[0]), _chunk_collision_origin(nside, ipix), key)
 
 
 ## Submit a recipe task if one isn't already in-flight or deferred.
@@ -2271,6 +2351,9 @@ func _create_chunk(info: Dictionary) -> void:
 		# Check disk cache first
 		if _chunk_cache:
 			shape = _chunk_cache.load_collision(key, lod)
+			# Reject shapes baked from fallback heights (see _cached_geom_valid).
+			if shape != null and not _cached_shape_valid(shape, info.nside, info.ipix, key):
+				shape = null
 			_col_from_cache = shape != null
 		if shape == null:
 			@warning_ignore("integer_division")
@@ -2281,12 +2364,9 @@ func _create_chunk(info: Dictionary) -> void:
 				col_res
 			)
 		if shape:
-			var col := CollisionShape3D.new()
-			col.shape = shape
-			col.name = key + "_col"
-			col.position = _chunk_collision_origin(info.nside, info.ipix)
-			_collision_body.add_child(col)
-			info["collision_shape"] = col
+			var body := _make_chunk_collision_body(key, info.nside, info.ipix, shape)
+			add_child(body)
+			info["collision_shape"] = body  # freed by _remove_chunk
 			# Save to disk if generated with real recipe heights
 			if not _col_from_cache and _chunk_cache:
 				var _epd := planet_data.export_nside

--- a/scenes/vehicles/vehicle.gd
+++ b/scenes/vehicles/vehicle.gd
@@ -292,6 +292,9 @@ var _cargo_debug_accum: float = 0.0  # throttle the debug refresh (dev aid, off 
 var _cargo_debug_markers: Dictionary = {}  # RigidBody3D cargo -> its MeshInstance3D envelope
 var _net_last_position: Vector3 = Vector3.ZERO
 var _net_last_rotation: Vector3 = Vector3.ZERO
+## Consecutive server ticks the pilotless vehicle has been quasi-still — after
+## 30 (0.5 s) the body is put to sleep to stop suspension micro-jitter.
+var _idle_still_ticks: int = 0
 var _net_throttle: float = 0.0  # pilot input relayed by the server (networked)
 var _net_steer: float = 0.0
 var _net_brake: bool = false
@@ -1380,6 +1383,31 @@ func _physics_process(delta: float) -> void:
 		_release_vanished_occupants()  # free seats + bed slots whose player disconnected (node freed)
 		_check_rollover_unlock()  # spill the load if the truck is tipped over
 		_pin_locked_cargo()  # hold the load rigidly in the bed (constant local pose) as the truck moves
+		# Settle & sleep an idle vehicle. Wheel-suspension micro-forces on the
+		# terrain trimesh otherwise keep the body awake forever, wandering by
+		# millimetres every tick — replicated to every client as endless
+		# "dancing". Once quasi-still with no pilot, put the body to sleep
+		# explicitly and skip the drive/brake force application (any force
+		# re-wakes it). A pilot entering, or a real collision, wakes it again.
+		if not is_instance_valid(_pilot) \
+				and linear_velocity.length_squared() < 0.01 \
+				and angular_velocity.length_squared() < 0.01:
+			_idle_still_ticks += 1
+			# A full second quasi-still before freezing: the suspension needs
+			# time to finish settling, or the pose is frozen with one side
+			# still compressed (a wheel visually sunk into the ground).
+			if _idle_still_ticks >= 60:
+				if not sleeping:
+					linear_velocity = Vector3.ZERO
+					angular_velocity = Vector3.ZERO
+					engine_force = 0.0
+					sleeping = true
+				_replicate_transform()  # still replicate doors/headlights/etc.
+				return
+		else:
+			_idle_still_ticks = 0
+			if sleeping and is_instance_valid(_pilot):
+				sleeping = false  # pilot back on board: resume simulation
 		if is_instance_valid(_pilot):
 			_apply_drive(delta)
 		elif _handbrake:
@@ -1485,6 +1513,16 @@ func _exit_tree() -> void:
 
 ## Client: apply the replicated state (position/rotation/pilot) from the server.
 func client_channel_data_update(data: Dictionary) -> void:
+	# The SERVER simulates this vehicle — never apply channel updates there.
+	# Horizon routes our own prop broadcasts back to us: the first echo
+	# snap-teleports the body (_interp.set_target snaps on first call) and
+	# every echoed property write (mass, …) re-wakes the RigidBody, so it can
+	# never sleep and micro-wanders forever (the vehicle half of the "dancing"
+	# bug). Replica smoothing/HUD state below is for CLIENTS only.
+	# NOTE for future multi-zone: a vehicle frozen by another zone's server
+	# would also be skipped here — revisit ownership then.
+	if _is_networked() and GameOrchestrator.is_server():
+		return
 	if data.has("position"):
 		var pos := Vector3(data["position"]["x"], data["position"]["y"], data["position"]["z"])
 		var rot := rotation

--- a/server/server.gd
+++ b/server/server.gd
@@ -141,6 +141,10 @@ var _pin_tick_counter: int = 0
 ## logs readable).  Reset/incremented in _pin_node_to_planet_chunk.
 var _pin_debug_logged: int = 0
 
+## Counter to throttle Horizon position/prop updates to every 2nd physics
+## frame (30 messages/sec at 60 FPS physics).
+var _horizon_update_counter: int = 0
+
 
 func _enter_tree() -> void:
 	NetworkOrchestrator.load_server_config()
@@ -150,12 +154,15 @@ func _ready() -> void:
 	_send_metrics()
 
 func _physics_process(_delta: float) -> void:
-	send_players_newposition_to_horizon()
-	send_props_update_to_horizon()
+	_horizon_update_counter += 1
+	if _horizon_update_counter >= 2:
+		_horizon_update_counter = 0
+		send_players_newposition_to_horizon()
+		send_props_update_to_horizon()
 
 func _process(_delta: float) -> void:
-	if check_pending_objects_timer == 10:
-		# every 10 frames, check pending players parenting
+	if check_pending_objects_timer == 20:
+		# every 20 frames, check pending players parenting
 		for pending_message in pending_messages_player_parenting.duplicate():
 			if _search_parent_node(pending_message["data"]["object_data"]["parent_id"]) != null:
 				print(
@@ -436,8 +443,8 @@ func _debug_closest_planets(pos: Vector3, n: int) -> String:
 	return out
 
 func start_server(receveid_universe_scene: Node) -> void:
-	Engine.physics_ticks_per_second = 30
-	Engine.max_fps = 30
+	Engine.physics_ticks_per_second = 60
+	Engine.max_fps = 60
 
 	universe_scene = receveid_universe_scene
 	# entities_spawn_node = receveid_player_spawn_node
@@ -486,13 +493,21 @@ func instantiate_player(message: Dictionary):
 	# print("Remnote player spawned with position: ", player_to_add.global_position)
 
 func player_move(message: Dictionary):
-	# print("================")
-	# print(message["data"]["uuid"])
-	# print(players_list.keys())
 	if players_list.has(message["player_id"]):
-		# print("YEAH!")
+		# Input sanity guard: genuine client input (movement/update_velocity,
+		# see client.gd _on_client_action_move) is a 2D direction with
+		# components in [-1, 1] and NO "z" key. Anything else (a malformed or
+		# misrouted message carrying a 3D world position) would be NORMALIZED
+		# by the walk code into a full-speed movement command — reject it.
+		var pos_data: Dictionary = message["data"]["pos"]
+		if pos_data.has("z"):
+			return
+		var input_x := float(pos_data["x"])
+		var input_y := float(pos_data["y"])
+		if absf(input_x) > 1.5 or absf(input_y) > 1.5:
+			return
 		var player = players_list[message["player_id"]]
-		player.input_from_server.input_direction = Vector2(float(message["data"]["pos"]["x"]), float(message["data"]["pos"]["y"]))
+		player.input_from_server.input_direction = Vector2(input_x, input_y)
 		player.input_from_server.rotation = Vector3(
 			float(message["data"]["rot"]["x"]), float(message["data"]["rot"]["y"]), float(message["data"]["rot"]["z"])
 		)
@@ -1123,6 +1138,19 @@ func _push_zone_residency_to_planet(planet_node: Node) -> void:
 		return
 	var planet: Planet = planet_node as Planet
 	if planet.planet_terrain == null or planet.planet_data == null:
+		return
+	# Fine-collision planets (file-mode crack planets like tarsis_4) get ALL
+	# their collision from the per-body pin system at collision_detail_nside
+	# (n8192). Do NOT also blanket the zone with coarse export-nside (n64)
+	# chunks: both attach shapes to the SAME PlanetCollision body, and where a
+	# coarse ~100 km facet crosses the fine surface the two floors sit within
+	# capsule height — a body lands on the lower floor and is silently
+	# depenetrated out of the upper one a few ticks later, forever. That was
+	# the player/vehicle "dancing" around the base, and why the vehicle could
+	# never fall asleep. An empty desired set also unloads any coarse chunks
+	# attached earlier (pins are preserved — see _apply_residency).
+	if planet.planet_data.collision_detail_nside() > planet.planet_data.export_nside:
+		planet.planet_terrain.set_resident_chunks(PackedStringArray())
 		return
 	# Convert zone AABB from world → planet-local by subtracting planet origin.
 	var aabb_world := _server_zone_aabb_world()


### PR DESCRIPTION
fix: per-chunk collision bodies for Jolt at astronomic coordinates
fix: terrain data export + cache validation + idle physics sleep

## Description

<!-- Describe the changes in this PR -->

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
- Update physics to 60 FPS.
- fix per-chunk collision bodies for Jolt at astronomic coordinates
- fix terrain data export + cache validation + idle physics sleep
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
- Mise à jour de la physique à 60 FPS.
- Correction des collisions par chunk pour Jolt aux coordonnées astronomiques.
- Correction de l'exportation des données de terrain, de la validation du cache et de la mise en veille de la physique en cas d'inactivité.
<!-- /CHANGELOG_FR -->
