### PR TITLE
Fix godot version for server (miss update it :/)

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,7 +3,7 @@
 ############################################
 FROM debian:trixie-slim AS builder
 
-ENV GODOT_VERSION=4.6.1
+ENV GODOT_VERSION=4.7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \


### PR DESCRIPTION
## Description

<!-- Describe the changes in this PR -->

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Update server godot version to 4.7, missed to use 4.7 like the client ;(
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Mise à jour de la version de Godot sur le serveur vers la 4.7 ; j'avais oublié d'utiliser la 4.7 comme pour le client ;(
<!-- /CHANGELOG_FR -->
