### PR TITLE
feat(settings): add a shadows on/off toggle and a shadow-distance slider to Graphics

### DIFF
--- a/scenes/globals/settings_manager.gd
+++ b/scenes/globals/settings_manager.gd
@@ -6,6 +6,10 @@ signal cargo_debug_changed(on: bool)
 signal fov_changed(fov: float)
 ## Emitted when the "show debug panels" toggle changes, so the in-game HUD reacts live (menu ↔ key).
 signal show_debug_changed(on: bool)
+## Emitted when the shadows toggle changes, so the day/night sun enables/disables its shadow live.
+signal shadows_changed(on: bool)
+## Emitted when the shadow distance changes, so the day/night sun updates its shadow range live.
+signal shadow_distance_changed(distance: float)
 
 # user:// is writable in an exported build (res:// is packed read-only), so settings actually
 # persist between sessions there.
@@ -34,6 +38,10 @@ func initialize_settings():
 	config.set_value("video", "fov", 100.0)
 	config.set_value("video", "screen_shake", true)
 	config.set_value("video", "dev_mode", false)
+	# Real-time shadows on by default; players on weak GPUs can turn them off in Graphics settings.
+	config.set_value("video", "shadows", true)
+	# Directional (sun) shadow draw distance in metres. Bigger = shadows further out but softer/costlier.
+	config.set_value("video", "shadow_distance", 300.0)
 	config.set_value("general", "cargo_debug", false)
 	# Shown by default: we are in early alpha, so the in-game debug panels are on out of the box.
 	config.set_value("general", "show_debug", true)
@@ -117,6 +125,25 @@ func set_max_fps(fps: int) -> void:
 	Engine.max_fps = fps
 	save_video_settings("max_fps", fps)
 	save_settings()
+
+## Real-time shadows on/off (drives the day/night sun's shadow_enabled). Persisted under [video];
+## emits so the sun toggles its shadow live without a restart. Default true.
+func set_shadows(on: bool) -> void:
+	save_video_settings("shadows", on)
+	save_settings()
+	shadows_changed.emit(on)
+
+func is_shadows() -> bool:
+	return config.get_value("video", "shadows", true)
+
+## Sun shadow draw distance (metres). Persisted under [video]; emits so the sun updates live. Default 300.
+func set_shadow_distance(distance: float) -> void:
+	save_video_settings("shadow_distance", distance)
+	save_settings()
+	shadow_distance_changed.emit(distance)
+
+func get_shadow_distance() -> float:
+	return config.get_value("video", "shadow_distance", 300.0)
 
 # ── Audio (single source of truth for the audio settings page) ──
 

--- a/scenes/props/city/day_night_cycle.gd
+++ b/scenes/props/city/day_night_cycle.gd
@@ -23,6 +23,11 @@ func _ready() -> void:
 		set_process(false)  # purely visual — no need to spin the sun on the headless server
 		return
 	_phase = start_phase
+	# Real-time sun shadows, gated by the graphics settings (default on) and reacting live to changes.
+	shadow_enabled = SettingsManager.is_shadows()
+	directional_shadow_max_distance = SettingsManager.get_shadow_distance()
+	SettingsManager.shadows_changed.connect(_on_shadows_changed)
+	SettingsManager.shadow_distance_changed.connect(_on_shadow_distance_changed)
 	if sun_tint == null:
 		sun_tint = _build_default_sun_tint()
 
@@ -50,3 +55,11 @@ func _build_default_sun_tint() -> Gradient:
 		Color(1.0, 1.0, 1.0),
 	])
 	return gradient
+
+## Live-apply the shadows on/off graphics setting (SettingsManager.shadows_changed).
+func _on_shadows_changed(on: bool) -> void:
+	shadow_enabled = on
+
+## Live-apply the shadow distance graphics setting (SettingsManager.shadow_distance_changed).
+func _on_shadow_distance_changed(distance: float) -> void:
+	directional_shadow_max_distance = distance

--- a/ui/settings_page/graphical_page/graphical_settings_page.gd
+++ b/ui/settings_page/graphical_page/graphical_settings_page.gd
@@ -24,6 +24,9 @@ var _res_left: int = 0
 @onready var _max_fps: OptionButton = $ScrollContainer/MarginContainer/VBoxContainer/MaxFps/OptionButton
 @onready var _fov: HSlider = $ScrollContainer/MarginContainer/VBoxContainer/Fov/HSlider
 @onready var _fov_value: Label = $ScrollContainer/MarginContainer/VBoxContainer/Fov/Value
+@onready var _shadows: Button = $ScrollContainer/MarginContainer/VBoxContainer/Shadows/Button
+@onready var _shadow_dist: HSlider = $ScrollContainer/MarginContainer/VBoxContainer/ShadowDistance/HSlider
+@onready var _shadow_dist_value: Label = $ScrollContainer/MarginContainer/VBoxContainer/ShadowDistance/Value
 
 func _ready() -> void:
 	_init_monitor()
@@ -33,6 +36,8 @@ func _ready() -> void:
 	_init_dev_mode()
 	_init_max_fps()
 	_init_fov()
