### PR TITLE
feat(props): visible unique id on crates (company-type-uuid) via Label3D frames

### DIFF
--- a/scenes/globals/generic_prop.gd
+++ b/scenes/globals/generic_prop.gd
@@ -6,7 +6,22 @@ signal hs_server_prop_delete
 
 @export var type_name = "generic_prop"
 
-var uuid: String = ""
+## Human-readable "serial" prefix shown on the crate (see serial()). The UUID below is the REAL unique
+## key (generated server-side, persisted in ScyllaDB); these two only brand it as "company-type". Defined
+## here once so every prop inherits them — set the values per scene in the Inspector.
+@export var id_company: String = "ARES"
+@export var id_type: String = "HAUL"
+## Show only the UUID's first block, uppercased (e.g. ARES-HAUL-8C44B2F9), to fit a small face. The
+## identity stays the FULL UUID; this is display-only.
+@export var id_short_display: bool = false
+
+## The unique identity of this prop (v4, server-generated, persisted in ScyllaDB, replicated to clients).
+## Assigned AFTER instancing (server spawn / client create_generic_object), so the setter refreshes the
+## on-crate id labels the moment it arrives.
+var uuid: String = "":
+	set(value):
+		uuid = value
+		_update_id_labels()
 
 var spawn_position: Vector3 = Vector3.ZERO
 var spawn_rotation: Vector3 = Vector3.UP
@@ -41,6 +56,26 @@ func _ready() -> void:
 	add_to_group("carriable")
 	# Created already under a vehicle (cargo loaded before we arrived): ride it (KINEMATIC).
 	PropNet.apply_ride_freeze_mode(self)
+	# Fill the on-crate id frames now if the uuid was already assigned before we entered the tree.
+	_update_id_labels()
+
+## Human-readable "company-type-uuid" serial shown on the crate. The UUID is the real unique key; the
+## company/type prefix is cosmetic. Empty until the uuid is assigned.
+func serial() -> String:
+	if uuid == "":
+		return ""
+	var uuid_display: String = uuid.split("-")[0].to_upper() if id_short_display else uuid
+	return "%s-%s-%s" % [id_company, id_type, uuid_display]
+
+## Fill every id "frame" on this crate — the Label3D children in the group "prop_id_label" (one per
+## face) — with the current serial. Called from the uuid setter AND _ready, so it survives any order.
+func _update_id_labels() -> void:
+	if uuid == "":
+		return
+	var txt: String = serial()
+	for node in find_children("*", "Label3D", true, false):
+		if node.is_in_group("prop_id_label"):
+			(node as Label3D).text = txt
 
 func _physics_process(_delta: float) -> void:
 	PropNet.server_tick(self)

--- a/scenes/props/cargo/hauling_box.tscn
+++ b/scenes/props/cargo/hauling_box.tscn
@@ -15,14 +15,15 @@ mass = 50.0
 continuous_cd = true
 script = ExtResource("1_haul")
 type_name = "palette_container"
+id_short_display = true
 
 [node name="boxmesh" parent="." unique_id=1100122273 instance=ExtResource("2_j2geo")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25432684811476347, 0)
 
-[node name="box" parent="boxmesh" index="0" unique_id=964594845]
+[node name="box" parent="boxmesh" index="0" unique_id=1623152151]
 surface_material_override/0 = ExtResource("3_hqfv2")
 
-[node name="box_decals" parent="boxmesh" index="1" unique_id=894410932]
+[node name="box_decals" parent="boxmesh" index="1" unique_id=885319987]
 surface_material_override/0 = ExtResource("4_6ad14")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=1415410391]
@@ -36,5 +37,45 @@ collision_layer = 32
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D" unique_id=1415410393]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.03649002313613891, 0)
 shape = SubResource("BoxShape3D_urcx6")
