### PR TITLE
feat(ui): toggle debug panels from Settings + rebindable Alt+² key

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -207,9 +207,9 @@ game_record={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194337,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
-debug_console={
+toggle_debug={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
 ]
 }
 toggle_tool={

--- a/scenes/globals/settings_manager.gd
+++ b/scenes/globals/settings_manager.gd
@@ -4,6 +4,8 @@ extends Node
 signal cargo_debug_changed(on: bool)
 ## Emitted when the camera field of view changes, so the active player camera updates live.
 signal fov_changed(fov: float)
+## Emitted when the "show debug panels" toggle changes, so the in-game HUD reacts live (menu ↔ key).
+signal show_debug_changed(on: bool)
 
 # user:// is writable in an exported build (res:// is packed read-only), so settings actually
 # persist between sessions there.
@@ -33,6 +35,8 @@ func initialize_settings():
 	config.set_value("video", "screen_shake", true)
 	config.set_value("video", "dev_mode", false)
 	config.set_value("general", "cargo_debug", false)
+	# Shown by default: we are in early alpha, so the in-game debug panels are on out of the box.
+	config.set_value("general", "show_debug", true)
 	for key in AUDIO_BUSES:
 		config.set_value("audio", key, 100.0)
 
@@ -173,6 +177,17 @@ func set_cargo_debug(on: bool) -> void:
 
 func is_cargo_debug() -> bool:
 	return config.get_value("general", "cargo_debug", false)
+
+## Show/hide the in-game debug panels (server/client FPS, coords, counts…). Persisted under [general];
+## emits so the HUD toggles live and the settings menu stays in sync with the toggle_debug key.
+## Default true (early alpha).
+func set_show_debug(on: bool) -> void:
+	config.set_value("general", "show_debug", on)
+	save_settings()
+	show_debug_changed.emit(on)
+
+func is_show_debug() -> bool:
+	return config.get_value("general", "show_debug", true)
 
 func set_monitor(index: int) -> void:
 	DisplayServer.window_set_current_screen(index)

--- a/scenes/normal_player/normal_player.gd
+++ b/scenes/normal_player/normal_player.gd
@@ -258,6 +258,9 @@ func _ready() -> void:
 		# Apply the saved field of view, and follow live changes from the settings menu.
 		camera.fov = SettingsManager.get_fov()
 		SettingsManager.fov_changed.connect(_on_fov_changed)
+		# Debug panels: follow live the settings-menu "Show debug panels" toggle.
+		if not SettingsManager.show_debug_changed.is_connected(_on_show_debug_changed):
+			SettingsManager.show_debug_changed.connect(_on_show_debug_changed)
 		# our own name tag is never created (only remote players get one)
 		astronaut.visible = false
 		interact_label.hide()
@@ -270,8 +273,9 @@ func _ready() -> void:
 
 		active = true
 
-		display_debug.emit(true)
-		_display_debug = true
+		# Initial visibility from the saved setting (default true — early alpha).
+		_display_debug = SettingsManager.is_show_debug()
+		display_debug.emit(_display_debug)
 
 		var loading_node = get_tree().root.get_node("Loading")
 		if loading_node:
@@ -409,13 +413,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		if _spawn_wheel:
 			_spawn_wheel.confirm()
 
-	if event.is_action_pressed("debug_console"):
-		if _display_debug:
-			display_debug.emit(false)
-			_display_debug = false
-		else:
-			display_debug.emit(true)
-			_display_debug = true
+	if event.is_action_pressed("toggle_debug"):
+		_display_debug = not _display_debug
+		display_debug.emit(_display_debug)
+		SettingsManager.set_show_debug(_display_debug)  # persist + keep the settings menu in sync
 
 func server_set_input(input_dir: Vector2, newrotation: Vector3) -> void:
 	input_from_server["input_direction"] = input_dir
@@ -1092,6 +1093,11 @@ func _force_temp_sky_environment() -> void:
 ## Live camera FOV update from the settings menu (local player only).
 func _on_fov_changed(fov: float) -> void:
 	camera.fov = fov
+
+## Live update from the settings menu "Show debug panels" toggle (kept in sync with the toggle_debug key).
+func _on_show_debug_changed(on: bool) -> void:
+	_display_debug = on
+	display_debug.emit(on)
 
 # Dev spawn wheel selection -> spawn the chosen prop in front of the player.
 func _on_spawn_selected(data) -> void:

--- a/ui/menu_config/menu_config.gd
+++ b/ui/menu_config/menu_config.gd
@@ -55,10 +55,28 @@ func create_action_list():
 
 func format_input_label(event: InputEvent) -> String:
 	if event is InputEventKey:
-		var keycode = DisplayServer.keyboard_get_keycode_from_physical(event.physical_keycode)
-		return OS.get_keycode_string(keycode)
+		# Show the modifiers too, so an "Alt + ²" binding doesn't read as a bare key.
+		var mods := ""
+		if event.ctrl_pressed: mods += "Ctrl + "
+		if event.alt_pressed: mods += "Alt + "
+		if event.shift_pressed: mods += "Shift + "
+		if event.meta_pressed: mods += "Meta + "
+		return mods + _physical_key_name(event.physical_keycode)
 
 	return event.as_text()
+
+## Human key name for a physical keycode: prefer the label printed on the key in the active layout
+## (e.g. "²" on an AZERTY row), and fall back to the layout keycode name (e.g. "Apostrophe") when the
+## key has no printable label. Physical keycodes keep bindings layout-independent; this only affects
+## how they READ in the Controls list.
+func _physical_key_name(physical_keycode: int) -> String:
+	var label := DisplayServer.keyboard_get_label_from_physical(physical_keycode)
+	if label != 0:
+		var label_text := OS.get_keycode_string(label)
+		if label_text.strip_edges() != "":
+			return label_text
+	var keycode := DisplayServer.keyboard_get_keycode_from_physical(physical_keycode)
+	return OS.get_keycode_string(keycode)
 
 func _on_input_button_pressed(b, a):
 	if !is_remapping:
@@ -141,7 +159,14 @@ func import_input_map() -> void:
 			input_event.button_index = int(ev_str.split("_")[1])
 		else:
 			input_event = InputEventKey.new()
-			input_event.physical_keycode = OS.find_keycode_from_string(ev_str)
+			# find_keycode_from_string encodes modifiers in the high bits; split them back out so a
+			# saved "Alt + ²" reloads WITH its Alt (else remapped modifier bindings lose the modifier).
+			var kc: int = OS.find_keycode_from_string(ev_str)
+			input_event.physical_keycode = kc & KEY_CODE_MASK
+			input_event.alt_pressed = (kc & KEY_MASK_ALT) != 0
+			input_event.ctrl_pressed = (kc & KEY_MASK_CTRL) != 0
+			input_event.shift_pressed = (kc & KEY_MASK_SHIFT) != 0
+			input_event.meta_pressed = (kc & KEY_MASK_META) != 0
 		print("ev : " + ev_str + " for " + action_name)
 		InputMap.action_add_event(action_name, input_event)
 

--- a/ui/settings_page/general_page/general_settings_page.gd
+++ b/ui/settings_page/general_page/general_settings_page.gd
@@ -3,13 +3,24 @@ extends Control
 ## Wires the general options to SettingsManager (apply + persist). For now: the cargo-debug toggle
 ## (green envelope around items really locked into a vehicle bed), mirroring the graphics page style.
 
+@onready var _show_debug: Button = $ScrollContainer/MarginContainer/VBoxContainer/ShowDebug/Button
 @onready var _cargo_debug: Button = $ScrollContainer/MarginContainer/VBoxContainer/CargoDebug/Button
 
 func _ready() -> void:
+	_show_debug.toggle_mode = true
+	_show_debug.button_pressed = SettingsManager.is_show_debug()
+	_show_debug.text = "On" if _show_debug.button_pressed else "Off"
+	_show_debug.toggled.connect(_on_show_debug_toggled)
+
 	_cargo_debug.toggle_mode = true
 	_cargo_debug.button_pressed = SettingsManager.is_cargo_debug()
 	_cargo_debug.text = "On" if _cargo_debug.button_pressed else "Off"
 	_cargo_debug.toggled.connect(_on_cargo_debug_toggled)
+
+## Show/hide the in-game debug panels. Kept in sync with the toggle_debug key via SettingsManager.
+func _on_show_debug_toggled(on: bool) -> void:
+	_show_debug.text = "On" if on else "Off"
+	SettingsManager.set_show_debug(on)
 
 func _on_cargo_debug_toggled(on: bool) -> void:
 	_cargo_debug.text = "On" if on else "Off"

--- a/ui/settings_page/general_page/general_settings_page.tscn
+++ b/ui/settings_page/general_page/general_settings_page.tscn
@@ -46,6 +46,23 @@ theme_override_constants/margin_bottom = 20
 [node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/MarginContainer" unique_id=257727327]
 layout_mode = 2
 
+[node name="ShowDebug" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer" unique_id=771001101]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/ShowDebug" unique_id=771001102]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Show debug panels (in-game — default Alt+²)"
+label_settings = SubResource("LabelSettings_gen")
+
+[node name="Button" type="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/ShowDebug" unique_id=771001103]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+theme_override_fonts/font = ExtResource("2_pcucv")
+toggle_mode = true
+text = "On"
+
 [node name="CargoDebug" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer" unique_id=1017380227]
 layout_mode = 2
 


### PR DESCRIPTION
## Description

Adds a way to hide the in-game debug panels:
- **Settings → General**: an **ON/OFF toggle** to show/hide the debug panels. Shown **ON by default** (early alpha).
- A **rebindable key** (default **Alt+²**) to toggle them in-game, exposed as a proper `toggle_debug` InputMap action so it appears in **Controls** and is remappable. Key names are displayed with human-friendly labels (and work on US layouts).

## Changelog

<!-- CHANGELOG_EN -->
You can now show/hide the on-screen debug panels from Settings → General, or with a rebindable key (default Alt+²) available in the Controls menu.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Vous pouvez désormais afficher/masquer les panneaux de débogage à l'écran depuis Paramètres → Général, ou avec une touche réattribuable (par défaut Alt+²) disponible dans le menu Commandes.
<!-- /CHANGELOG_FR -->