+	_init_shadows()
+	_init_shadow_distance()
 	_monitor.item_selected.connect(func(i: int) -> void: SettingsManager.set_monitor(i))
 	# DisplayMode item id 0 = Fullscreen, 1 = Windowed (as authored in the scene).
 	_display_mode.item_selected.connect(
@@ -47,6 +52,10 @@ func _ready() -> void:
 	_fov.value_changed.connect(func(v: float) -> void:
 		_fov_value.text = str(int(v))
 		SettingsManager.set_fov(v))
+	_shadows.toggled.connect(_on_shadows_toggled)
+	_shadow_dist.value_changed.connect(func(v: float) -> void:
+		_shadow_dist_value.text = str(int(v))
+		SettingsManager.set_shadow_distance(v))
 
 ## Apply the picked resolution, then ask to keep it with a visible 10 s auto-revert countdown. A too-big
 ## resolution on a small screen would otherwise leave the player stuck; the timer reverts on its own.
@@ -161,6 +170,21 @@ func _init_dev_mode() -> void:
 func _on_dev_mode_toggled(on: bool) -> void:
 	_dev_mode.text = "On" if on else "Off"
 	SettingsManager.set_dev_mode(on)
+
+## Reflect the saved shadows flag on the toggle.
+func _init_shadows() -> void:
+	_shadows.toggle_mode = true
+	_shadows.button_pressed = SettingsManager.is_shadows()
+	_shadows.text = "On" if _shadows.button_pressed else "Off"
+
+func _on_shadows_toggled(on: bool) -> void:
+	_shadows.text = "On" if on else "Off"
+	SettingsManager.set_shadows(on)
+
+## Reflect the saved sun shadow distance on the slider + its value label.
+func _init_shadow_distance() -> void:
+	_shadow_dist.value = SettingsManager.get_shadow_distance()
+	_shadow_dist_value.text = str(int(_shadow_dist.value))
 
 ## Reflect the saved field of view on the slider + its value label.
 func _init_fov() -> void:

--- a/ui/settings_page/graphical_page/graphical_settings_page.tscn
+++ b/ui/settings_page/graphical_page/graphical_settings_page.tscn
@@ -136,6 +136,49 @@ size_flags_horizontal = 10
 theme_override_fonts/font = ExtResource("2_pcucv")
 text = "On"
 
+[node name="Shadows" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer" unique_id=1500000001]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/Shadows" unique_id=1500000002]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Shadows"
+label_settings = SubResource("LabelSettings_aqojs")
+
+[node name="Button" type="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/Shadows" unique_id=1500000003]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+theme_override_fonts/font = ExtResource("2_pcucv")
+toggle_mode = true
+text = "On"
+
+[node name="ShadowDistance" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer" unique_id=1500000004]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/ShadowDistance" unique_id=1500000005]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Shadow Distance"
+label_settings = SubResource("LabelSettings_aqojs")
+
+[node name="HSlider" type="HSlider" parent="ScrollContainer/MarginContainer/VBoxContainer/ShadowDistance" unique_id=1500000006]
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+size_flags_vertical = 1
+min_value = 50.0
+max_value = 1000.0
+step = 10.0
+value = 300.0
+
+[node name="Value" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/ShadowDistance" unique_id=1500000007]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+text = "300"
+label_settings = SubResource("LabelSettings_aqojs")
+horizontal_alignment = 1
+
 [node name="DevMode" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer" unique_id=1344832484]
 layout_mode = 2
 


### PR DESCRIPTION
## Description

Adds two **Graphics** settings so players can trade shadow quality for performance:

- **Shadows** on/off toggle (default **On**) — drives the day/night sun's `shadow_enabled`.
- **Shadow Distance** slider **50–1000 m** (default **300**) — drives the sun's `directional_shadow_max_distance`.

Both are **persisted** (`user://settings.ini`, section `[video]`) and **applied live** to the sun — no restart. Implementation follows the existing `SettingsManager` pattern (single source of truth + persist + signal):

- `SettingsManager`: new signals `shadows_changed` / `shadow_distance_changed`, defaults (`shadows=true`, `shadow_distance=300`), and `set/is_shadows` + `set/get_shadow_distance`.
- `graphical_settings_page` (`.gd` + `.tscn`): wires the toggle (like V-Sync / Dev mode) and the slider (like Field of View).
- `day_night_cycle` (the sun): reads both settings on `_ready` and reacts live via the signals. Client-only (the headless server skips it).

### How to test
1. Launch the game, open **Settings > Graphics**.
2. **Shadows** and **Shadow Distance** appear under V-Sync.
3. Toggle Shadows Off/On → sun shadows disappear / come back **immediately**.
4. Drag Shadow Distance → shadows reach further / closer **live**.
5. Restart the game → both settings are remembered.

Client-side visual only; no gameplay/network impact.

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Added Graphics settings to toggle real-time shadows on/off and adjust the sun shadow draw distance (persisted, applied live).
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Ajout de réglages Graphics pour activer/désactiver les ombres temps réel et régler la distance d'affichage des ombres du soleil (persistés, appliqués en direct).
<!-- /CHANGELOG_FR -->
