### PR TITLE
fix(vehicle): truck steering-wheel direction/speed + reverse camera

### DIFF
--- a/scenes/vehicles/trucks/truck.tscn
+++ b/scenes/vehicles/trucks/truck.tscn
@@ -25,11 +25,13 @@ script = ExtResource("1_vehicle")
 engine_power = 850.0
 max_speed_kmh = 55.0
 steer_speed = 0.8
+steer_return_speed = 1.0
+steering_wheel_ratio = 4.0
+steering_wheel_axis = Vector3(0, -1, 0)
 bed_wall_height = 0.6
 wheel_radius = 0.05
 wheel_visual_drop = 0.02
 real_wheel_spin_axis = Vector3(0, 1, 0)
-steering_wheel_axis = Vector3(0, 1, 0)
 motor_max_rpm = 3000.0
 debug_color_driven_wheels = false
 cargo_bay_size = Vector3(1.8, 0.6, 2.9)
@@ -138,10 +140,9 @@ spot_angle = 33.29
 [node name="RearCamera_Rear" parent="." unique_id=984847245 node_paths=PackedStringArray("screen") instance=ExtResource("6_nd433")]
 transform = Transform3D(-1, -2.4651903e-32, 1.2246063538223775e-16, 8.634337199246993e-17, 0.7091372917707068, 0.705070423021777, -8.684140332348007e-17, 0.705070423021777, -0.7091372917707068, -0.00059340561188747, 1.515455978092255, 0.09343121015790744)
 screen = NodePath("../Model/Screen_Rear")
-mirror = true
 
 [node name="RearCamera_RetroL" parent="." unique_id=1162117254 node_paths=PackedStringArray("screen") instance=ExtResource("6_nd433")]
-transform = Transform3D(-1, -3.698526287045972e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.060540212046014e-16, 0.49999999999999994, -0.8660254037844387, -1.00805571025538, 1.673670425970804, -0.777821705103517)
+transform = Transform3D(-1, -3.698526287045972e-32, 1.2246063538223775e-16, 6.123031769111884e-17, 0.8660254037844387, 0.49999999999999994, -1.0605402120460141e-16, 0.49999999999999994, -0.8660254037844387, -1.00805571025538, 1.673670425970804, -0.777821705103517)
 screen = NodePath("../Model/ScreenL_Retro")
 resolution = Vector2i(320, 320)
 mirror = true


### PR DESCRIPTION
## Description

Fixes on the truck (`truck.tscn`) driving feel:
- **Steering wheel** now turns in the **correct direction** and at a **realistic speed** (it was rotating the wrong way and far too fast).
- **Reverse camera** is **flipped vertically** but **not mirrored** (so text/objects read the right way round when reversing).

## Changelog

<!-- CHANGELOG_EN -->
Truck: the steering wheel now turns the right way at a sensible speed, and the reverse camera is no longer mirrored.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Camion : le volant tourne désormais dans le bon sens à une vitesse raisonnable, et l'image de la caméra de recul n'est plus inversée.
<!-- /CHANGELOG_FR -->