+
+[node name="IdFrameFront" type="Label3D" parent="." unique_id=771122334 groups=["prop_id_label"]]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.06967657874970228, 0.1914409795980456)
+pixel_size = 0.0005
+modulate = Color(0.09, 0.09, 0.09, 1)
+text = "ARES-HAUL-XXXXXXXX"
+font_size = 30
+outline_size = 0
+
+[node name="IdFrameBack" type="Label3D" parent="." unique_id=771122335 groups=["prop_id_label"]]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.06967657874970228, -0.19018414121822622)
+pixel_size = 0.0005
+modulate = Color(0.09, 0.09, 0.09, 1)
+text = "ARES-HAUL-XXXXXXXX"
+font_size = 30
+outline_size = 0
+
+[node name="IdFrameRight" type="Label3D" parent="." unique_id=771122336 groups=["prop_id_label"]]
+transform = Transform3D(-1.2246064e-16, 0, 1, 0, 1, 0, -1, 0, -1.2246064e-16, 0.19140920966197805, 0.06967657874970228, 0)
+pixel_size = 0.0005
+modulate = Color(0.09, 0.09, 0.09, 1)
+text = "ARES-HAUL-XXXXXXXX"
+font_size = 30
+outline_size = 0
+
+[node name="IdFrameLeft" type="Label3D" parent="." unique_id=771122337 groups=["prop_id_label"]]
+transform = Transform3D(1.2246064e-16, 0, -1, 0, 1, 0, 1, 0, 1.2246064e-16, -0.1895871945550169, 0.06967657874970228, 0)
+pixel_size = 0.0005
+modulate = Color(0.09, 0.09, 0.09, 1)
+text = "ARES-HAUL-XXXXXXXX"
+font_size = 30
+outline_size = 0
+
+[node name="IdFrameTop" type="Label3D" parent="." unique_id=771122338 groups=["prop_id_label"]]
+transform = Transform3D(-1, 0, 1.2246064e-16, 1.2246064e-16, 0, 1, 0, 1, 0, 0, 0.14788524644088408, 0)
+pixel_size = 0.0005
+modulate = Color(0.09, 0.09, 0.09, 1)
+text = "ARES-HAUL-XXXXXXXX"
+font_size = 30
+outline_size = 0
 
 [editable path="boxmesh"]


### PR DESCRIPTION
## Description

Every hauling box / pallet / cargo box now shows a **unique, stable ID** on its faces
(e.g. `ARES-HAUL-8C44B2F9`), so crates that "live their own life and are never destroyed" are
identifiable at a glance.

### How

The ID **is the prop's UUID** — already generated server-side, persisted in the ScyllaDB `items`
table and replicated to clients. This PR just makes it **visible**, with a readable prefix:

- `GenericProp` gains two `@export` fields — `id_company` (default `ARES`) and `id_type` (default
  `HAUL`), set per scene — plus `id_short_display` (show only the UUID's first block to fit a small
  face; the identity stays the full UUID).
- `GenericProp.serial()` returns `"<id_company>-<id_type>-<uuid>"`; `_update_id_labels()` fills
  **every** `Label3D` in the group **`prop_id_label`** with it, called from the `uuid` setter **and**
  `_ready` — so any number of "id-frames" (one per face) show the same id as soon as the uuid arrives.
- Everything is derived **locally from the UUID** → **no DB, network or service change**.

`scenes/props/cargo/hauling_box.tscn` is wired as the reference (5 id-frames: front/back/left/right/top).
Any crate opts in by adding a `Label3D` to the group `prop_id_label` — **the group is the trigger, not
the node name**. Static decor boxes (`scenes/props/StorageBoxes/*`, `extends Node3D`, no uuid) are out
of scope.

Docs: **DyingStar-game/technical-docs#57** (new "Crate IDs" page, illustrated).

## Changelog

<!-- CHANGELOG_EN -->
Hauling boxes, pallets and cargo boxes now display their unique ID on every face
(e.g. `ARES-HAUL-8C44B2F9`), so each crate can be identified at a glance. The ID is the crate's stable
UUID — it never changes and survives server restarts.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Les caisses de transport, palettes et caisses cargo affichent désormais leur identifiant unique sur
chaque face (ex. `ARES-HAUL-8C44B2F9`), pour identifier chaque caisse d'un coup d'œil. L'identifiant est
l'UUID stable de la caisse — il ne change jamais et survit aux redémarrages serveur.
<!-- /CHANGELOG_FR -->
