### PR TITLE
perf(server): freeze reloaded settled props at boot to remove the start-up physics spike

### DIFF
--- a/server/server.gd
+++ b/server/server.gd
@@ -297,12 +297,9 @@ func _cull_settled_bodies() -> void:
 			continue
 		for body_uuid in props_list[ptype].keys():
 			var body = props_list[ptype][body_uuid]
-			if not is_instance_valid(body) or not (body is RigidBody3D) or body is Vehicle:
+			if not _is_cullable_body(body):
 				continue
 			var rb: RigidBody3D = body
-			var parent := rb.get_parent()
-			if parent is Player or parent is Vehicle:
-				continue  # carried / loaded in a bed — keep it dynamic
 			if _player_within(rb.global_position, ACTIVE_RADIUS):
 				if rb.freeze and rb.get_meta("_culled_frozen", false):
 					_unfreeze_culled_body(rb)
@@ -331,6 +328,15 @@ func _player_within(pos: Vector3, radius: float) -> bool:
 		if is_instance_valid(p) and p is Node3D and pos.distance_squared_to((p as Node3D).global_position) < r2:
 			return true
 	return false
+
+## True if [param node] is a free physics prop the settle-culler may freeze/unfreeze: a live
+## RigidBody3D that is not a Vehicle and not carried/bed-loaded (those must stay dynamic). Shared
+## by _cull_settled_bodies (runtime) and create_generic_object (reload) so both agree.
+func _is_cullable_body(node: Node) -> bool:
+	if not is_instance_valid(node) or not (node is RigidBody3D) or node is Vehicle:
+		return false
+	var parent: Node = node.get_parent()
+	return not (parent is Player or parent is Vehicle)
 
 func _freeze_culled_body(rb: RigidBody3D) -> void:
 	rb.linear_velocity = Vector3.ZERO
@@ -996,7 +1002,15 @@ func create_generic_object(event: Dictionary) -> void:
 		if is_instance_of(spawnable_prop_instance, RigidBody3D):
 			spawnable_prop_instance.freeze = true
 	else:
-		spawnable_prop_instance.set_physics_process(true)
+		# At server boot there are NO players yet, so every reloaded body would spawn awake and re-run
+		# collision for ~SETTLE_TICKS before the settle-culler freezes it — a startup CPU spike with
+		# thousands of rocks. Freeze settled free bodies up front instead; the culler unfreezes them
+		# (they carry the _culled_frozen flag) as soon as a player comes within ACTIVE_RADIUS. A body
+		# already near a player (rare at boot, possible on later GORC streaming) stays awake.
+		if _is_cullable_body(spawnable_prop_instance) and not _player_within(pos, ACTIVE_RADIUS):
+			_freeze_culled_body(spawnable_prop_instance)
+		else:
+			spawnable_prop_instance.set_physics_process(true)
 
 	for pending_message in pending_messages_player_parenting.duplicate():
 		if pending_message["data"]["object_data"]["parent_id"] == event["data"]["object_uuid"]:


### PR DESCRIPTION
## Description

Removes the physics CPU spike on **server start-up** where every prop reloaded from persistence re-runs collision at once.

**Root cause.** At start-up there is no player connected yet. Each prop reloaded from ScyllaDB spawned awake (`create_generic_object` → `set_physics_process(true)`) and re-ran collision for ~`SETTLE_TICKS` before the existing settle-culler (`_cull_settled_bodies`, from #228) caught up and froze it. With thousands of rocks that is a CPU spike at boot.

**Fix (server-only — no network, no persistence, no client change).** In `create_generic_object`, a reloaded in-zone body that is *cullable* (a free `RigidBody3D`, not a `Vehicle`, not carried / bed-loaded) **and far from every player** is now frozen up front via the existing `_freeze_culled_body` (freeze + OCS shape-disable + `_culled_frozen` meta). The existing culler unfreezes it the moment a player comes within `ACTIVE_RADIUS` (60 m), so rocks stay mineable/pushable on approach. Since no player is connected at boot, everything reloads frozen and the spike is gone.

Also extracts the culler's "is this a freezable free body?" test into a shared `_is_cullable_body()` so runtime culling and reload use the exact same rule (DRY, behaviour-preserving refactor of the culler).

This is the lightweight local approach agreed with DDurieux instead of replicating the sleep state over the network: it fully kills the boot spike without moving it to disk I/O. **Known limitation** (accepted): a body genuinely *in motion* when the server saved would freeze in place until a player approaches — rare and unobserved at boot.

### How to test
1. Spawn a lot of rocks/crates, let them settle.
2. Restart the server → physics time at boot should now be **flat** (no spike).
3. Walk toward a frozen rock → within 60 m it wakes up (mineable / pushable).
4. Mine / cut a nearby rock → works.
5. A carried rock, or a rock loaded in a truck bed, at reload stays dynamic (not frozen).

Single-file change in `server/server.gd`. `gdlint` clean.

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Fixed a physics CPU spike on server start-up: props reloaded from persistence no longer all re-run collision at once — they reload frozen and wake up when a player approaches.
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Correction d'un pic de charge CPU physique au démarrage du serveur : les props rechargés depuis la persistance ne recalculent plus tous leurs collisions d'un coup — ils repartent gelés et se réveillent à l'approche d'un joueur.
<!-- /CHANGELOG_FR -->
